### PR TITLE
Adjust TabNavigator to handle search pre-render

### DIFF
--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/GetStateForActionHandlers.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/GetStateForActionHandlers.ts
@@ -50,6 +50,21 @@ const MODAL_ROUTES_TO_DISMISS = new Set<string>([
 
 const screensWithEnteringAnimation = new Set<string>();
 
+/**
+ * Stores the original TAB_NAVIGATOR route before a tab-switch pre-insertion
+ * (handleReplaceFullscreenUnderRHP). Restored on cancel by handleRemoveFullscreenUnderRHP,
+ * or cleared by clearPreInsertedOriginalTabRoute when navigation commits successfully.
+ */
+let preInsertedOriginalTabRoute: StackNavigationState<ParamListBase>['routes'][number] | undefined;
+
+function getPreInsertedOriginalTabRoute(): StackNavigationState<ParamListBase>['routes'][number] | undefined {
+    return preInsertedOriginalTabRoute;
+}
+
+function clearPreInsertedOriginalTabRoute() {
+    preInsertedOriginalTabRoute = undefined;
+}
+
 /** Shape of `action.payload.params` when pushing the root tab navigator with a nested tab route (`screen` + optional `params`). */
 type TabNavigatorPushPayloadParams = {
     screen: string;
@@ -128,44 +143,6 @@ function getFocusedRouteFromNavigatorState(navState: NavigationState | PartialSt
             : // Partial states from linking should include `index`; fall back to first route.
               0;
     return navState.routes[idx] as NavigationPartialRoute;
-}
-
-/**
- * After a TAB_NAVIGATOR push, merges `params.state` from the path-derived tab subtree so the new root tab
- * matches deep-link shape (avoids a follow-up NAVIGATE and duplicate tab history). Same idea as
- * getRehydratedTabNavigatorStateAfterPush, but uses the focused tab from `targetTabRouteFromPath`.
- */
-function mergePushedTabNavigatorWithPathState(
-    rehydratedState: StackNavigationState<ParamListBase>,
-    targetTabRouteFromPath: {state?: NavigationState | PartialState<NavigationState>},
-): StackNavigationState<ParamListBase> {
-    const rehydratedLastRoute = rehydratedState.routes.at(-1);
-    if (rehydratedLastRoute?.name !== NAVIGATORS.TAB_NAVIGATOR) {
-        return rehydratedState;
-    }
-
-    const focusedTabRoute = getFocusedRouteFromNavigatorState(targetTabRouteFromPath.state);
-    if (!focusedTabRoute) {
-        return rehydratedState;
-    }
-
-    const tabNavigatorNestedState = buildTabNavigatorNestedState(focusedTabRoute);
-    const paramsWithoutNestedTarget = Object.fromEntries(
-        Object.entries((rehydratedLastRoute.params ?? {}) as Record<string, unknown>).filter(([key]) => key !== 'screen' && key !== 'params'),
-    ) as Record<string, unknown>;
-
-    const updatedLastRoute = {
-        ...rehydratedLastRoute,
-        params: {
-            ...paramsWithoutNestedTarget,
-            state: tabNavigatorNestedState as unknown as PartialState<NavigationState>,
-        },
-    };
-
-    return {
-        ...rehydratedState,
-        routes: [...rehydratedState.routes.slice(0, -1), updatedLastRoute],
-    } as StackNavigationState<ParamListBase>;
 }
 
 /**
@@ -325,23 +302,19 @@ function handleReplaceReportsSplitNavigatorAction(
 /**
  * Handles the REPLACE_FULLSCREEN_UNDER_RHP action.
  *
- * Inserts a new fullscreen route (e.g. SearchFullscreenNavigator) underneath the
- * currently open modal (RHP) without destroying the original fullscreen route.
+ * Pre-inserts a destination screen underneath the currently open RHP so that dismissing
+ * the modal reveals the target without an extra navigation step.
  *
- * State transition (conceptual): [Tab, RHP] -> [Tab, Tab', RHP] where Tab' carries the
- * destination tab subtree from `getStateFromPath` (e.g. Search). The stack may keep two
- * TabNavigator instances; see ensureTabNavigatorRoutes.
+ * When the target is a TAB_NAVIGATOR screen (Home, Search, etc.), we switch tabs within
+ * the single existing TAB_NAVIGATOR instance instead of pushing a duplicate. The original
+ * TAB_NAVIGATOR route is saved to `preInsertedOriginalTabRoute` so it can be fully
+ * restored if the user cancels (see handleRemoveFullscreenUnderRHP).
  *
- * This is intentionally different from a REPLACE (which would drop the previous Tab
- * slice). Preserving the prior Tab route is important for history and for preserving
- * the previous tab's state when dismissing the RHP on the next frame.
+ * State transition for tab targets: [Tab(A), RHP] -> [Tab(B), RHP]
+ * State transition for other fullscreen targets: [FS, RHP] -> [FS, FS', RHP]
  *
- * The companion history-preservation logic lives in addRootHistoryRouterExtension
- * which keeps `state.history` unchanged for this action so that no browser history
- * update is triggered during the insert step itself.
- *
- * @see revealRouteBeforeDismissingModal in Navigation.ts - the caller that orchestrates
- *      this action followed by a DISMISS_MODAL on the next animation frame.
+ * @see removePreInsertedFullscreenIfNeeded in Navigation.ts — the caller that cleans up
+ *      the pre-insertion when the user cancels.
  */
 function handleReplaceFullscreenUnderRHP(
     state: StackNavigationState<ParamListBase>,
@@ -361,15 +334,53 @@ function handleReplaceFullscreenUnderRHP(
         return null;
     }
 
-    // 1. Pop the modal to get the clean fullscreen-only state.
+    const routesWithoutRHP = state.routes.slice(0, -1);
+
+    // When the target is a TAB_NAVIGATOR screen, switch tabs within the existing instance
+    // rather than pushing a duplicate navigator.
+    if (targetRoute.name === NAVIGATORS.TAB_NAVIGATOR) {
+        const tabNavIndex = routesWithoutRHP.findLastIndex((r) => r.name === NAVIGATORS.TAB_NAVIGATOR);
+        if (tabNavIndex < 0) {
+            return null;
+        }
+        const existingTabRoute = routesWithoutRHP.at(tabNavIndex);
+        const existingTabState = existingTabRoute?.state as NavigationState | undefined;
+        if (!existingTabRoute || !existingTabState?.routes?.length) {
+            return null;
+        }
+        const focusedTargetTab = getFocusedRouteFromNavigatorState(targetRoute.state);
+        if (!focusedTargetTab) {
+            return null;
+        }
+        const targetTabIndex = existingTabState.routes.findIndex((r) => r.name === focusedTargetTab.name);
+        if (targetTabIndex < 0) {
+            return null;
+        }
+        // Only update the target tab's nested state; all other tabs are left intact.
+        const updatedTabRoutes = existingTabState.routes.map((r, i) => {
+            if (i !== targetTabIndex) {
+                return r;
+            }
+            return {
+                ...r,
+                ...(focusedTargetTab.params !== undefined ? {params: focusedTargetTab.params} : {}),
+                ...(focusedTargetTab.state !== undefined ? {state: focusedTargetTab.state as typeof r.state} : {}),
+            };
+        });
+        const updatedTabState = {...existingTabState, routes: updatedTabRoutes, index: targetTabIndex};
+        const updatedTabRoute = {...existingTabRoute, state: updatedTabState} as StackNavigationState<ParamListBase>['routes'][number];
+        // Save original route so handleRemoveFullscreenUnderRHP can fully restore it on cancel.
+        preInsertedOriginalTabRoute = existingTabRoute;
+        const newRoutes = [...routesWithoutRHP.slice(0, tabNavIndex), updatedTabRoute, ...routesWithoutRHP.slice(tabNavIndex + 1), rhpRoute];
+        return stackRouter.getRehydratedState({...state, routes: newRoutes, index: newRoutes.length - 1}, configOptions);
+    }
+
+    // For non-tab fullscreen targets: push the route underneath the RHP (existing behavior).
     const stateAfterPop = stackRouter.getStateForAction(state, StackActions.pop(), configOptions);
     if (!stateAfterPop) {
         return null;
     }
 
-    // 2. Push the target fullscreen route on top of the existing one(s).
-    //    getStateFromPath returns nested state (e.g. TabNavigator with tab `state` + `index`, or nested stacks).
-    //    StackActions.push expects { screen, params } for navigators; use the focused child (via `index`), not `routes.at(-1)`.
     let pushParams = targetRoute.params as Record<string, unknown> | undefined;
     const nestedRoute = getFocusedRouteFromNavigatorState(targetRoute.state);
     if (nestedRoute) {
@@ -386,12 +397,7 @@ function handleReplaceFullscreenUnderRHP(
         return null;
     }
 
-    // 3. Re-add the modal on top so visually nothing changes yet - the user still sees
-    //    the RHP, but the new fullscreen route is now rendered behind it.
-    let rehydratedStateAfterPush = stackRouter.getRehydratedState(stateAfterPush, configOptions);
-    if (targetRoute.name === NAVIGATORS.TAB_NAVIGATOR) {
-        rehydratedStateAfterPush = mergePushedTabNavigatorWithPathState(rehydratedStateAfterPush, targetRoute);
-    }
+    const rehydratedStateAfterPush = stackRouter.getRehydratedState(stateAfterPush, configOptions);
     return {
         ...rehydratedStateAfterPush,
         routes: [...rehydratedStateAfterPush.routes, rhpRoute],
@@ -400,13 +406,15 @@ function handleReplaceFullscreenUnderRHP(
 }
 
 /**
- * Reverses handleReplaceFullscreenUnderRHP by removing the fullscreen route that
- * was pre-inserted underneath the currently open modal.
+ * Reverses handleReplaceFullscreenUnderRHP when the user cancels without submitting.
  *
- * State transition: [Home, Search, RHP] -> [Home, RHP]
+ * For the tab-switch path (target was a TAB_NAVIGATOR screen): restores the original
+ * TAB_NAVIGATOR route that was saved during pre-insertion, putting the user back on
+ * the tab they were on before with all state intact.
+ * State transition: [Tab(B), RHP] -> [Tab(A), RHP]
  *
- * Used when the user backs out of the expense confirmation screen without submitting,
- * so the pre-inserted destination route is cleaned up.
+ * For the push path (target was a non-tab fullscreen): removes the pre-inserted route.
+ * State transition: [FS, FS', RHP] -> [FS, RHP]
  */
 function handleRemoveFullscreenUnderRHP(
     state: StackNavigationState<ParamListBase>,
@@ -420,6 +428,21 @@ function handleRemoveFullscreenUnderRHP(
     }
 
     const routesWithoutRHP = state.routes.slice(0, -1);
+
+    // Tab-switch path: restore the original TAB_NAVIGATOR route saved during pre-insertion.
+    if (preInsertedOriginalTabRoute) {
+        const tabNavIndex = routesWithoutRHP.findLastIndex((r) => r.name === NAVIGATORS.TAB_NAVIGATOR);
+        if (tabNavIndex < 0) {
+            preInsertedOriginalTabRoute = undefined;
+            return null;
+        }
+        const originalRoute = preInsertedOriginalTabRoute;
+        preInsertedOriginalTabRoute = undefined;
+        const newRoutes = [...routesWithoutRHP.slice(0, tabNavIndex), originalRoute, ...routesWithoutRHP.slice(tabNavIndex + 1), rhpRoute];
+        return stackRouter.getRehydratedState({...state, routes: newRoutes, index: newRoutes.length - 1}, configOptions);
+    }
+
+    // Push path: remove the pre-inserted fullscreen route (existing behavior).
     if (routesWithoutRHP.length < 2) {
         return null;
     }
@@ -431,8 +454,7 @@ function handleRemoveFullscreenUnderRHP(
 
     const routesWithoutPreInserted = routesWithoutRHP.slice(0, -1);
     const newRoutes = [...routesWithoutPreInserted, rhpRoute];
-    const rehydratedState = stackRouter.getRehydratedState({...state, routes: newRoutes, index: newRoutes.length - 1}, configOptions);
-    return rehydratedState;
+    return stackRouter.getRehydratedState({...state, routes: newRoutes, index: newRoutes.length - 1}, configOptions);
 }
 
 /**
@@ -499,4 +521,6 @@ export {
     handleReplaceReportsSplitNavigatorAction,
     screensWithEnteringAnimation,
     handleToggleSidePanelWithHistoryAction,
+    getPreInsertedOriginalTabRoute,
+    clearPreInsertedOriginalTabRoute,
 };

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -25,6 +25,7 @@ import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import SCREENS, {PROTECTED_SCREENS} from '@src/SCREENS';
 import type {Account, SidePanel} from '@src/types/onyx';
+import {clearPreInsertedOriginalTabRoute, getPreInsertedOriginalTabRoute} from './AppNavigator/createRootStackNavigator/GetStateForActionHandlers';
 import getInitialSplitNavigatorState from './AppNavigator/createSplitNavigator/getInitialSplitNavigatorState';
 import originalCloseRHPFlow from './helpers/closeRHPFlow';
 import findMatchingDynamicSuffix from './helpers/dynamicRoutesUtils/findMatchingDynamicSuffix';
@@ -1022,7 +1023,10 @@ function preInsertFullscreenUnderRHP(route: Route) {
     });
 
     const stateAfter = navigationRef.current.getRootState();
-    if (stateAfter.routes.length === routeCountBefore && stateAfter.routes.at(-1)?.key === lastKeyBefore) {
+    // When the target is a tab (no push), route count and the top key are unchanged.
+    // Check the stored original route to detect a successful tab-switch pre-insertion.
+    const wasTabSwitched = !!getPreInsertedOriginalTabRoute();
+    if (!wasTabSwitched && stateAfter.routes.length === routeCountBefore && stateAfter.routes.at(-1)?.key === lastKeyBefore) {
         Log.hmmm(`[Navigation] preInsertFullscreenUnderRHP dispatch was ignored`, {route});
         return;
     }
@@ -1040,6 +1044,7 @@ function getIsFullscreenPreInsertedUnderRHP() {
 function clearFullscreenPreInsertedFlag() {
     isFullscreenPreInsertedUnderRHP = false;
     preInsertedFullscreenRouteName = undefined;
+    clearPreInsertedOriginalTabRoute();
 }
 
 /**
@@ -1076,7 +1081,31 @@ function removePreInsertedFullscreenIfNeeded() {
         return;
     }
 
-    // RHP already dismissed - the pre-inserted fullscreen is now the topmost route; pop it.
+    // RHP already dismissed. For the tab-switch path, jump back to the original tab.
+    // For the push path, pop the pre-inserted route directly.
+    const originalTabRoute = getPreInsertedOriginalTabRoute();
+    if (originalTabRoute) {
+        clearPreInsertedOriginalTabRoute();
+        const originalTabState = originalTabRoute.state as NavigationState | undefined;
+        const originalFocusedTabIndex = originalTabState?.index ?? 0;
+        const originalTabName = originalTabState?.routes?.[originalFocusedTabIndex]?.name;
+        if (originalTabName) {
+            requestAnimationFrame(() => {
+                const currentState = navigationRef.getRootState();
+                const tabNavRoute = currentState?.routes.find((r) => r.name === NAVIGATORS.TAB_NAVIGATOR);
+                if (!tabNavRoute?.state?.key) {
+                    return;
+                }
+                navigationRef.current?.dispatch({
+                    ...TabActions.jumpTo(originalTabName),
+                    target: tabNavRoute.state.key,
+                });
+            });
+        }
+        return;
+    }
+
+    // Push path: the pre-inserted fullscreen is now the topmost route; pop it.
     // Deferred to the next frame to avoid dispatching during a React commit.
     // Capture the route key now so the rAF callback can match on identity, not just name.
     const targetRouteKey = rootState.routes.at(-1)?.key;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>