### PR TITLE
Your tasks - case study

### DIFF
--- a/.cursor/plans/your_tasks_home_widget_459ede82.plan.md
+++ b/.cursor/plans/your_tasks_home_widget_459ede82.plan.md
@@ -4,7 +4,7 @@ overview: Add a "Your tasks" widget to the home page right column that shows up 
 todos:
   - id: write-hook-tests
     content: "Write unit tests only (no implementation) for useSelfDMTasks hook at tests/unit/hooks/useSelfDMTasks.test.ts. Tests will import from the hook path but the hook does not exist yet — tests are expected to fail. Covers: empty state, task detection, open+completed tasks, filtering non-task actions, 5-item limit, task data resolution."
-    status: pending
+    status: completed
   - id: implement-hook
     content: Implement useSelfDMTasks hook at src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts to make the tests pass
     status: pending

--- a/.cursor/plans/your_tasks_home_widget_459ede82.plan.md
+++ b/.cursor/plans/your_tasks_home_widget_459ede82.plan.md
@@ -7,16 +7,16 @@ todos:
     status: completed
   - id: implement-hook
     content: Implement useSelfDMTasks hook at src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts to make the tests pass
-    status: pending
+    status: completed
   - id: implement-task-item
     content: Implement simple TaskItem component (clickable checkbox, title, description) at src/pages/home/YourTasksSection/TaskItem.tsx
-    status: pending
+    status: completed
   - id: implement-section
     content: Implement YourTasksSection component at src/pages/home/YourTasksSection/index.tsx using WidgetContainer and TaskItem
-    status: pending
+    status: completed
   - id: integrate-homepage
     content: Add YourTasksSection to HomePage.tsx right column as first widget, add translation keys
-    status: pending
+    status: completed
 isProject: false
 ---
 

