### PR TITLE
[WorkspaceSwitcher] Do not grey out content and display default cursor when read-only

### DIFF
--- a/src/components/AvatarWithImagePicker.js
+++ b/src/components/AvatarWithImagePicker.js
@@ -34,6 +34,9 @@ const propTypes = {
     /** Additional style props */
     style: stylePropTypes,
 
+    /** Additional style props for disabled picker */
+    disabledStyle: stylePropTypes,
+
     /** Executed once an image has been selected */
     onImageSelected: PropTypes.func,
 
@@ -87,10 +90,7 @@ const propTypes = {
     avatarStyle: stylePropTypes.isRequired,
 
     /** Indicates if picker feature should be disabled */
-    disabled: PropTypes.bool,
-
-    /** Should we use default cursor for disabled content */
-    shouldUseDefaultCursorWhenDisabled: PropTypes.bool,
+    disabled: PropTypes.bool, 
 };
 
 const defaultProps = {
@@ -98,6 +98,7 @@ const defaultProps = {
     onImageSelected: () => {},
     onImageRemoved: () => {},
     style: [],
+    disabledStyle: [],
     DefaultAvatar: () => {},
     isUsingDefaultAvatar: false,
     size: CONST.AVATAR_SIZE.DEFAULT,
@@ -112,13 +113,13 @@ const defaultProps = {
     previewSource: '',
     originalFileName: '',
     disabled: false,
-    shouldUseDefaultCursorWhenDisabled: false,
 };
 
 function AvatarWithImagePicker({
     isFocused,
     DefaultAvatar,
     style,
+    disabledStyle,
     pendingAction,
     errors,
     errorRowStyles,
@@ -136,7 +137,6 @@ function AvatarWithImagePicker({
     editorMaskImage,
     avatarStyle,
     disabled,
-    shouldUseDefaultCursorWhenDisabled
 }) {
     const theme = useTheme();
     const styles = useThemeStyles();
@@ -319,7 +319,7 @@ function AvatarWithImagePicker({
                             accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
                             accessibilityLabel={translate('avatarWithImagePicker.editImage')}
                             disabled={isAvatarCropModalOpen || disabled}
-                            disabledStyle={disabled && shouldUseDefaultCursorWhenDisabled && [styles.cursorDefault]}
+                            disabledStyle={disabledStyle}
                             ref={anchorRef}
                         >
                             <View>

--- a/src/components/AvatarWithImagePicker.js
+++ b/src/components/AvatarWithImagePicker.js
@@ -112,7 +112,7 @@ const defaultProps = {
     previewSource: '',
     originalFileName: '',
     disabled: false,
-    shouldUseDefaultCursorWhenDisabled: false, 
+    shouldUseDefaultCursorWhenDisabled: false,
 };
 
 function AvatarWithImagePicker({
@@ -136,6 +136,7 @@ function AvatarWithImagePicker({
     editorMaskImage,
     avatarStyle,
     disabled,
+    shouldUseDefaultCursorWhenDisabled
 }) {
     const theme = useTheme();
     const styles = useThemeStyles();
@@ -318,7 +319,7 @@ function AvatarWithImagePicker({
                             accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
                             accessibilityLabel={translate('avatarWithImagePicker.editImage')}
                             disabled={isAvatarCropModalOpen || disabled}
-                            disabledStyle={true && [styles.cursorDefault]}
+                            disabledStyle={disabled && shouldUseDefaultCursorWhenDisabled && [styles.cursorDefault]}
                             ref={anchorRef}
                         >
                             <View>

--- a/src/components/AvatarWithImagePicker.js
+++ b/src/components/AvatarWithImagePicker.js
@@ -88,6 +88,9 @@ const propTypes = {
 
     /** Indicates if picker feature should be disabled */
     disabled: PropTypes.bool,
+
+    /** Should we use default cursor for disabled content */
+    shouldUseDefaultCursorWhenDisabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -109,6 +112,7 @@ const defaultProps = {
     previewSource: '',
     originalFileName: '',
     disabled: false,
+    shouldUseDefaultCursorWhenDisabled: false, 
 };
 
 function AvatarWithImagePicker({
@@ -314,6 +318,7 @@ function AvatarWithImagePicker({
                             accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
                             accessibilityLabel={translate('avatarWithImagePicker.editImage')}
                             disabled={isAvatarCropModalOpen || disabled}
+                            disabledStyle={true && [styles.cursorDefault]}
                             ref={anchorRef}
                         >
                             <View>

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -197,6 +197,9 @@ type MenuItemProps = (IconProps | AvatarProps | NoIcon) & {
     /** Should we grey out the menu item when it is disabled? */
     shouldGreyOutWhenDisabled?: boolean;
 
+    /** Should we use default cursor for disabled content */
+    shouldUseDefaultCursorWhenDisabled?: boolean;
+
     /** The action accept for anonymous user or not */
     isAnonymousAction?: boolean;
 
@@ -280,6 +283,7 @@ function MenuItem(
         brickRoadIndicator,
         shouldRenderAsHTML = false,
         shouldGreyOutWhenDisabled = true,
+        shouldUseDefaultCursorWhenDisabled = false,
         isAnonymousAction = false,
         shouldBlockSelection = false,
         shouldParseTitle = false,
@@ -398,6 +402,7 @@ function MenuItem(
                             shouldGreyOutWhenDisabled && disabled && styles.buttonOpacityDisabled,
                         ] as StyleProp<ViewStyle>
                     }
+                    disabledStyle={shouldUseDefaultCursorWhenDisabled && [styles.cursorDefault]}
                     disabled={disabled}
                     ref={ref}
                     role={CONST.ROLE.MENUITEM}
@@ -412,7 +417,7 @@ function MenuItem(
                                         <Text style={StyleUtils.combineStyles([styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting, styles.pre])}>{label}</Text>
                                     </View>
                                 )}
-                                <View style={[styles.flexRow, styles.pointerEventsAuto, disabled && styles.cursorDisabled]}>
+                                <View style={[styles.flexRow, styles.pointerEventsAuto, disabled && !shouldUseDefaultCursorWhenDisabled && styles.cursorDisabled]}>
                                     {!!icon && Array.isArray(icon) && (
                                         <MultipleAvatars
                                             isHovered={isHovered}
@@ -581,7 +586,7 @@ function MenuItem(
                                     </View>
                                 )}
                                 {shouldShowRightIcon && (
-                                    <View style={[styles.popoverMenuIcon, styles.pointerEventsAuto, disabled && styles.cursorDisabled]}>
+                                    <View style={[styles.popoverMenuIcon, styles.pointerEventsAuto, disabled && !shouldUseDefaultCursorWhenDisabled && styles.cursorDisabled]}>
                                         <Icon
                                             src={iconRight}
                                             fill={StyleUtils.getIconFillColor(getButtonState(focused || isHovered, pressed, success, disabled, interactive))}

--- a/src/components/Pressable/PressableWithoutFeedback.tsx
+++ b/src/components/Pressable/PressableWithoutFeedback.tsx
@@ -4,7 +4,7 @@ import type {PressableRef} from './GenericPressable/types';
 import type PressableProps from './GenericPressable/types';
 
 function PressableWithoutFeedback(
-    {pressStyle, hoverStyle, focusStyle, disabledStyle, screenReaderActiveStyle, shouldUseHapticsOnPress, shouldUseHapticsOnLongPress, ...rest}: PressableProps,
+    {pressStyle, hoverStyle, focusStyle, screenReaderActiveStyle, shouldUseHapticsOnPress, shouldUseHapticsOnLongPress, ...rest}: PressableProps,
     ref: PressableRef,
 ) {
     return (

--- a/src/pages/workspace/WorkspaceOverviewPage.js
+++ b/src/pages/workspace/WorkspaceOverviewPage.js
@@ -102,7 +102,7 @@ function WorkspaceOverviewPage({policy, currencyList, route}) {
                         headerTitle={translate('workspace.common.workspaceAvatar')}
                         originalFileName={policy.originalFileName}
                         disabled={readOnly}
-                        shouldUseDefaultCursorWhenDisabled
+                        disabledStyle={styles.cursorDefault}
                     />
                     <OfflineWithFeedback pendingAction={lodashGet(policy, 'pendingFields.generalSettings')}>
                         <MenuItemWithTopDescription

--- a/src/pages/workspace/WorkspaceOverviewPage.js
+++ b/src/pages/workspace/WorkspaceOverviewPage.js
@@ -102,6 +102,7 @@ function WorkspaceOverviewPage({policy, currencyList, route}) {
                         headerTitle={translate('workspace.common.workspaceAvatar')}
                         originalFileName={policy.originalFileName}
                         disabled={readOnly}
+                        shouldUseDefaultCursorWhenDisabled
                     />
                     <OfflineWithFeedback pendingAction={lodashGet(policy, 'pendingFields.generalSettings')}>
                         <MenuItemWithTopDescription

--- a/src/pages/workspace/WorkspaceOverviewPage.js
+++ b/src/pages/workspace/WorkspaceOverviewPage.js
@@ -110,6 +110,8 @@ function WorkspaceOverviewPage({policy, currencyList, route}) {
                             shouldShowRightIcon={!readOnly}
                             disabled={readOnly}
                             onPress={onPressName}
+                            shouldGreyOutWhenDisabled={false}
+                            shouldUseDefaultCursorWhenDisabled
                         />
 
                         <View>
@@ -119,6 +121,8 @@ function WorkspaceOverviewPage({policy, currencyList, route}) {
                                 shouldShowRightIcon={!readOnly}
                                 disabled={hasVBA || readOnly}
                                 onPress={onPressCurrency}
+                                shouldGreyOutWhenDisabled={false}
+                                shouldUseDefaultCursorWhenDisabled
                             />
                             <Text style={[styles.textLabel, styles.colorMuted, styles.mt2, styles.mh5]}>
                                 {hasVBA ? translate('workspace.editor.currencyInputDisabledText') : translate('workspace.editor.currencyInputHelpText')}


### PR DESCRIPTION
<img width="1138" alt="Screenshot 2024-01-22 at 16 52 38" src="https://github.com/software-mansion-labs/expensify-app-fork/assets/60450261/a1ec7ede-32a6-476f-8d46-96d55338f621">
1. Content is not greyed-out and when disabled
2. Default cursor is used