### PR TITLE
[TEST] feat(mfa): fork CI and permissions smoke test

### DIFF
--- a/MFA_FORK_CI_TEST.md
+++ b/MFA_FORK_CI_TEST.md
@@ -1,0 +1,10 @@
+# Fork CI and permissions smoke test
+
+This file is a temporary marker used to open a test pull request against the `dariusz-81197-mfa-state-machine` integration branch on the `software-mansion-labs/expensify-app-fork` fork.
+
+Purpose:
+
+- Verify that CI runs on pull requests opened in the fork.
+- Verify that Expensify maintainers have the access they need to review.
+
+This file and its branch can be deleted once both checks above are confirmed.


### PR DESCRIPTION
## [TEST PR - safe to close] Fork CI and permissions smoke test

This is a throwaway test PR. It adds a single marker file (`MFA_FORK_CI_TEST.md`) on top of the `dariusz-81197-mfa-state-machine` integration branch, which now lives on the `software-mansion-labs/expensify-app-fork` fork.

### Why

Following the discussion about moving the MFA state-machine integration branch off `Expensify/App` and onto the SWM fork, this PR verifies the new setup before we resume feature work here:

- **CI** - confirm that the GitHub Actions pipeline runs on pull requests opened inside the fork.
- **Permissions** - confirm that Expensify maintainers have the access they need to view, review, and approve PRs on the fork.

### Notes

- Opened as ready (not draft) on purpose, so that any CI jobs gated on `ready_for_review` also run and we get the full signal.
- No application code is touched; the only change is the marker markdown file.
- Once both checks above are confirmed, this PR and the `dariusz-biela/test/fork-ci-check` branch can be deleted.