--- a/.cursor/plans/your_tasks_home_widget_459ede82.plan.md
+++ b/.cursor/plans/your_tasks_home_widget_459ede82.plan.md
@@ -1,0 +1,117 @@
+---
+name: Your Tasks Home Widget
+overview: Add a "Your tasks" widget to the home page right column that shows up to 5 tasks from the user's self-DM report (both open and completed), with a simple custom TaskItem component (checkbox, title, description). No "See all" link.
+todos:
+  - id: write-hook-tests
+    content: "Write unit tests only (no implementation) for useSelfDMTasks hook at tests/unit/hooks/useSelfDMTasks.test.ts. Tests will import from the hook path but the hook does not exist yet — tests are expected to fail. Covers: empty state, task detection, open+completed tasks, filtering non-task actions, 5-item limit, task data resolution."
+    status: pending
+  - id: implement-hook
+    content: Implement useSelfDMTasks hook at src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts to make the tests pass
+    status: pending
+  - id: implement-task-item
+    content: Implement simple TaskItem component (clickable checkbox, title, description) at src/pages/home/YourTasksSection/TaskItem.tsx
+    status: pending
+  - id: implement-section
+    content: Implement YourTasksSection component at src/pages/home/YourTasksSection/index.tsx using WidgetContainer and TaskItem
+    status: pending
+  - id: integrate-homepage
+    content: Add YourTasksSection to HomePage.tsx right column as first widget, add translation keys
+    status: pending
+isProject: false
+---
+
+# Your Tasks Home Widget
+
+## Architecture
+
+The widget follows the same pattern as `TimeSensitiveSection` and `AssignedCardsSection`:
+
+- A custom hook (`useSelfDMTasks`) to fetch and filter task-related report actions from the user's self-DM report
+- A section component (`YourTasksSection`) that renders inside a `WidgetContainer` and returns `null` when there are no tasks
+- A simple `TaskItem` component with: clickable checkbox, title, and description
+
+```mermaid
+flowchart TD
+    HomePage --> RightColumn
+    RightColumn --> YourTasksSection["YourTasksSection (new)"]
+    RightColumn --> AssignedCardsSection
+    RightColumn --> AnnouncementSection
+    YourTasksSection --> useSelfDMTasks["useSelfDMTasks hook"]
+    useSelfDMTasks --> selfDMReport["useSelfDMReport (existing)"]
+    useSelfDMTasks --> reportActions["useOnyx REPORT_ACTIONS"]
+    useSelfDMTasks --> allReports["useOnyx COLLECTION.REPORT"]
+    YourTasksSection --> WidgetContainer
+    YourTasksSection --> TaskItem["TaskItem (checkbox + title + description)"]
+```
+
+
+
+## Data Flow
+
+1. `useSelfDMTasks` hook:
+
+- Uses existing `useSelfDMReport` hook to get the self-DM report ID
+- Subscribes to `ONYXKEYS.COLLECTION.REPORT_ACTIONS` for that report's actions
+- Filters actions using `isCreatedTaskReportAction` from ReportActionsUtils
+- For each task action, resolves the full task report from `ONYXKEYS.COLLECTION.REPORT` using `originalMessage.taskReportID`
+- Filters out cancelled/deleted task reports
+- Returns task reports limited to 5
+- Returns a `hasAnyTasks` flag for visibility gating
+
+1. `TaskItem` component:
+
+- Clickable checkbox that toggles task completion (completeTask / reopenTask)
+- Title from the task report's `reportName`
+- Description from the task report's `description` field
+
+1. `YourTasksSection` component:
+
+- Returns `null` if `hasAnyTasks` is false
+- Wraps content in `WidgetContainer` with title "Your tasks"
+- Renders each task using `TaskItem`
+
+1. Placement in `HomePage.tsx`: First child of the right column, before `AssignedCardsSection`
+
+## Key Files
+
+- **Existing test utilities**: [tests/utils/collections/reports.ts](tests/utils/collections/reports.ts) -- has `createSelfDM`, `createRegularTaskReport`
+- **Existing test utilities**: [tests/utils/collections/reportActions.ts](tests/utils/collections/reportActions.ts) -- has `createRandomReportAction`
+- **Widget pattern reference**: [src/pages/home/TimeSensitiveSection/index.tsx](src/pages/home/TimeSensitiveSection/index.tsx)
+- **Task utils reference**: [src/components/ReportActionItem/TaskPreview.tsx](src/components/ReportActionItem/TaskPreview.tsx)
+- **Hook test pattern**: [tests/unit/hooks/useTimeSensitiveCards.test.ts](tests/unit/hooks/useTimeSensitiveCards.test.ts)
+
+## Phase 1: Unit Tests Only
+
+Write tests for the `useSelfDMTasks` hook at `tests/unit/hooks/useSelfDMTasks.test.ts`.
+**This step creates only the test file.** The hook does not exist yet — tests will fail until Phase 2.
+
+Test cases:
+
+- **Empty state**: Returns empty tasks array and `hasAnyTasks: false` when no tasks exist in self-DM
+- **Task detection**: Returns tasks from self-DM report actions that are `isCreatedTaskReportAction`
+- **Both open and completed**: Includes both open tasks (stateNum=OPEN) and completed tasks (stateNum=APPROVED)
+- **Non-task actions ignored**: Filters out regular ADD_COMMENT actions that don't have `taskReportID`
+- **Limit of 5**: Returns at most 5 tasks and signals when there are more
+- **Task data resolution**: Each returned task includes the associated task report data (title, status)
+
+Test setup pattern (following `useTimeSensitiveCards.test.ts`):
+
+- Use real Onyx with `Onyx.init`, `Onyx.clear`, `waitForBatchedUpdates`
+- Use `createSelfDM` for the self-DM report
+- Create task report actions with `taskReportID` in `originalMessage`
+- Use `createRegularTaskReport` or build task reports manually with appropriate fields
+
+## Phase 2: Hook Implementation
+
+Create `src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts` to make the Phase 1 tests pass.
+
+## Phase 3: UI Components
+
+- Create `src/pages/home/YourTasksSection/TaskItem.tsx` (simple: checkbox, title, description)
+- Create `src/pages/home/YourTasksSection/index.tsx`
+
+## Phase 4: Integration
+
+- Update HomePage.tsx to add `YourTasksSection` as first child in the right column
+- Add translation key `homePage.yourTasks` in locale files
+

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -987,6 +987,7 @@ const translations = {
                 cta: 'Review',
             },
         },
+        yourTasks: 'Your tasks',
         assignedCards: 'Assigned cards',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} remaining`,
         announcements: 'Announcements',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -818,6 +818,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 cta: 'Revisar',
             },
         },
+        yourTasks: 'Tus tareas',
         assignedCards: 'Tarjetas asignadas',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} restantes`,
         announcements: 'Anuncios',

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -22,6 +22,7 @@ import AssignedCardsSection from './AssignedCardsSection';
 import DiscoverSection from './DiscoverSection';
 import ForYouSection from './ForYouSection';
 import TimeSensitiveSection from './TimeSensitiveSection';
