### PR TITLE
Fix broken auth params when opening desktop App from deeplink.

### DIFF
--- a/src/libs/Navigation/NavigationRoot.tsx
+++ b/src/libs/Navigation/NavigationRoot.tsx
@@ -179,15 +179,15 @@ function NavigationRoot({authenticated, lastVisitedPath, initialUrl, onReady, sh
 
         // REPORTS_SPLIT_NAVIGATOR will persist after user logout, because it is used both for logged-in and logged-out users
         // That's why for ReportsSplit we need to explicitly clear params when resetting navigation state,
-        // However if other routes (related to login/logout) appear in nav state, then we want to preserve params for those
-        const isReportSplitNavigator = lastRoute.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR;
+        // However in case other routes (related to login/logout) appear in nav state, then we want to preserve params for those
+        const isReportSplitNavigatorMounted = lastRoute.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR;
         navigationRef.reset({
             ...rootState,
             index: 0,
             routes: [
                 {
                     ...lastRoute,
-                    params: isReportSplitNavigator ? {} : lastRoute.params,
+                    params: isReportSplitNavigatorMounted ? undefined : lastRoute.params,
                 },
             ],
         });

--- a/src/libs/Navigation/NavigationRoot.tsx
+++ b/src/libs/Navigation/NavigationRoot.tsx
@@ -19,6 +19,7 @@ import * as Session from '@userActions/Session';
 import {updateOnboardingLastVisitedPath} from '@userActions/Welcome';
 import {getOnboardingInitialPath} from '@userActions/Welcome/OnboardingFlow';
 import CONST from '@src/CONST';
+import NAVIGATORS from '@src/NAVIGATORS';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
@@ -175,7 +176,21 @@ function NavigationRoot({authenticated, lastVisitedPath, initialUrl, onReady, sh
         if (!lastRoute) {
             return;
         }
-        navigationRef.reset({...rootState, index: 0, routes: [{...lastRoute, params: {}}]});
+
+        // REPORTS_SPLIT_NAVIGATOR will persist after user logout, because it is used both for logged-in and logged-out users
+        // That's why for ReportsSplit we need to explicitly clear params when resetting navigation state,
+        // However if other routes (related to login/logout) appear in nav state, then we want to preserve params for those
+        const isReportSplitNavigator = lastRoute.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR;
+        navigationRef.reset({
+            ...rootState,
+            index: 0,
+            routes: [
+                {
+                    ...lastRoute,
+                    params: isReportSplitNavigator ? {} : lastRoute.params,
+                },
+            ],
+        });
     }, [authenticated, previousAuthenticated]);
 
     const handleStateChange = (state: NavigationState | undefined) => {


### PR DESCRIPTION

Fixes: **Desktop - Open New Expensify - Web user is not automatically logged into the Desktop app** https://github.com/Expensify/App/pull/49539#issuecomment-2603266212

### Explanation of Change
Huge help from @WojtekBoman on this one.

When we open desktop app from web deeplink, from a different user account, we go through the flow of logging current user out and redirecting to `LogInWithShortLivedAuthTokenPage`.
Because of resetting navigation after logout, we were always clearing route `params`, but in this flow the authToken is in route params. 
Because of that once we navigated to `LogInWithShortLivedAuthTokenPage`:
 - the params were empty
 - token was missing
 - there was nowhere to backTo

This PR preserves params for everything but ReportSplit navigator.

### Fixed Issues