+import YourTasksSection from './YourTasksSection';
 
 function HomePage() {
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -72,6 +73,7 @@ function HomePage() {
                             <DiscoverSection />
                         </View>
                         <View style={styles.homePageRightColumn(shouldUseNarrowLayout)}>
+                            <YourTasksSection />
                             <AssignedCardsSection />
                             <AnnouncementSection />
                         </View>

--- a/src/pages/home/YourTasksSection/TaskItem.tsx
+++ b/src/pages/home/YourTasksSection/TaskItem.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {View} from 'react-native';
+import Checkbox from '@components/Checkbox';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import Text from '@components/Text';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useHasOutstandingChildTask from '@hooks/useHasOutstandingChildTask';
+import useLocalize from '@hooks/useLocalize';
+import useParentReport from '@hooks/useParentReport';
+import useParentReportAction from '@hooks/useParentReportAction';
+import useReportIsArchived from '@hooks/useReportIsArchived';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {callFunctionIfActionIsAllowed} from '@libs/actions/Session';
+import {canActionTask, completeTask, reopenTask} from '@libs/actions/Task';
+import Navigation from '@libs/Navigation/Navigation';
+import {isCompletedTaskReport} from '@libs/ReportUtils';
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+import type {Report} from '@src/types/onyx';
+
+type TaskItemProps = {
+    taskReport: Report;
+};
+
+function TaskItem({taskReport}: TaskItemProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {accountID} = useCurrentUserPersonalDetails();
+
+    const parentReportAction = useParentReportAction(taskReport);
+    const parentReport = useParentReport(taskReport.reportID);
+    const isParentReportArchived = useReportIsArchived(parentReport?.reportID);
+    const hasOutstandingChildTask = useHasOutstandingChildTask(taskReport);
+
+    const isCompleted = isCompletedTaskReport(taskReport);
+    const isActionable = canActionTask(taskReport, parentReportAction, accountID, parentReport, isParentReportArchived);
+
+    const title = taskReport.reportName ?? '';
+    const description = taskReport.description ?? '';
+
+    const handleCheckboxPress = callFunctionIfActionIsAllowed(() => {
+        if (isCompleted) {
+            reopenTask(taskReport, parentReport, accountID, taskReport.reportID);
+        } else {
+            completeTask(taskReport, parentReport?.hasOutstandingChildTask ?? false, hasOutstandingChildTask, parentReportAction, taskReport.reportID);
+        }
+    });
+
+    return (
+        <PressableWithoutFeedback
+            onPress={() => Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(taskReport.reportID, undefined, undefined, Navigation.getActiveRoute()))}
+            style={[styles.flexRow, styles.alignItemsCenter, styles.pv3, shouldUseNarrowLayout ? styles.ph5 : styles.ph8]}
+            role={CONST.ROLE.BUTTON}
+            accessibilityLabel={title}
+        >
+            <Checkbox
+                style={styles.mr3}
+                isChecked={isCompleted}
+                disabled={!isActionable}
+                onPress={handleCheckboxPress}
+                accessibilityLabel={translate('task.task')}
+            />
+            <View style={[styles.flex1, styles.flexColumn, styles.justifyContentCenter]}>
+                <Text
+                    style={[styles.widgetItemTitle, isCompleted && styles.textLineThrough]}
+                    numberOfLines={1}
+                >
+                    {title}
+                </Text>
+                {!!description && (
+                    <Text
+                        style={[styles.widgetItemSubtitle, isCompleted && styles.textLineThrough]}
+                        numberOfLines={1}
+                    >
+                        {description}
+                    </Text>
+                )}
+            </View>
+        </PressableWithoutFeedback>
+    );
+}
+
+TaskItem.displayName = 'TaskItem';
+
+export default TaskItem;

--- a/src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts
+++ b/src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts
@@ -1,0 +1,11 @@
+import type {Report} from '@src/types/onyx';
+
+// TODO: Implement in Phase 2
+function useSelfDMTasks(): {tasks: Report[]; hasAnyTasks: boolean} {
+    return {
+        tasks: [],
+        hasAnyTasks: false,
+    };
+}
+
+export default useSelfDMTasks;

--- a/src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts
+++ b/src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 import useOnyx from '@hooks/useOnyx';
 import useSelfDMReport from '@hooks/useSelfDMReport';
 import {getOriginalMessage, isCreatedTaskReportAction} from '@libs/ReportActionsUtils';
+import {isCanceledTaskReport} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
 
@@ -27,7 +28,7 @@ function useSelfDMTasks(): {tasks: Report[]; hasAnyTasks: boolean} {
             }
 
             const taskReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${taskReportID}`];
-            if (!taskReport) {
+            if (!taskReport || isCanceledTaskReport(taskReport, action)) {
                 continue;
             }
 

--- a/src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts
+++ b/src/pages/home/YourTasksSection/hooks/useSelfDMTasks.ts
@@ -1,11 +1,46 @@
+import {useMemo} from 'react';
+import useOnyx from '@hooks/useOnyx';
+import useSelfDMReport from '@hooks/useSelfDMReport';
+import {getOriginalMessage, isCreatedTaskReportAction} from '@libs/ReportActionsUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
 
-// TODO: Implement in Phase 2
+const MAX_TASKS = 5;
+
 function useSelfDMTasks(): {tasks: Report[]; hasAnyTasks: boolean} {
-    return {
-        tasks: [],
-        hasAnyTasks: false,
-    };
+    const selfDMReport = useSelfDMReport();
+    const [reportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReport.reportID}`);
+    const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+
+    const {tasks, hasAnyTasks} = useMemo(() => {
+        const actions = Object.values(reportActions ?? {});
+        const taskReports: Report[] = [];
+
+        for (const action of actions) {
+            if (!isCreatedTaskReportAction(action)) {
+                continue;
+            }
+
+            const taskReportID = getOriginalMessage(action)?.taskReportID;
+            if (!taskReportID) {
+                continue;
+            }
+
+            const taskReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${taskReportID}`];
+            if (!taskReport) {
+                continue;
+            }
+
+            taskReports.push(taskReport);
+        }
+
+        return {
+            tasks: taskReports.slice(0, MAX_TASKS),
+            hasAnyTasks: taskReports.length > 0,
+        };
+    }, [reportActions, allReports]);
+
+    return {tasks, hasAnyTasks};
 }
 
 export default useSelfDMTasks;

--- a/src/pages/home/YourTasksSection/index.tsx
+++ b/src/pages/home/YourTasksSection/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import WidgetContainer from '@components/WidgetContainer';
+import useLocalize from '@hooks/useLocalize';
+import useSelfDMTasks from './hooks/useSelfDMTasks';
+import TaskItem from './TaskItem';
+
+function YourTasksSection() {
+    const {translate} = useLocalize();
+    const {tasks, hasAnyTasks} = useSelfDMTasks();
+
+    if (!hasAnyTasks) {
+        return null;
+    }
+
+    return (
+        <WidgetContainer title={translate('homePage.yourTasks')}>
+            {tasks.map((task) => (
+                <TaskItem
+                    key={task.reportID}
+                    taskReport={task}
+                />
+            ))}
+        </WidgetContainer>
+    );
+}
+
+YourTasksSection.displayName = 'YourTasksSection';
+
+export default YourTasksSection;

--- a/src/pages/home/YourTasksSection/index.tsx
+++ b/src/pages/home/YourTasksSection/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import WidgetContainer from '@components/WidgetContainer';
 import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
 import useSelfDMTasks from './hooks/useSelfDMTasks';
 import TaskItem from './TaskItem';
 
 function YourTasksSection() {
     const {translate} = useLocalize();
+    const styles = useThemeStyles();
     const {tasks, hasAnyTasks} = useSelfDMTasks();
 
     if (!hasAnyTasks) {
@@ -13,7 +15,10 @@ function YourTasksSection() {
     }
 
     return (
-        <WidgetContainer title={translate('homePage.yourTasks')}>
+        <WidgetContainer
+            title={translate('homePage.yourTasks')}
+            containerStyles={styles.pb5}
+        >
             {tasks.map((task) => (
                 <TaskItem
                     key={task.reportID}

--- a/tests/unit/hooks/useSelfDMTasks.test.ts
+++ b/tests/unit/hooks/useSelfDMTasks.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {renderHook} from '@testing-library/react-native';
+import Onyx from 'react-native-onyx';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import useSelfDMTasks from '@src/pages/home/YourTasksSection/hooks/useSelfDMTasks';
+import type {Report, ReportAction, ReportActions} from '@src/types/onyx';
+import {createRegularTaskReport, createSelfDM} from '../../utils/collections/reports';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+
+const CURRENT_USER_ACCOUNT_ID = 1;
+
+function buildTaskCreationAction(reportActionID: string, taskReportID: string, created?: string): ReportAction {
+    return {
+        actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+        reportActionID,
+        actorAccountID: CURRENT_USER_ACCOUNT_ID,
+        created: created ?? '2025-01-01 00:00:00.000',
+        message: [{type: 'COMMENT', html: 'task', text: 'task'}],
+        originalMessage: {
+            html: 'task',
+            taskReportID,
+            whisperedTo: [],
+        },
+        person: [{type: 'TEXT', style: 'strong', text: 'User'}],
+        automatic: false,
+        avatar: '',
+        shouldShow: true,
+        lastModified: '2025-01-01 00:00:00.000',
+    } as ReportAction;
+}
+
+function buildRegularCommentAction(reportActionID: string): ReportAction {
+    return {
+        actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+        reportActionID,
+        actorAccountID: CURRENT_USER_ACCOUNT_ID,
+        created: '2025-01-01 00:00:00.000',
+        message: [{type: 'COMMENT', html: 'hello', text: 'hello'}],
+        originalMessage: {
+            html: 'hello',
+            whisperedTo: [],
+        },
+        person: [{type: 'TEXT', style: 'strong', text: 'User'}],
+        automatic: false,
+        avatar: '',
+        shouldShow: true,
+        lastModified: '2025-01-01 00:00:00.000',
+    } as ReportAction;
+}
+
+function buildTaskReport(reportID: string, overrides: Partial<Report> = {}): Report {
+    return {
+        ...createRegularTaskReport(Number(reportID), CURRENT_USER_ACCOUNT_ID),
+        reportID,
+        reportName: `Task ${reportID}`,
+        description: `Description for task ${reportID}`,
+        stateNum: CONST.REPORT.STATE_NUM.OPEN,
+        statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+        ...overrides,
+    };
+}
+
+describe('useSelfDMTasks', () => {
+    const selfDMReport = createSelfDM(100, CURRENT_USER_ACCOUNT_ID);
+    const selfDMReportID = selfDMReport.reportID;
+
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    afterEach(async () => {
+        await Onyx.clear();
+    });
+
+    it('should return empty tasks and hasAnyTasks false when no tasks exist in self-DM', async () => {
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReportID}`, selfDMReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReportID}`, {});
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useSelfDMTasks());
+
+        expect(result.current.tasks).toEqual([]);
+        expect(result.current.hasAnyTasks).toBe(false);
+    });
+
+    it('should detect tasks from self-DM report actions that are created task actions', async () => {
+        const taskReport = buildTaskReport('200');
+        const taskAction = buildTaskCreationAction('1', '200');
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReportID}`, selfDMReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}200`, taskReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReportID}`, {1: taskAction} as ReportActions);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useSelfDMTasks());
+
+        expect(result.current.tasks.length).toBeGreaterThanOrEqual(1);
+        expect(result.current.hasAnyTasks).toBe(true);
+    });
+
+    it('should include both open and completed tasks', async () => {
+        const openTask = buildTaskReport('201', {
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+        });
+        const completedTask = buildTaskReport('202', {
+            stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+            statusNum: CONST.REPORT.STATUS_NUM.APPROVED,
+        });
+
+        const action1 = buildTaskCreationAction('1', '201', '2025-01-01 00:00:00.000');
+        const action2 = buildTaskCreationAction('2', '202', '2025-01-02 00:00:00.000');
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReportID}`, selfDMReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}201`, openTask);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}202`, completedTask);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReportID}`, {
+            1: action1,
+            2: action2,
+        } as ReportActions);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useSelfDMTasks());
+
+        expect(result.current.tasks).toHaveLength(2);
+        expect(result.current.hasAnyTasks).toBe(true);
+
+        const reportIDs = result.current.tasks.map((t: Report) => t.reportID);
+        expect(reportIDs).toContain('201');
+        expect(reportIDs).toContain('202');
+    });
+
+    it('should filter out regular ADD_COMMENT actions that do not have taskReportID', async () => {
+        const taskReport = buildTaskReport('203');
+        const taskAction = buildTaskCreationAction('1', '203');
+        const regularComment = buildRegularCommentAction('2');
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReportID}`, selfDMReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}203`, taskReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReportID}`, {
+            1: taskAction,
+            2: regularComment,
+        } as ReportActions);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useSelfDMTasks());
+
+        expect(result.current.tasks).toHaveLength(1);
+        expect(result.current.tasks.at(0)?.reportID).toBe('203');
+    });
+
+    it('should return at most 5 tasks', async () => {
+        const actions: ReportActions = {};
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReportID}`, selfDMReport);
+
+        for (let i = 1; i <= 7; i++) {
+            const reportID = `${300 + i}`;
+            // eslint-disable-next-line no-await-in-loop
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, buildTaskReport(reportID));
+            actions[String(i)] = buildTaskCreationAction(String(i), reportID, `2025-01-0${i} 00:00:00.000`);
+        }
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReportID}`, actions);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useSelfDMTasks());
+
+        expect(result.current.tasks).toHaveLength(5);
+        expect(result.current.hasAnyTasks).toBe(true);
+    });
+
+    it('should resolve task report data including title and status for each returned task', async () => {
+        const taskReport = buildTaskReport('204', {
+            reportName: 'Fix the login bug',
+            description: 'Users cannot log in with SSO',
+            stateNum: CONST.REPORT.STATE_NUM.OPEN,
+            statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+        });
+        const taskAction = buildTaskCreationAction('1', '204');
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${selfDMReportID}`, selfDMReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}204`, taskReport);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${selfDMReportID}`, {1: taskAction} as ReportActions);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useSelfDMTasks());
+
+        expect(result.current.tasks).toHaveLength(1);
+        const task = result.current.tasks.at(0);
+        expect(task?.reportID).toBe('204');
+        expect(task?.reportName).toBe('Fix the login bug');
+        expect(task?.stateNum).toBe(CONST.REPORT.STATE_NUM.OPEN);
+    });
+});


### PR DESCRIPTION
### Explanation of Change

This PR adds a new "Your tasks" widget to the Home page right column. The widget displays up to 5 tasks from the user's self-DM report, showing both open and completed tasks.

**New files:**
- `useSelfDMTasks` hook — reads report actions from the user's self-DM, filters for task creation actions, resolves the associated task reports from Onyx, excludes cancelled tasks, and returns up to 5 task reports.
- `TaskItem` component — renders a single task row with a clickable checkbox (to complete/reopen), task title, and optional description. Tapping the row navigates to the task report. Completed tasks show strikethrough text.
- `YourTasksSection` — wraps the task list in a `WidgetContainer`. Returns `null` when there are no tasks.

**Modified files:**
- `HomePage.tsx` — adds `YourTasksSection` as the first widget in the right column (before `AssignedCardsSection`).
- `en.ts` / `es.ts` — adds `homePage.yourTasks` translation key.

Unit tests for the `useSelfDMTasks` hook are included covering: empty state, task detection, open + completed tasks, filtering non-task actions, 5-item limit, and task data resolution.

### Fixed Issues

$
PROPOSAL:

### Tests

1. Log in and navigate to the Home page
2. Create a task in your self-DM chat (click +, "Assign task", assign to yourself)
3. Navigate back to the Home page
4. Verify the "Your tasks" widget appears in the right column with the task you just created
5. Verify the task shows a checkbox, title, and description
6. Click the checkbox to complete the task — verify the title gets strikethrough styling
7. Click the checkbox again to reopen the task — verify the strikethrough is removed
8. Click on the task row — verify it navigates to the task report
9. Create 6+ tasks in your self-DM — verify only 5 are shown in the widget
10. Verify that regular (non-task) messages in the self-DM do not appear in the widget
11. Verify that no errors appear in the JS console

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline (disable network)
2. Navigate to the Home page
3. Verify the "Your tasks" widget still displays previously loaded tasks
4. Toggle a task checkbox — verify the optimistic update applies immediately (strikethrough appears/disappears)
5. Go back online — verify the state syncs correctly

### QA Steps

1. Log in and navigate to the Home page
2. If you have no tasks in your self-DM, create one: go to your self-DM chat, click +, select "Assign task", fill in title/description, assign to yourself
3. Navigate back to the Home page
4. Verify the "Your tasks" widget appears in the right column above "Assigned cards"
5. Verify each task shows a checkbox, title, and description (if present)
6. Click the checkbox on an open task — verify it shows as completed (strikethrough text)
7. Click the checkbox on a completed task — verify it reopens (strikethrough removed)
8. Tap on a task row — verify it navigates to the task report
9. If you have more than 5 tasks, verify only 5 are displayed
10. Verify that no errors appear in the JS console

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
