### PR TITLE
[No QA] feat(mfa): add the soft prompt step to the state machine

### DIFF
--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationInternalApiContext.ts
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationInternalApiContext.ts
@@ -21,6 +21,9 @@ type MultifactorAuthenticationInternalApi = {
     /** Notify the machine that the close animation has fully finished. Called by the modal navigator on teardown; the machine then moves from `closing` back to `closed`. */
     notifyModalClosed: () => void;
 
+    /** Approve the soft prompt. Called by the prompt screen's confirm button; the machine persists the acceptance and moves the flow on. */
+    approveSoftPrompt: () => void;
+
     /** Centralized back-press / backdrop entry. */
     requestCancel: () => void;
 

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationInternalApiContext.ts
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationInternalApiContext.ts
@@ -21,7 +21,7 @@ type MultifactorAuthenticationInternalApi = {
     /** Notify the machine that the close animation has fully finished. Called by the modal navigator on teardown; the machine then moves from `closing` back to `closed`. */
     notifyModalClosed: () => void;
 
-    /** Approve the soft prompt. Called by the prompt screen's confirm button; the machine persists the acceptance and moves the flow on. */
+    /** Approve the soft prompt. The machine persists the acceptance and moves the flow to the outcome. */
     approveSoftPrompt: () => void;
 
     /** Centralized back-press / backdrop entry. */

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -61,6 +61,13 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             return;
         }
 
+        // The flow captures the account at INIT and keeps it for per-account device state, so a
+        // session that has not hydrated yet must not start a flow keyed to the placeholder account.
+        if (accountID === CONST.DEFAULT_NUMBER_ID) {
+            addMFABreadcrumb('Flow rejected: account not initialized', {scenario: scenarioName}, 'warning');
+            return;
+        }
+
         const startCredentialsState = await captureCredentialsState();
 
         addMFABreadcrumb('Flow started', {

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -81,7 +81,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
 
         const scenario = getScenarioConfig(scenarioName);
 
-        send({type: 'INIT', scenarioName, scenario, payload: params && Object.keys(params).length > 0 ? params : undefined});
+        send({type: 'INIT', accountID, scenarioName, scenario, payload: params && Object.keys(params).length > 0 ? params : undefined});
     };
 
     const closeModal = () => send({type: 'CLOSE_MODAL'});

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -86,6 +86,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
 
     const closeModal = () => send({type: 'CLOSE_MODAL'});
     const notifyModalClosed = () => send({type: 'MODAL_CLOSED'});
+    const approveSoftPrompt = () => send({type: 'SOFT_PROMPT_APPROVED'});
 
     // There is no cancel-confirmation dialog yet, so every cancel path closes the modal directly.
     const requestCancel = () => send({type: 'CLOSE_MODAL'});
@@ -100,6 +101,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
         state,
         closeModal,
         notifyModalClosed,
+        approveSoftPrompt,
         requestCancel,
         hideCancelConfirm,
         confirmCancel,

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -10,17 +10,13 @@ import useSyncMfaModalNavigatorWithHistory from '@components/MultifactorAuthenti
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useInspectedMachine from '@hooks/useInspectedMachine';
 import useNetwork from '@hooks/useNetwork';
-import useOnyx from '@hooks/useOnyx';
 
 import getPlatform from '@libs/getPlatform';
-
-import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
 
 import CONST from '@src/CONST';
 
 import type {ReactNode} from 'react';
 
-import {hasAcceptedSoftPromptSelector} from '@selectors/DeviceBiometrics';
 import React from 'react';
 
 import type {MultifactorAuthenticationExecuteScenarioArgs, MultifactorAuthenticationExternalAPI} from './MultifactorAuthenticationExternalApiContext';
@@ -40,7 +36,6 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
     const {isOffline} = useNetwork();
     const platform = getPlatform();
     const biometrics = useBiometrics();
-    const [hasEverAcceptedSoftPrompt = false] = useOnyx(getDeviceBiometricsOnyxKey(accountID), {selector: hasAcceptedSoftPromptSelector});
 
     const [snapshot, send] = useInspectedMachine(MFAMachine);
     const state = snapshotToState(snapshot);
@@ -50,7 +45,6 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
         return {
             hasServerCredentials: biometrics.serverKnownCredentialIDs.length > 0,
             hasLocalCredentials,
-            hasEverAcceptedSoftPrompt,
         };
     };
 
@@ -74,7 +68,6 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             hasPayload: params !== undefined && Object.keys(params).length > 0,
             platform,
             isOffline,
-            hasAcceptedSoftPrompt: startCredentialsState.hasEverAcceptedSoftPrompt,
             serverHasAnyCredentials: startCredentialsState.hasServerCredentials,
         });
         trackMFAFlowStart({scenario: scenarioName, isOffline, credentialsState: startCredentialsState});

--- a/src/components/MultifactorAuthentication/Context/state.ts
+++ b/src/components/MultifactorAuthentication/Context/state.ts
@@ -22,9 +22,6 @@ type MultifactorAuthenticationState = {
     /** Challenge received from backend for authorization (full object with allowCredentials, rpId, challenge) */
     authorizationChallenge: AuthenticationChallenge | undefined;
 
-    /** Whether user approved the soft prompt for biometric setup */
-    softPromptApproved: boolean;
-
     /** Whether registration step has been completed */
     isRegistrationComplete: boolean;
 
@@ -46,7 +43,6 @@ const DEFAULT_STATE: MultifactorAuthenticationState = {
     validateCode: undefined,
     registrationChallenge: undefined,
     authorizationChallenge: undefined,
-    softPromptApproved: false,
     isRegistrationComplete: false,
     isAuthorizationComplete: false,
     isFlowComplete: false,

--- a/src/components/MultifactorAuthentication/Context/stateReducer.ts
+++ b/src/components/MultifactorAuthentication/Context/stateReducer.ts
@@ -25,8 +25,6 @@ function stateReducer(state: MultifactorAuthenticationState, action: Action): Mu
             return {...state, registrationChallenge: action.payload};
         case 'SET_AUTHORIZATION_CHALLENGE':
             return {...state, authorizationChallenge: action.payload};
-        case 'SET_SOFT_PROMPT_APPROVED':
-            return {...state, softPromptApproved: action.payload};
         case 'SET_REGISTRATION_COMPLETE':
             return {...state, isRegistrationComplete: action.payload};
         case 'SET_AUTHORIZATION_COMPLETE':

--- a/src/components/MultifactorAuthentication/Context/types.ts
+++ b/src/components/MultifactorAuthentication/Context/types.ts
@@ -12,7 +12,6 @@ type Action =
     | {type: 'SET_VALIDATE_CODE'; payload: string | undefined}
     | {type: 'SET_REGISTRATION_CHALLENGE'; payload: RegistrationChallenge | undefined}
     | {type: 'SET_AUTHORIZATION_CHALLENGE'; payload: AuthenticationChallenge | undefined}
-    | {type: 'SET_SOFT_PROMPT_APPROVED'; payload: boolean}
     | {type: 'SET_REGISTRATION_COMPLETE'; payload: boolean}
     | {type: 'SET_AUTHORIZATION_COMPLETE'; payload: boolean}
     | {type: 'SET_FLOW_COMPLETE'; payload: boolean}

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -14,6 +14,7 @@ import type IconAsset from '@src/types/utils/IconAsset';
 import {hasAcceptedSoftPromptSelector} from '@selectors/DeviceBiometrics';
 import {useEffect, useRef, useState} from 'react';
 
+import {useMultifactorAuthenticationInternal} from './MultifactorAuthenticationInternalApiContext';
 import {useMultifactorAuthenticationState} from './MultifactorAuthenticationStateContext';
 
 type PromptContent = {
@@ -35,6 +36,9 @@ type PromptContent = {
  */
 function usePromptContent(promptType: MultifactorAuthenticationPromptType): PromptContent {
     const state = useMultifactorAuthenticationState();
+    // The soft-prompt approval was migrated to the state machine, so it is read from the
+    // machine-derived state while the remaining flow fields still live in the legacy reducer.
+    const {state: machineState} = useMultifactorAuthenticationInternal();
     const {areLocalCredentialsKnownToServer} = useBiometrics();
     const {accountID} = useCurrentUserPersonalDetails();
     const [serverHasCredentials, setServerHasCredentials] = useState(false);
@@ -72,7 +76,7 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     const contentData = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[promptType];
 
     // Returning user: server has credentials, but user hasn't approved soft prompt yet
-    const isReturningUser = wasPreviouslyRegisteredRef.current || (hasEverAcceptedSoftPrompt && serverHasCredentials && !state.softPromptApproved);
+    const isReturningUser = wasPreviouslyRegisteredRef.current || (hasEverAcceptedSoftPrompt && serverHasCredentials && !machineState.softPromptApproved);
 
     useEffect(() => {
         if (!isReturningUser) {
@@ -101,7 +105,7 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     // Hide it for: users who already approved the soft prompt, users who finished registration,
     // or returning users with existing server credentials. The button prompts users to enable biometrics.
     const shouldDisplayConfirmButton =
-        !hasEverAcceptedSoftPrompt || (!state.softPromptApproved && !state.isRegistrationComplete && !serverHasCredentials && !wasPreviouslyRegisteredRef.current);
+        !hasEverAcceptedSoftPrompt || (!machineState.softPromptApproved && !state.isRegistrationComplete && !serverHasCredentials && !wasPreviouslyRegisteredRef.current);
 
     return {
         illustration: contentData.illustration,

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -36,8 +36,7 @@ type PromptContent = {
  */
 function usePromptContent(promptType: MultifactorAuthenticationPromptType): PromptContent {
     const state = useMultifactorAuthenticationState();
-    // The soft-prompt approval was migrated to the state machine, so it is read from the
-    // machine-derived state while the remaining flow fields still live in the legacy reducer.
+    // The soft-prompt approval lives in the machine, while the remaining flow fields still come from the legacy reducer.
     const {state: machineState} = useMultifactorAuthenticationInternal();
     const {areLocalCredentialsKnownToServer} = useBiometrics();
     const {accountID} = useCurrentUserPersonalDetails();

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -4,10 +4,12 @@ import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
 
-import Onyx from 'react-native-onyx';
-import {fromPromise} from 'xstate';
+import type {EventObject} from 'xstate';
 
-import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from './types';
+import Onyx from 'react-native-onyx';
+import {fromCallback, fromPromise} from 'xstate';
+
+import type {ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, ValidateDeviceInput} from './types';
 
 /**
  * A refused device resolves as a failed MFAResult, so the machine's onError transition for this
@@ -16,45 +18,19 @@ import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from './types'
 const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => checkDeviceEligibility(input.allowedAuthenticationMethods));
 
 /**
- * Resolves with the current account's device-local soft-prompt flag. Onyx exposes this value through
- * its callback API, so the promise disconnects the temporary connection after the first value or
- * when XState stops the actor.
+ * Subscribes to the current account's device-local soft-prompt flag. The first value sends the
+ * machine out of the invoking state, whose exit stops this actor and disconnects the subscription.
  */
-const readHasAcceptedSoftPrompt = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
-    ({input, signal}) =>
-        new Promise<boolean>((resolve) => {
-            let connection: ReturnType<typeof Onyx.connectWithoutView> | undefined;
-            let shouldDisconnect = false;
-            let settled = false;
+const readHasAcceptedSoftPrompt = fromCallback<EventObject, ReadHasAcceptedSoftPromptInput>(({input, sendBack}) => {
+    const connection = Onyx.connectWithoutView({
+        key: getDeviceBiometricsOnyxKey(input.accountID),
+        callback: (deviceBiometrics) => {
+            sendBack({type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted: deviceBiometrics?.hasAcceptedSoftPrompt ?? false} satisfies SoftPromptAcceptanceReadEvent);
+        },
+    });
 
-            const disconnect = () => {
-                if (connection === undefined) {
-                    shouldDisconnect = true;
-                    return;
-                }
-                Onyx.disconnect(connection);
-                connection = undefined;
-            };
-            const resolveFirstValue = (accepted: boolean) => {
-                if (settled) {
-                    return;
-                }
-                settled = true;
-                signal.removeEventListener('abort', disconnect);
-                disconnect();
-                resolve(accepted);
-            };
-
-            signal.addEventListener('abort', disconnect, {once: true});
-            connection = Onyx.connectWithoutView({
-                key: getDeviceBiometricsOnyxKey(input.accountID),
-                callback: (deviceBiometrics) => resolveFirstValue(deviceBiometrics?.hasAcceptedSoftPrompt ?? false),
-            });
-            if (shouldDisconnect) {
-                disconnect();
-            }
-        }),
-);
+    return () => Onyx.disconnect(connection);
+});
 
 /**
  * Builds the side-effect actors that the machine states invoke. The machine is always created with

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -23,36 +23,18 @@ const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => 
 const readHasAcceptedSoftPrompt = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
     ({input, signal}) =>
         new Promise<boolean>((resolve) => {
-            let connection: ReturnType<typeof Onyx.connectWithoutView> | undefined;
-            let shouldDisconnect = false;
-            let settled = false;
-
-            const disconnect = () => {
-                if (connection === undefined) {
-                    shouldDisconnect = true;
-                    return;
-                }
-                Onyx.disconnect(connection);
-                connection = undefined;
-            };
-            const resolveFirstValue = (accepted: boolean) => {
-                if (settled) {
-                    return;
-                }
-                settled = true;
-                signal.removeEventListener('abort', disconnect);
-                disconnect();
-                resolve(accepted);
-            };
+            let connection: ReturnType<typeof Onyx.connectWithoutView>;
+            const disconnect = () => Onyx.disconnect(connection);
 
             signal.addEventListener('abort', disconnect, {once: true});
             connection = Onyx.connectWithoutView({
                 key: getDeviceBiometricsOnyxKey(input.accountID),
-                callback: (deviceBiometrics) => resolveFirstValue(deviceBiometrics?.hasAcceptedSoftPrompt ?? false),
+                callback: (deviceBiometrics) => {
+                    signal.removeEventListener('abort', disconnect);
+                    disconnect();
+                    resolve(deviceBiometrics?.hasAcceptedSoftPrompt ?? false);
+                },
             });
-            if (shouldDisconnect) {
-                disconnect();
-            }
         }),
 );
 

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -16,9 +16,8 @@ import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from './types'
 const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => checkDeviceEligibility(input.allowedAuthenticationMethods));
 
 /**
- * Resolves with the current account's device-local soft-prompt flag. Onyx exposes this value through
- * its callback API, so the promise disconnects the temporary connection after the first value or
- * when XState stops the actor.
+ * Reads the account's device-local soft-prompt flag once. The temporary Onyx connection is
+ * disconnected after the first value or when XState stops the actor.
  */
 const readHasAcceptedSoftPrompt = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
     ({input, signal}) =>

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -4,12 +4,10 @@ import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
 
-import type {EventObject} from 'xstate';
-
 import Onyx from 'react-native-onyx';
-import {fromCallback, fromPromise} from 'xstate';
+import {fromPromise} from 'xstate';
 
-import type {ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, ValidateDeviceInput} from './types';
+import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from './types';
 
 /**
  * A refused device resolves as a failed MFAResult, so the machine's onError transition for this
@@ -18,19 +16,45 @@ import type {ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, Vali
 const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => checkDeviceEligibility(input.allowedAuthenticationMethods));
 
 /**
- * Subscribes to the current account's device-local soft-prompt flag. The first value sends the
- * machine out of the invoking state, whose exit stops this actor and disconnects the subscription.
+ * Resolves with the current account's device-local soft-prompt flag. Onyx exposes this value through
+ * its callback API, so the promise disconnects the temporary connection after the first value or
+ * when XState stops the actor.
  */
-const readHasAcceptedSoftPrompt = fromCallback<EventObject, ReadHasAcceptedSoftPromptInput>(({input, sendBack}) => {
-    const connection = Onyx.connectWithoutView({
-        key: getDeviceBiometricsOnyxKey(input.accountID),
-        callback: (deviceBiometrics) => {
-            sendBack({type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted: deviceBiometrics?.hasAcceptedSoftPrompt ?? false} satisfies SoftPromptAcceptanceReadEvent);
-        },
-    });
+const readHasAcceptedSoftPrompt = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
+    ({input, signal}) =>
+        new Promise<boolean>((resolve) => {
+            let connection: ReturnType<typeof Onyx.connectWithoutView> | undefined;
+            let shouldDisconnect = false;
+            let settled = false;
 
-    return () => Onyx.disconnect(connection);
-});
+            const disconnect = () => {
+                if (connection === undefined) {
+                    shouldDisconnect = true;
+                    return;
+                }
+                Onyx.disconnect(connection);
+                connection = undefined;
+            };
+            const resolveFirstValue = (accepted: boolean) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                signal.removeEventListener('abort', disconnect);
+                disconnect();
+                resolve(accepted);
+            };
+
+            signal.addEventListener('abort', disconnect, {once: true});
+            connection = Onyx.connectWithoutView({
+                key: getDeviceBiometricsOnyxKey(input.accountID),
+                callback: (deviceBiometrics) => resolveFirstValue(deviceBiometrics?.hasAcceptedSoftPrompt ?? false),
+            });
+            if (shouldDisconnect) {
+                disconnect();
+            }
+        }),
+);
 
 /**
  * Builds the side-effect actors that the machine states invoke. The machine is always created with

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -2,9 +2,12 @@ import checkDeviceEligibility from '@components/MultifactorAuthentication/biomet
 
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
+import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
+
+import Onyx from 'react-native-onyx';
 import {fromPromise} from 'xstate';
 
-import type {ValidateDeviceInput} from './types';
+import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from './types';
 
 /**
  * A refused device resolves as a failed MFAResult, so the machine's onError transition for this
@@ -13,11 +16,52 @@ import type {ValidateDeviceInput} from './types';
 const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => checkDeviceEligibility(input.allowedAuthenticationMethods));
 
 /**
+ * Resolves with the current account's device-local soft-prompt flag. Onyx exposes this value through
+ * its callback API, so the promise disconnects the temporary connection after the first value or
+ * when XState stops the actor.
+ */
+const readHasAcceptedSoftPrompt = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
+    ({input, signal}) =>
+        new Promise<boolean>((resolve) => {
+            let connection: ReturnType<typeof Onyx.connectWithoutView> | undefined;
+            let shouldDisconnect = false;
+            let settled = false;
+
+            const disconnect = () => {
+                if (connection === undefined) {
+                    shouldDisconnect = true;
+                    return;
+                }
+                Onyx.disconnect(connection);
+                connection = undefined;
+            };
+            const resolveFirstValue = (accepted: boolean) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                signal.removeEventListener('abort', disconnect);
+                disconnect();
+                resolve(accepted);
+            };
+
+            signal.addEventListener('abort', disconnect, {once: true});
+            connection = Onyx.connectWithoutView({
+                key: getDeviceBiometricsOnyxKey(input.accountID),
+                callback: (deviceBiometrics) => resolveFirstValue(deviceBiometrics?.hasAcceptedSoftPrompt ?? false),
+            });
+            if (shouldDisconnect) {
+                disconnect();
+            }
+        }),
+);
+
+/**
  * Builds the side-effect actors that the machine states invoke. The machine is always created with
  * these working implementations, so no caller needs to provide stubs or overrides.
  */
 function createActors() {
-    return {validateDevice};
+    return {validateDevice, readHasAcceptedSoftPrompt};
 }
 
 export default createActors;

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -4,7 +4,7 @@ import {navigate as mfaNavigate, resetMfaNavigation} from '@components/Multifact
 import {createUnhandledExceptionMFAError, getMFAFailureError} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import Navigation from '@libs/Navigation/Navigation';
 
-import {hasEverAcceptedSoftPrompt, markHasAcceptedSoftPrompt} from '@userActions/MultifactorAuthentication';
+import {markHasAcceptedSoftPrompt} from '@userActions/MultifactorAuthentication';
 
 import CONST from '@src/CONST';
 import SCREENS from '@src/SCREENS';
@@ -26,6 +26,7 @@ const PROMPT_TARGET = `#${MFA_STATE.PROMPT}` as const;
 const PROMPT_TYPE = CONST.MULTIFACTOR_AUTHENTICATION.PROMPT_TYPE_MAP[deviceVerificationType];
 
 const DEFAULT_CONTEXT: MfaContext = {
+    accountID: undefined,
     error: undefined,
     scenarioName: undefined,
     scenario: undefined,
@@ -64,6 +65,7 @@ const MFAMachine = setup({
             }
             return {
                 ...DEFAULT_CONTEXT,
+                accountID: event.accountID,
                 scenarioName: event.scenarioName,
                 scenario: event.scenario,
                 payload: event.payload,
@@ -83,7 +85,12 @@ const MFAMachine = setup({
         approveSoftPrompt: assign({softPromptApproved: true}),
         // The durable "asked once" flag lives in Onyx, so future flows on this device can skip the
         // prompt. Owned by the machine so every sender of SOFT_PROMPT_APPROVED persists it.
-        persistSoftPromptAcceptance: () => markHasAcceptedSoftPrompt(),
+        persistSoftPromptAcceptance: ({context}) => {
+            if (context.accountID === undefined) {
+                throw new Error('MFA account must be initialized before persisting soft-prompt acceptance');
+            }
+            markHasAcceptedSoftPrompt(context.accountID);
+        },
         // Runs on CLOSE_MODAL: drops the cancel-confirmation modal so it cannot linger over the
         // closing navigator (CLOSE_MODAL can fire without the flow completing, e.g. an offline cancel).
         hideCancelConfirmModal: assign({isCancelConfirmVisible: false}),
@@ -134,16 +141,12 @@ const MFAMachine = setup({
                                     }
                                     return {allowedAuthenticationMethods: context.scenario.allowedAuthenticationMethods};
                                 },
-                                // An eligible device moves on to the soft prompt, with two overrides.
-                                // A stored error always wins: the flow goes straight to the outcome
-                                // resolver, which selects failure. A user who already accepted the
-                                // soft prompt on this device (read from Onyx at decision time) skips
-                                // it. A refusal stores its blocking MFAError first and resolves the
-                                // same way as a stored error.
+                                // An eligible device moves on to the soft-prompt acceptance check. A
+                                // stored error always wins and goes straight to the outcome resolver,
+                                // while a refusal stores its blocking MFAError before resolving it.
                                 onDone: [
                                     {guard: ({context, event}) => event.output.success && context.error !== undefined, target: OUTCOME_TARGET},
-                                    {guard: ({event}) => event.output.success && hasEverAcceptedSoftPrompt(), target: OUTCOME_TARGET},
-                                    {guard: ({event}) => event.output.success, target: PROMPT_TARGET},
+                                    {guard: ({event}) => event.output.success, target: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE},
                                     {target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
                                 ],
                                 // Expected refusals travel as failed results through onDone, so a
@@ -151,6 +154,25 @@ const MFAMachine = setup({
                                 onError: {
                                     target: OUTCOME_TARGET,
                                     actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Device check', event.error)}),
+                                },
+                            },
+                        },
+                        // Reads the per-account Onyx flag through a one-shot promise actor. Its done
+                        // event carries the first value and leaving this state cancels the read.
+                        [MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE]: {
+                            invoke: {
+                                id: 'readHasAcceptedSoftPrompt',
+                                src: 'readHasAcceptedSoftPrompt',
+                                input: ({context}) => {
+                                    if (context.accountID === undefined) {
+                                        throw new Error('MFA account must be initialized before reading soft-prompt acceptance');
+                                    }
+                                    return {accountID: context.accountID};
+                                },
+                                onDone: [{guard: ({event}) => event.output, target: OUTCOME_TARGET}, {target: PROMPT_TARGET}],
+                                onError: {
+                                    target: OUTCOME_TARGET,
+                                    actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Soft-prompt acceptance read', event.error)}),
                                 },
                             },
                         },

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -1,7 +1,10 @@
+import {deviceVerificationType} from '@components/MultifactorAuthentication/biometrics/operations';
 import {navigate as mfaNavigate, resetMfaNavigation} from '@components/MultifactorAuthentication/mfaNavigation';
 
 import {createUnhandledExceptionMFAError, getMFAFailureError} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import Navigation from '@libs/Navigation/Navigation';
+
+import {hasEverAcceptedSoftPrompt, markHasAcceptedSoftPrompt} from '@userActions/MultifactorAuthentication';
 
 import CONST from '@src/CONST';
 import SCREENS from '@src/SCREENS';
@@ -14,15 +17,20 @@ import createActors from './mfaActors';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
-// Absolute target for the outcome branch. The device check runs under `preparing`, so reaching the
-// sibling `outcome` branch needs an id target rather than a relative one.
+// Absolute targets for the screen branches. The device check runs under `preparing`, so reaching a
+// sibling branch needs an id target rather than a relative one.
 const OUTCOME_TARGET = `#${MFA_STATE.OUTCOME}` as const;
+const PROMPT_TARGET = `#${MFA_STATE.PROMPT}` as const;
+
+// Which prompt variant the screen renders is a device property, resolved once per platform.
+const PROMPT_TYPE = CONST.MULTIFACTOR_AUTHENTICATION.PROMPT_TYPE_MAP[deviceVerificationType];
 
 const DEFAULT_CONTEXT: MfaContext = {
     error: undefined,
     scenarioName: undefined,
     scenario: undefined,
     payload: undefined,
+    softPromptApproved: false,
     isCancelConfirmVisible: false,
 };
 
@@ -69,6 +77,13 @@ const MFAMachine = setup({
         navigateToFailureOutcome: () => {
             Navigation.runAfterTransition(() => mfaNavigate(SCREENS.MULTIFACTOR_AUTHENTICATION.OUTCOME_FAILURE));
         },
+        navigateToPrompt: () => {
+            Navigation.runAfterTransition(() => mfaNavigate(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT, {promptType: PROMPT_TYPE}));
+        },
+        approveSoftPrompt: assign({softPromptApproved: true}),
+        // The durable "asked once" flag lives in Onyx, so future flows on this device can skip the
+        // prompt. Owned by the machine so every sender of SOFT_PROMPT_APPROVED persists it.
+        persistSoftPromptAcceptance: () => markHasAcceptedSoftPrompt(),
         // Runs on CLOSE_MODAL: drops the cancel-confirmation modal so it cannot linger over the
         // closing navigator (CLOSE_MODAL can fire without the flow completing, e.g. an offline cancel).
         hideCancelConfirmModal: assign({isCancelConfirmVisible: false}),
@@ -119,11 +134,16 @@ const MFAMachine = setup({
                                     }
                                     return {allowedAuthenticationMethods: context.scenario.allowedAuthenticationMethods};
                                 },
-                                // Every result enters the outcome resolver. A refusal stores its
-                                // blocking MFAError first, so the resolver selects failure from that
-                                // error, while an eligible device with no error selects success.
+                                // An eligible device moves on to the soft prompt, with two overrides.
+                                // A stored error always wins: the flow goes straight to the outcome
+                                // resolver, which selects failure. A user who already accepted the
+                                // soft prompt on this device (read from Onyx at decision time) skips
+                                // it. A refusal stores its blocking MFAError first and resolves the
+                                // same way as a stored error.
                                 onDone: [
-                                    {guard: ({event}) => event.output.success, target: OUTCOME_TARGET},
+                                    {guard: ({context, event}) => event.output.success && context.error !== undefined, target: OUTCOME_TARGET},
+                                    {guard: ({event}) => event.output.success && hasEverAcceptedSoftPrompt(), target: OUTCOME_TARGET},
+                                    {guard: ({event}) => event.output.success, target: PROMPT_TARGET},
                                     {target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
                                 ],
                                 // Expected refusals travel as failed results through onDone, so a
@@ -134,6 +154,24 @@ const MFAMachine = setup({
                                 },
                             },
                         },
+                    },
+                },
+                // The soft-prompt screen: asks the user to consent to biometric verification before
+                // the flow continues. Entered only when the user has never accepted the prompt on
+                // this device; the registration vs reinstall variants arrive with the registration
+                // decision.
+                [MFA_STATE.PROMPT]: {
+                    id: MFA_STATE.PROMPT,
+                    entry: ['navigateToPrompt'],
+                    initial: MFA_STATE.AWAITING_SOFT_PROMPT,
+                    on: {
+                        SOFT_PROMPT_APPROVED: {
+                            target: MFA_STATE.OUTCOME,
+                            actions: ['approveSoftPrompt', 'persistSoftPromptAcceptance'],
+                        },
+                    },
+                    states: {
+                        [MFA_STATE.AWAITING_SOFT_PROMPT]: {},
                     },
                 },
                 [MFA_STATE.OUTCOME]: {

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -141,13 +141,13 @@ const MFAMachine = setup({
                                     }
                                     return {allowedAuthenticationMethods: context.scenario.allowedAuthenticationMethods};
                                 },
-                                // An eligible device moves on to the soft-prompt acceptance check. A
-                                // stored error always wins and goes straight to the outcome resolver,
-                                // while a refusal stores its blocking MFAError before resolving it.
+                                // A refusal stores its blocking MFAError before resolving it. A stored
+                                // error still wins over a successful result, while a clean success moves
+                                // on to the soft-prompt acceptance check.
                                 onDone: [
-                                    {guard: ({context, event}) => event.output.success && context.error !== undefined, target: OUTCOME_TARGET},
-                                    {guard: ({event}) => event.output.success, target: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE},
-                                    {target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
+                                    {guard: ({event}) => !event.output.success, target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
+                                    {guard: ({context}) => context.error !== undefined, target: OUTCOME_TARGET},
+                                    {target: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE},
                                 ],
                                 // Expected refusals travel as failed results through onDone, so a
                                 // rejection means the platform check itself threw unexpectedly.

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -157,8 +157,8 @@ const MFAMachine = setup({
                                 },
                             },
                         },
-                        // Subscribes to the per-account Onyx flag. The callback actor sends the first
-                        // value back as an event, and leaving this state disconnects it.
+                        // Reads the per-account Onyx flag through a one-shot promise actor. Its done
+                        // event carries the first value and leaving this state cancels the read.
                         [MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE]: {
                             invoke: {
                                 id: 'readHasAcceptedSoftPrompt',
@@ -169,13 +169,11 @@ const MFAMachine = setup({
                                     }
                                     return {accountID: context.accountID};
                                 },
+                                onDone: [{guard: ({event}) => event.output, target: OUTCOME_TARGET}, {target: PROMPT_TARGET}],
                                 onError: {
                                     target: OUTCOME_TARGET,
                                     actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Soft-prompt acceptance read', event.error)}),
                                 },
-                            },
-                            on: {
-                                ACTOR_SOFT_PROMPT_ACCEPTANCE_READ: [{guard: ({event}) => event.accepted, target: OUTCOME_TARGET}, {target: PROMPT_TARGET}],
                             },
                         },
                     },

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -139,9 +139,7 @@ const MFAMachine = setup({
                                     }
                                     return {allowedAuthenticationMethods: context.scenario.allowedAuthenticationMethods};
                                 },
-                                // A refusal stores its blocking MFAError before resolving it. A stored
-                                // error still wins over a successful result, while a clean success moves
-                                // on to the soft-prompt acceptance check.
+                                // An error stored earlier in the flow wins even over a successful device check.
                                 onDone: [
                                     {guard: ({event}) => !event.output.success, target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
                                     {guard: ({context}) => context.error !== undefined, target: OUTCOME_TARGET},
@@ -155,8 +153,6 @@ const MFAMachine = setup({
                                 },
                             },
                         },
-                        // Reads the per-account Onyx flag through a one-shot promise actor. Its done
-                        // event carries the first value and leaving this state cancels the read.
                         [MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE]: {
                             invoke: {
                                 id: 'readHasAcceptedSoftPrompt',
@@ -176,7 +172,7 @@ const MFAMachine = setup({
                         },
                     },
                 },
-                // Shows the soft prompt after device validation when the current account has not accepted it.
+                // This branch shows the soft prompt when the current account has not accepted it on this device.
                 [MFA_STATE.PROMPT]: {
                     id: MFA_STATE.PROMPT,
                     entry: ['navigateToPrompt'],

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -157,8 +157,8 @@ const MFAMachine = setup({
                                 },
                             },
                         },
-                        // Reads the per-account Onyx flag through a one-shot promise actor. Its done
-                        // event carries the first value and leaving this state cancels the read.
+                        // Subscribes to the per-account Onyx flag. The callback actor sends the first
+                        // value back as an event, and leaving this state disconnects it.
                         [MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE]: {
                             invoke: {
                                 id: 'readHasAcceptedSoftPrompt',
@@ -169,11 +169,13 @@ const MFAMachine = setup({
                                     }
                                     return {accountID: context.accountID};
                                 },
-                                onDone: [{guard: ({event}) => event.output, target: OUTCOME_TARGET}, {target: PROMPT_TARGET}],
                                 onError: {
                                     target: OUTCOME_TARGET,
                                     actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Soft-prompt acceptance read', event.error)}),
                                 },
+                            },
+                            on: {
+                                ACTOR_SOFT_PROMPT_ACCEPTANCE_READ: [{guard: ({event}) => event.accepted, target: OUTCOME_TARGET}, {target: PROMPT_TARGET}],
                             },
                         },
                     },

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -83,8 +83,6 @@ const MFAMachine = setup({
             Navigation.runAfterTransition(() => mfaNavigate(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT, {promptType: PROMPT_TYPE}));
         },
         approveSoftPrompt: assign({softPromptApproved: true}),
-        // The durable "asked once" flag lives in Onyx, so future flows on this device can skip the
-        // prompt. Owned by the machine so every sender of SOFT_PROMPT_APPROVED persists it.
         persistSoftPromptAcceptance: ({context}) => {
             if (context.accountID === undefined) {
                 throw new Error('MFA account must be initialized before persisting soft-prompt acceptance');
@@ -178,10 +176,7 @@ const MFAMachine = setup({
                         },
                     },
                 },
-                // The soft-prompt screen: asks the user to consent to biometric verification before
-                // the flow continues. Entered only when the user has never accepted the prompt on
-                // this device; the registration vs reinstall variants arrive with the registration
-                // decision.
+                // Shows the soft prompt after device validation when the current account has not accepted it.
                 [MFA_STATE.PROMPT]: {
                     id: MFA_STATE.PROMPT,
                     entry: ['navigateToPrompt'],

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -64,18 +64,15 @@ type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScena
     payload: MultifactorAuthenticationScenarioParams<T> | undefined;
 };
 
-/** Carries the device-local soft-prompt flag read by the Onyx callback actor. */
-type SoftPromptAcceptanceReadEvent = {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ'; accepted: boolean};
-
 /**
  * Events accepted by the machine. INIT starts a flow and lifecycle events drive the modal.
  *
  * CLOSE_MODAL requests the close so the flow moves to `closing`. MODAL_CLOSED is the navigator's
  * notification that the close animation fully finished, which moves `closing` to `closed` and wipes
- * the context. Events with the `ACTOR_` prefix are sent internally by invoked actors, while
- * SOFT_PROMPT_APPROVED comes from the prompt screen's confirm button.
+ * the context. SOFT_PROMPT_APPROVED is sent by the prompt screen's confirm button and moves the flow
+ * past the soft prompt.
  */
-type MfaEvent = MultifactorAuthenticationInitEvent | SoftPromptAcceptanceReadEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'} | {type: 'SOFT_PROMPT_APPROVED'};
+type MfaEvent = MultifactorAuthenticationInitEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'} | {type: 'SOFT_PROMPT_APPROVED'};
 
 /** Describes the input the machine passes to the device-check actor. */
 type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationMethods};
@@ -83,4 +80,4 @@ type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationM
 /** Identifies the per-account Onyx member read by the soft-prompt actor. */
 type ReadHasAcceptedSoftPromptInput = {accountID: number};
 
-export type {MfaContext, MfaEvent, MfaModalState, MultifactorAuthenticationInitEvent, ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, ValidateDeviceInput};
+export type {MfaContext, MfaEvent, MfaModalState, MultifactorAuthenticationInitEvent, ReadHasAcceptedSoftPromptInput, ValidateDeviceInput};

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -29,6 +29,12 @@ type MfaContext = {
     /** Additional parameters for the current scenario */
     payload: MultifactorAuthenticationScenarioAdditionalParams<MultifactorAuthenticationScenario> | undefined;
 
+    /**
+     * Whether the user approved the soft prompt during this flow. The durable acceptance lives in
+     * Onyx under the device-biometrics key; this flag only tracks the current flow.
+     */
+    softPromptApproved: boolean;
+
     /** Whether the cancel-confirmation modal triggered by a back press is currently visible */
     isCancelConfirmVisible: boolean;
 };
@@ -59,9 +65,10 @@ type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScena
  *
  * CLOSE_MODAL requests the close so the flow moves to `closing`. MODAL_CLOSED is the navigator's
  * notification that the close animation fully finished, which moves `closing` to `closed` and wipes
- * the context.
+ * the context. SOFT_PROMPT_APPROVED is sent by the prompt screen's confirm button and moves the flow
+ * past the soft prompt.
  */
-type MfaEvent = MultifactorAuthenticationInitEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'};
+type MfaEvent = MultifactorAuthenticationInitEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'} | {type: 'SOFT_PROMPT_APPROVED'};
 
 /** Describes the input the machine passes to the device-check actor. */
 type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationMethods};

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -64,15 +64,18 @@ type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScena
     payload: MultifactorAuthenticationScenarioParams<T> | undefined;
 };
 
+/** Carries the device-local soft-prompt flag read by the Onyx callback actor. */
+type SoftPromptAcceptanceReadEvent = {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ'; accepted: boolean};
+
 /**
  * Events accepted by the machine. INIT starts a flow and lifecycle events drive the modal.
  *
  * CLOSE_MODAL requests the close so the flow moves to `closing`. MODAL_CLOSED is the navigator's
  * notification that the close animation fully finished, which moves `closing` to `closed` and wipes
- * the context. SOFT_PROMPT_APPROVED is sent by the prompt screen's confirm button and moves the flow
- * past the soft prompt.
+ * the context. Events with the `ACTOR_` prefix are sent internally by invoked actors, while
+ * SOFT_PROMPT_APPROVED comes from the prompt screen's confirm button.
  */
-type MfaEvent = MultifactorAuthenticationInitEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'} | {type: 'SOFT_PROMPT_APPROVED'};
+type MfaEvent = MultifactorAuthenticationInitEvent | SoftPromptAcceptanceReadEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'} | {type: 'SOFT_PROMPT_APPROVED'};
 
 /** Describes the input the machine passes to the device-check actor. */
 type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationMethods};
@@ -80,4 +83,4 @@ type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationM
 /** Identifies the per-account Onyx member read by the soft-prompt actor. */
 type ReadHasAcceptedSoftPromptInput = {accountID: number};
 
-export type {MfaContext, MfaEvent, MfaModalState, MultifactorAuthenticationInitEvent, ReadHasAcceptedSoftPromptInput, ValidateDeviceInput};
+export type {MfaContext, MfaEvent, MfaModalState, MultifactorAuthenticationInitEvent, ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, ValidateDeviceInput};

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -17,6 +17,9 @@ import type CONST from '@src/CONST';
  * a compile error.
  */
 type MfaContext = {
+    /** Account that owns the active flow and its device-local MFA state */
+    accountID: number | undefined;
+
     /** Current error state - stops the flow and navigates to the failure outcome */
     error: MFAError | undefined;
 
@@ -46,22 +49,23 @@ type MfaModalState =
     | typeof CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE.CLOSING;
 
 /**
- * The INIT event that starts a flow, with `scenarioName`, `scenario` config, and `payload` correlated
- * through `T`. `executeScenario` dispatches it with `T` fixed to the started scenario, so pairing a name
- * with another scenario's config or params is a compile error at the call site.
+ * The INIT event that starts a flow, with the owning `accountID`, `scenarioName`, `scenario` config,
+ * and `payload` correlated through `T`. `executeScenario` dispatches it with `T` fixed to the started
+ * scenario, so pairing a name with another scenario's config or params is a compile error at the call site.
  *
  * `T` defaults to the full scenario union so the non-specialized event (and {@link MfaEvent}) stays
  * usable as the actor's event type, where the running scenario is not known statically.
  */
 type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScenario = MultifactorAuthenticationScenario> = {
     type: 'INIT';
+    accountID: number;
     scenarioName: T;
     scenario: MultifactorAuthenticationScenarioConfigFor<T>;
     payload: MultifactorAuthenticationScenarioParams<T> | undefined;
 };
 
 /**
- * Events accepted by the machine. INIT starts a flow and the lifecycle events drive the modal.
+ * Events accepted by the machine. INIT starts a flow and lifecycle events drive the modal.
  *
  * CLOSE_MODAL requests the close so the flow moves to `closing`. MODAL_CLOSED is the navigator's
  * notification that the close animation fully finished, which moves `closing` to `closed` and wipes
@@ -73,4 +77,7 @@ type MfaEvent = MultifactorAuthenticationInitEvent | {type: 'CLOSE_MODAL'} | {ty
 /** Describes the input the machine passes to the device-check actor. */
 type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationMethods};
 
-export type {MfaContext, MfaEvent, MfaModalState, MultifactorAuthenticationInitEvent, ValidateDeviceInput};
+/** Identifies the per-account Onyx member read by the soft-prompt actor. */
+type ReadHasAcceptedSoftPromptInput = {accountID: number};
+
+export type {MfaContext, MfaEvent, MfaModalState, MultifactorAuthenticationInitEvent, ReadHasAcceptedSoftPromptInput, ValidateDeviceInput};

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -32,10 +32,7 @@ type MfaContext = {
     /** Additional parameters for the current scenario */
     payload: MultifactorAuthenticationScenarioAdditionalParams<MultifactorAuthenticationScenario> | undefined;
 
-    /**
-     * Whether the user approved the soft prompt during this flow. The durable acceptance lives in
-     * Onyx under the device-biometrics key; this flag only tracks the current flow.
-     */
+    /** Whether the user approved the soft prompt during this flow. The durable acceptance lives in Onyx under the device-biometrics key. */
     softPromptApproved: boolean;
 
     /** Whether the cancel-confirmation modal triggered by a back press is currently visible */

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -49,12 +49,8 @@ type MfaModalState =
     | typeof CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE.CLOSING;
 
 /**
- * The INIT event that starts a flow, with the owning `accountID`, `scenarioName`, `scenario` config,
- * and `payload` correlated through `T`. `executeScenario` dispatches it with `T` fixed to the started
- * scenario, so pairing a name with another scenario's config or params is a compile error at the call site.
- *
- * `T` defaults to the full scenario union so the non-specialized event (and {@link MfaEvent}) stays
- * usable as the actor's event type, where the running scenario is not known statically.
+ * `T` keeps the scenario name, config, and payload aligned.
+ * The default allows this event to be used as part of `MfaEvent`.
  */
 type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScenario = MultifactorAuthenticationScenario> = {
     type: 'INIT';
@@ -64,14 +60,7 @@ type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScena
     payload: MultifactorAuthenticationScenarioParams<T> | undefined;
 };
 
-/**
- * Events accepted by the machine. INIT starts a flow and lifecycle events drive the modal.
- *
- * CLOSE_MODAL requests the close so the flow moves to `closing`. MODAL_CLOSED is the navigator's
- * notification that the close animation fully finished, which moves `closing` to `closed` and wipes
- * the context. SOFT_PROMPT_APPROVED is sent by the prompt screen's confirm button and moves the flow
- * past the soft prompt.
- */
+/** Events handled by the MFA state machine. */
 type MfaEvent = MultifactorAuthenticationInitEvent | {type: 'CLOSE_MODAL'} | {type: 'MODAL_CLOSED'} | {type: 'SOFT_PROMPT_APPROVED'};
 
 /** Describes the input the machine passes to the device-check actor. */

--- a/src/components/MultifactorAuthentication/observability/trackMFAFlowOutcome.ts
+++ b/src/components/MultifactorAuthentication/observability/trackMFAFlowOutcome.ts
@@ -29,7 +29,6 @@ function classifyFailure(reason: MultifactorAuthenticationReason | undefined): F
 type CredentialsState = {
     hasServerCredentials: boolean;
     hasLocalCredentials: boolean;
-    hasEverAcceptedSoftPrompt: boolean;
 };
 
 type MFAFlowOutcomeContext = {

--- a/src/libs/MultifactorAuthentication/shared/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/shared/VALUES.ts
@@ -221,6 +221,7 @@ const MFA_STATE = {
     CLOSING: 'closing',
     PREPARING: 'preparing',
     VALIDATING_DEVICE: 'validatingDevice',
+    CHECKING_SOFT_PROMPT_ACCEPTANCE: 'checkingSoftPromptAcceptance',
     PROMPT: 'prompt',
     AWAITING_SOFT_PROMPT: 'awaitingSoftPrompt',
     OUTCOME: 'outcome',

--- a/src/libs/MultifactorAuthentication/shared/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/shared/VALUES.ts
@@ -221,6 +221,8 @@ const MFA_STATE = {
     CLOSING: 'closing',
     PREPARING: 'preparing',
     VALIDATING_DEVICE: 'validatingDevice',
+    PROMPT: 'prompt',
+    AWAITING_SOFT_PROMPT: 'awaitingSoftPrompt',
     OUTCOME: 'outcome',
     RESOLVING_OUTCOME: 'resolvingOutcome',
     SUCCESS: 'success',
@@ -319,6 +321,7 @@ const SHARED_VALUES = {
         MODAL_BACKDROP: 'MultifactorAuthenticationModalBackdrop',
         OUTCOME_SCREEN: 'MultifactorAuthenticationOutcomeScreen',
         OUTCOME_CONFIRM_BUTTON: 'MultifactorAuthenticationOutcomeConfirmButton',
+        PROMPT_CONFIRM_BUTTON: 'MultifactorAuthenticationPromptConfirmButton',
     },
 } as const;
 

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -10,10 +10,11 @@ import type {MultifactorAuthenticationReason} from '@libs/MultifactorAuthenticat
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {LocallyProcessed3DSChallengeReviews} from '@src/types/onyx';
+import type {DeviceBiometrics, LocallyProcessed3DSChallengeReviews} from '@src/types/onyx';
 
-import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
+import type {OnyxCollection, OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 
+import {hasAcceptedSoftPromptSelector} from '@selectors/DeviceBiometrics';
 // These functions use makeRequestWithSideEffects because challenge data must be returned immediately
 // for security and timing requirements (see detailed explanation below)
 import Onyx from 'react-native-onyx';
@@ -54,6 +55,33 @@ function cleanUpLocallyProcessed3DSTransactionReviews(entriesToDelete: string[])
         value[entry] = null;
     }
     Onyx.merge(ONYXKEYS.LOCALLY_PROCESSED_3DS_TRANSACTION_REVIEWS, value);
+}
+
+// Non-reactive session read so callers outside React (the MFA state machine's actions and guards)
+// can address per-account keys without threading accountID through their inputs.
+let currentUserAccountID: number = CONST.DEFAULT_NUMBER_ID;
+Onyx.connectWithoutView({
+    key: ONYXKEYS.SESSION,
+    callback: (session) => {
+        currentUserAccountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
+    },
+});
+
+// The device-biometrics key is per-account, so this subscribes to the whole collection and the
+// getter picks the current user's entry at decision time. A member-key subscription would go stale
+// when the session's account changes.
+let deviceBiometricsCollection: OnyxCollection<DeviceBiometrics>;
+Onyx.connectWithoutView({
+    key: ONYXKEYS.COLLECTION.DEVICE_BIOMETRICS,
+    waitForCollectionCallback: true,
+    callback: (collection) => {
+        deviceBiometricsCollection = collection;
+    },
+});
+
+/** Whether the current user has ever accepted the biometrics soft prompt on this device. */
+function hasEverAcceptedSoftPrompt(): boolean {
+    return hasAcceptedSoftPromptSelector(deviceBiometricsCollection?.[getDeviceBiometricsOnyxKey(currentUserAccountID)]) ?? false;
 }
 
 /**
@@ -431,8 +459,8 @@ function getDeviceBiometricsOnyxKey(accountID: number): `${typeof ONYXKEYS.COLLE
     return `${ONYXKEYS.COLLECTION.DEVICE_BIOMETRICS}${accountID}`;
 }
 
-function markHasAcceptedSoftPrompt(accountID: number) {
-    Onyx.merge(getDeviceBiometricsOnyxKey(accountID), {
+function markHasAcceptedSoftPrompt() {
+    Onyx.merge(getDeviceBiometricsOnyxKey(currentUserAccountID), {
         hasAcceptedSoftPrompt: true,
     });
 }
@@ -450,6 +478,7 @@ export {
     troubleshootMultifactorAuthentication,
     revokeMultifactorAuthenticationCredentials,
     getDeviceBiometricsOnyxKey,
+    hasEverAcceptedSoftPrompt,
     markHasAcceptedSoftPrompt,
     clearLocalMFAPublicKeyList,
     setPersonalDetailsAndShipExpensifyCardsWithPIN,

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -10,11 +10,10 @@ import type {MultifactorAuthenticationReason} from '@libs/MultifactorAuthenticat
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {DeviceBiometrics, LocallyProcessed3DSChallengeReviews} from '@src/types/onyx';
+import type {LocallyProcessed3DSChallengeReviews} from '@src/types/onyx';
 
-import type {OnyxCollection, OnyxEntry, OnyxUpdate} from 'react-native-onyx';
+import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 
-import {hasAcceptedSoftPromptSelector} from '@selectors/DeviceBiometrics';
 // These functions use makeRequestWithSideEffects because challenge data must be returned immediately
 // for security and timing requirements (see detailed explanation below)
 import Onyx from 'react-native-onyx';
@@ -55,33 +54,6 @@ function cleanUpLocallyProcessed3DSTransactionReviews(entriesToDelete: string[])
         value[entry] = null;
     }
     Onyx.merge(ONYXKEYS.LOCALLY_PROCESSED_3DS_TRANSACTION_REVIEWS, value);
-}
-
-// Non-reactive session read so callers outside React (the MFA state machine's actions and guards)
-// can address per-account keys without threading accountID through their inputs.
-let currentUserAccountID: number = CONST.DEFAULT_NUMBER_ID;
-Onyx.connectWithoutView({
-    key: ONYXKEYS.SESSION,
-    callback: (session) => {
-        currentUserAccountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
-    },
-});
-
-// The device-biometrics key is per-account, so this subscribes to the whole collection and the
-// getter picks the current user's entry at decision time. A member-key subscription would go stale
-// when the session's account changes.
-let deviceBiometricsCollection: OnyxCollection<DeviceBiometrics>;
-Onyx.connectWithoutView({
-    key: ONYXKEYS.COLLECTION.DEVICE_BIOMETRICS,
-    waitForCollectionCallback: true,
-    callback: (collection) => {
-        deviceBiometricsCollection = collection;
-    },
-});
-
-/** Whether the current user has ever accepted the biometrics soft prompt on this device. */
-function hasEverAcceptedSoftPrompt(): boolean {
-    return hasAcceptedSoftPromptSelector(deviceBiometricsCollection?.[getDeviceBiometricsOnyxKey(currentUserAccountID)]) ?? false;
 }
 
 /**
@@ -459,8 +431,8 @@ function getDeviceBiometricsOnyxKey(accountID: number): `${typeof ONYXKEYS.COLLE
     return `${ONYXKEYS.COLLECTION.DEVICE_BIOMETRICS}${accountID}`;
 }
 
-function markHasAcceptedSoftPrompt() {
-    Onyx.merge(getDeviceBiometricsOnyxKey(currentUserAccountID), {
+function markHasAcceptedSoftPrompt(accountID: number) {
+    Onyx.merge(getDeviceBiometricsOnyxKey(accountID), {
         hasAcceptedSoftPrompt: true,
     });
 }
@@ -478,7 +450,6 @@ export {
     troubleshootMultifactorAuthentication,
     revokeMultifactorAuthenticationCredentials,
     getDeviceBiometricsOnyxKey,
-    hasEverAcceptedSoftPrompt,
     markHasAcceptedSoftPrompt,
     clearLocalMFAPublicKeyList,
     setPersonalDetailsAndShipExpensifyCardsWithPIN,

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -2,45 +2,39 @@ import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOffli
 import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import LoadingIndicator from '@components/LoadingIndicator';
-import {useMultifactorAuthenticationActions, usePromptContent} from '@components/MultifactorAuthentication/Context';
+import {MULTIFACTOR_AUTHENTICATION_PROMPT_UI} from '@components/MultifactorAuthentication/config';
 import {useMultifactorAuthenticationInternal} from '@components/MultifactorAuthentication/Context/MultifactorAuthenticationInternalApiContext';
 import MultifactorAuthenticationPromptContent from '@components/MultifactorAuthentication/PromptContent';
 import useMFACancelOnEscape from '@components/MultifactorAuthentication/useMFACancelOnEscape';
 import ScreenWrapper from '@components/ScreenWrapper';
 
-import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 
-import {markHasAcceptedSoftPrompt} from '@libs/actions/MultifactorAuthentication';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {MultifactorAuthenticationModalNavigatorParamList} from '@libs/Navigation/types';
 
-import variables from '@styles/variables';
-
+import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
 
 import React from 'react';
-import {View} from 'react-native';
 
 type MultifactorAuthenticationPromptPageProps = PlatformStackScreenProps<MultifactorAuthenticationModalNavigatorParamList, typeof SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT>;
 
+/**
+ * The soft-prompt screen. The machine routes here only when the user has never accepted the soft
+ * prompt on this device, so the content is the static copy for the platform's prompt type and the
+ * confirm button is always available. The registration and authorization prompt variants arrive with
+ * their own slices.
+ */
 function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationPromptPageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
-    const {requestCancel, state} = useMultifactorAuthenticationInternal();
-    const {dispatch} = useMultifactorAuthenticationActions();
+    const {requestCancel, approveSoftPrompt, state} = useMultifactorAuthenticationInternal();
     const {isCancelConfirmVisible} = state;
-    const {accountID} = useCurrentUserPersonalDetails();
 
-    const {illustration, title, subtitle, shouldDisplayConfirmButton} = usePromptContent(route.params.promptType);
+    const {illustration, title, subtitle} = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[route.params.promptType];
     const interceptFocusTrapEscape = useMFACancelOnEscape();
-
-    const onConfirm = () => {
-        markHasAcceptedSoftPrompt(accountID);
-        dispatch({type: 'SET_SOFT_PROMPT_APPROVED', payload: true});
-    };
 
     return (
         <ScreenWrapper
@@ -66,18 +60,13 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
                     subtitle={subtitle}
                 />
                 <FixedFooter style={[styles.flexColumn, styles.gap3]}>
-                    {shouldDisplayConfirmButton ? (
-                        <Button
-                            success
-                            large
-                            onPress={onConfirm}
-                            text={translate('common.buttonConfirm')}
-                        />
-                    ) : (
-                        <View style={[styles.w100, styles.justifyContentCenter, {height: variables.componentSizeLarge}]}>
-                            <LoadingIndicator iconSize={28} />
-                        </View>
-                    )}
+                    <Button
+                        success
+                        large
+                        onPress={approveSoftPrompt}
+                        text={translate('common.buttonConfirm')}
+                        testID={CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID.PROMPT_CONFIRM_BUTTON}
+                    />
                 </FixedFooter>
             </FullPageOfflineBlockingView>
         </ScreenWrapper>

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -22,10 +22,8 @@ import React from 'react';
 type MultifactorAuthenticationPromptPageProps = PlatformStackScreenProps<MultifactorAuthenticationModalNavigatorParamList, typeof SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT>;
 
 /**
- * The soft-prompt screen. The machine routes here only when the user has never accepted the soft
- * prompt on this device, so the content is the static copy for the platform's prompt type and the
- * confirm button is always available. The registration and authorization prompt variants arrive with
- * their own slices.
+ * The machine routes here only when the account has not accepted the soft prompt on this device,
+ * so the copy is static and the confirm button is always available.
  */
 function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationPromptPageProps) {
     const {translate} = useLocalize();

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -149,12 +149,15 @@ const testConfig = {
             expect(state.context.accountID).toBeDefined();
             expect(state.context.error).toBeUndefined();
         },
-        // The screen copy is not asserted because it depends on the platform the operations module resolves to under jest.
+        // The biometrics copy is expected because the jest-expo haste config resolves the operations
+        // module to its native variant, which verifies with HSM-backed biometrics.
         [`${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.AWAITING_SOFT_PROMPT}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
             expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
             expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeOnTheScreen();
+            expect(screen.getByText(translateLocal('multifactorAuthentication.verifyYourself.biometrics'))).toBeOnTheScreen();
+            expect(screen.getByText(translateLocal('multifactorAuthentication.enableQuickVerification.biometrics'))).toBeOnTheScreen();
             expect(state.context.error).toBeUndefined();
             expect(state.context.softPromptApproved).toBe(false);
         },

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -15,6 +15,7 @@ import type {SnapshotFrom} from 'xstate';
 import Onyx from 'react-native-onyx';
 import getWalkedPaths, {
     isAutoDrivenEvent,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
     READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE,
     VALIDATE_DEVICE_DONE_EVENT_TYPE,
     VALIDATE_DEVICE_ERROR_EVENT_TYPE,
@@ -60,7 +61,6 @@ const TEST_ID = CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID;
 type MfaEventType = MfaEvent['type'];
 
 type MfaInitEvent = Extract<MfaEvent, {type: 'INIT'}>;
-type SoftPromptAcceptanceReadEvent = Extract<MfaEvent, {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ'}>;
 type MfaEventExecutorStep<Type extends MfaEventType> = {event: {type: Type}};
 type MfaEventExecutors = {
     [Type in MfaEventType]: (step: MfaEventExecutorStep<Type>) => Promise<void>;
@@ -68,6 +68,7 @@ type MfaEventExecutors = {
 type MfaActorEventExecutors = {
     [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step: {event: {type: typeof VALIDATE_DEVICE_DONE_EVENT_TYPE; output: MFAResult}}) => Promise<void>;
     [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => Promise<void>;
+    [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step: {event: {type: typeof READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE; output: boolean}}) => Promise<void>;
     [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => Promise<void>;
 };
 
@@ -75,10 +76,6 @@ type ExecuteScenario = ReturnType<typeof renderMfaUi>['executeScenario'];
 
 function isMfaInitEvent(event: {type: string}): event is MfaInitEvent {
     return event.type === 'INIT' && 'accountID' in event && 'scenarioName' in event && 'scenario' in event && 'payload' in event;
-}
-
-function isSoftPromptAcceptanceReadEvent(event: {type: string}): event is SoftPromptAcceptanceReadEvent {
-    return event.type === 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ' && 'accepted' in event;
 }
 
 /**
@@ -121,19 +118,13 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
             act(() => pendingModalClose.run());
             await waitForBatchedUpdatesWithAct();
         },
-        ACTOR_SOFT_PROMPT_ACCEPTANCE_READ: (step) => {
-            if (!isSoftPromptAcceptanceReadEvent(step.event)) {
-                throw new Error('Soft-prompt acceptance executor received a path event without the accepted fixture value.');
-            }
-            const {accepted} = step.event;
-            return settleActor(() => resolveSoftPromptAcceptance(accepted));
-        },
         SOFT_PROMPT_APPROVED: async () => {
             fireEvent.press(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON));
             await waitForBatchedUpdatesWithAct();
         },
         [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveValidateDevice(step.event.output)),
         [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleActor(rejectValidateDevice),
+        [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveSoftPromptAcceptance(step.event.output)),
         [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => settleActor(rejectSoftPromptAcceptanceRead),
     } satisfies MfaEventExecutors & MfaActorEventExecutors;
 }

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -15,7 +15,6 @@ import type {SnapshotFrom} from 'xstate';
 import Onyx from 'react-native-onyx';
 import getWalkedPaths, {
     isAutoDrivenEvent,
-    READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
     READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE,
     VALIDATE_DEVICE_DONE_EVENT_TYPE,
     VALIDATE_DEVICE_ERROR_EVENT_TYPE,
@@ -61,6 +60,7 @@ const TEST_ID = CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID;
 type MfaEventType = MfaEvent['type'];
 
 type MfaInitEvent = Extract<MfaEvent, {type: 'INIT'}>;
+type SoftPromptAcceptanceReadEvent = Extract<MfaEvent, {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ'}>;
 type MfaEventExecutorStep<Type extends MfaEventType> = {event: {type: Type}};
 type MfaEventExecutors = {
     [Type in MfaEventType]: (step: MfaEventExecutorStep<Type>) => Promise<void>;
@@ -68,7 +68,6 @@ type MfaEventExecutors = {
 type MfaActorEventExecutors = {
     [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step: {event: {type: typeof VALIDATE_DEVICE_DONE_EVENT_TYPE; output: MFAResult}}) => Promise<void>;
     [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => Promise<void>;
-    [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step: {event: {type: typeof READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE; output: boolean}}) => Promise<void>;
     [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => Promise<void>;
 };
 
@@ -76,6 +75,10 @@ type ExecuteScenario = ReturnType<typeof renderMfaUi>['executeScenario'];
 
 function isMfaInitEvent(event: {type: string}): event is MfaInitEvent {
     return event.type === 'INIT' && 'accountID' in event && 'scenarioName' in event && 'scenario' in event && 'payload' in event;
+}
+
+function isSoftPromptAcceptanceReadEvent(event: {type: string}): event is SoftPromptAcceptanceReadEvent {
+    return event.type === 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ' && 'accepted' in event;
 }
 
 /**
@@ -118,13 +121,19 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
             act(() => pendingModalClose.run());
             await waitForBatchedUpdatesWithAct();
         },
+        ACTOR_SOFT_PROMPT_ACCEPTANCE_READ: (step) => {
+            if (!isSoftPromptAcceptanceReadEvent(step.event)) {
+                throw new Error('Soft-prompt acceptance executor received a path event without the accepted fixture value.');
+            }
+            const {accepted} = step.event;
+            return settleActor(() => resolveSoftPromptAcceptance(accepted));
+        },
         SOFT_PROMPT_APPROVED: async () => {
             fireEvent.press(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON));
             await waitForBatchedUpdatesWithAct();
         },
         [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveValidateDevice(step.event.output)),
         [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleActor(rejectValidateDevice),
-        [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveSoftPromptAcceptance(step.event.output)),
         [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => settleActor(rejectSoftPromptAcceptanceRead),
     } satisfies MfaEventExecutors & MfaActorEventExecutors;
 }

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -12,6 +12,7 @@ import SCREENS from '@src/SCREENS';
 import type * as MfaRealUiMocks from 'tests/utils/mfa/realUi/mocks';
 import type {SnapshotFrom} from 'xstate';
 
+import Onyx from 'react-native-onyx';
 import getWalkedPaths, {isAutoDrivenEvent, VALIDATE_DEVICE_DONE_EVENT_TYPE, VALIDATE_DEVICE_ERROR_EVENT_TYPE} from 'tests/utils/mfa/flowPaths';
 import {getSettleableLeafStates} from 'tests/utils/mfa/leafStates';
 import renderMfaUi from 'tests/utils/mfa/realUi/harness';
@@ -109,6 +110,10 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
             act(() => pendingModalClose.run());
             await waitForBatchedUpdatesWithAct();
         },
+        SOFT_PROMPT_APPROVED: async () => {
+            fireEvent.press(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON));
+            await waitForBatchedUpdatesWithAct();
+        },
         [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleValidateDevice(() => resolveValidateDevice(step.event.output)),
         [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleValidateDevice(rejectValidateDevice),
     } satisfies MfaEventExecutors & ValidateDeviceActorEventExecutors;
@@ -126,6 +131,16 @@ const testConfig = {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.INITIAL_SCREEN)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
+        },
+        // The confirm button and the route are the screen's stable markers. The copy is not asserted
+        // because it depends on the platform the operations module resolves to under jest.
+        [`${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.AWAITING_SOFT_PROMPT}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
+            expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
+            expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
+            expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
+            expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeOnTheScreen();
+            expect(state.context.error).toBeUndefined();
+            expect(state.context.softPromptApproved).toBe(false);
         },
         [`${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
@@ -180,9 +195,14 @@ const walkedPathTestCases = walkedPaths.map((path) => ({
 describe('the real MFA modal matches the machine at every step of every generated path', () => {
     // The navigation buffer is deliberately not reset here. The machine resets it when it enters
     // `closed`, which also runs when each test's fresh actor starts, so a reset here would hide a
-    // machine that stopped doing that cleanup.
-    beforeEach(() => {
+    // machine that stopped doing that cleanup. Onyx is cleared because approving the soft prompt
+    // persists the acceptance, and no path may depend on what an earlier path stored.
+    beforeEach(async () => {
         resetMfaUiMocks();
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
     });
 
     afterEach(() => {

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -22,7 +22,7 @@ import getWalkedPaths, {
 } from 'tests/utils/mfa/flowPaths';
 import {getSettleableLeafStates} from 'tests/utils/mfa/leafStates';
 import renderMfaUi from 'tests/utils/mfa/realUi/harness';
-import {pendingModalClose, rejectSoftPromptAcceptanceRead, rejectValidateDevice, resetMfaUiMocks, resolveSoftPromptAcceptance, resolveValidateDevice} from 'tests/utils/mfa/realUi/mocks';
+import {pendingModalClose, readHasAcceptedSoftPromptControl, resetMfaUiMocks, validateDeviceControl} from 'tests/utils/mfa/realUi/mocks';
 import {translateLocal} from 'tests/utils/TestHelper';
 import waitForBatchedUpdatesWithAct from 'tests/utils/waitForBatchedUpdatesWithAct';
 import {matchesState} from 'xstate';
@@ -122,10 +122,10 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
             fireEvent.press(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON));
             await waitForBatchedUpdatesWithAct();
         },
-        [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveValidateDevice(step.event.output)),
-        [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleActor(rejectValidateDevice),
-        [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveSoftPromptAcceptance(step.event.output)),
-        [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => settleActor(rejectSoftPromptAcceptanceRead),
+        [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleActor(() => validateDeviceControl.resolve(step.event.output)),
+        [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleActor(validateDeviceControl.reject),
+        [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step) => settleActor(() => readHasAcceptedSoftPromptControl.resolve(step.event.output)),
+        [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => settleActor(readHasAcceptedSoftPromptControl.reject),
     } satisfies MfaEventExecutors & MfaActorEventExecutors;
 }
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -149,8 +149,7 @@ const testConfig = {
             expect(state.context.accountID).toBeDefined();
             expect(state.context.error).toBeUndefined();
         },
-        // The confirm button and the route are the screen's stable markers. The copy is not asserted
-        // because it depends on the platform the operations module resolves to under jest.
+        // The screen copy is not asserted because it depends on the platform the operations module resolves to under jest.
         [`${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.AWAITING_SOFT_PROMPT}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -7,12 +7,14 @@ import {mfaNavigationRef} from '@components/MultifactorAuthentication/mfaNavigat
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
 
 import type * as MfaRealUiMocks from 'tests/utils/mfa/realUi/mocks';
 import type {SnapshotFrom} from 'xstate';
 
 import Onyx from 'react-native-onyx';
+import {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
 import getWalkedPaths, {
     isAutoDrivenEvent,
     READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
@@ -215,11 +217,14 @@ describe('the real MFA modal matches the machine at every step of every generate
     // The navigation buffer is deliberately not reset here. The machine resets it when it enters
     // `closed`, which also runs when each test's fresh actor starts, so a reset here would hide a
     // machine that stopped doing that cleanup. Onyx is cleared because approving the soft prompt
-    // persists the acceptance, and no path may depend on what an earlier path stored.
+    // persists the acceptance, and no path may depend on what an earlier path stored. The session
+    // account is then seeded because the MFA context rejects a flow start while the account is
+    // still the hydration placeholder.
     beforeEach(async () => {
         resetMfaUiMocks();
         await act(async () => {
             await Onyx.clear();
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: MFA_TEST_ACCOUNT_ID});
         });
         await waitForBatchedUpdatesWithAct();
     });

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -13,10 +13,16 @@ import type * as MfaRealUiMocks from 'tests/utils/mfa/realUi/mocks';
 import type {SnapshotFrom} from 'xstate';
 
 import Onyx from 'react-native-onyx';
-import getWalkedPaths, {isAutoDrivenEvent, VALIDATE_DEVICE_DONE_EVENT_TYPE, VALIDATE_DEVICE_ERROR_EVENT_TYPE} from 'tests/utils/mfa/flowPaths';
+import getWalkedPaths, {
+    isAutoDrivenEvent,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE,
+    VALIDATE_DEVICE_DONE_EVENT_TYPE,
+    VALIDATE_DEVICE_ERROR_EVENT_TYPE,
+} from 'tests/utils/mfa/flowPaths';
 import {getSettleableLeafStates} from 'tests/utils/mfa/leafStates';
 import renderMfaUi from 'tests/utils/mfa/realUi/harness';
-import {pendingModalClose, rejectValidateDevice, resetMfaUiMocks, resolveValidateDevice} from 'tests/utils/mfa/realUi/mocks';
+import {pendingModalClose, rejectSoftPromptAcceptanceRead, rejectValidateDevice, resetMfaUiMocks, resolveSoftPromptAcceptance, resolveValidateDevice} from 'tests/utils/mfa/realUi/mocks';
 import {translateLocal} from 'tests/utils/TestHelper';
 import waitForBatchedUpdatesWithAct from 'tests/utils/waitForBatchedUpdatesWithAct';
 import {matchesState} from 'xstate';
@@ -59,15 +65,17 @@ type MfaEventExecutorStep<Type extends MfaEventType> = {event: {type: Type}};
 type MfaEventExecutors = {
     [Type in MfaEventType]: (step: MfaEventExecutorStep<Type>) => Promise<void>;
 };
-type ValidateDeviceActorEventExecutors = {
+type MfaActorEventExecutors = {
     [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step: {event: {type: typeof VALIDATE_DEVICE_DONE_EVENT_TYPE; output: MFAResult}}) => Promise<void>;
     [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => Promise<void>;
+    [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step: {event: {type: typeof READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE; output: boolean}}) => Promise<void>;
+    [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => Promise<void>;
 };
 
 type ExecuteScenario = ReturnType<typeof renderMfaUi>['executeScenario'];
 
 function isMfaInitEvent(event: {type: string}): event is MfaInitEvent {
-    return event.type === 'INIT' && 'scenarioName' in event && 'scenario' in event && 'payload' in event;
+    return event.type === 'INIT' && 'accountID' in event && 'scenarioName' in event && 'scenario' in event && 'payload' in event;
 }
 
 /**
@@ -78,7 +86,7 @@ function isMfaInitEvent(event: {type: string}): event is MfaInitEvent {
  */
 /* eslint-disable @typescript-eslint/naming-convention -- keys mirror the machine's event type union. */
 function createMfaEventExecutors(executeScenario: ExecuteScenario) {
-    const settleValidateDevice = async (settle: () => void) => {
+    const settleActor = async (settle: () => void) => {
         await act(async () => settle());
     };
 
@@ -114,9 +122,11 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
             fireEvent.press(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON));
             await waitForBatchedUpdatesWithAct();
         },
-        [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleValidateDevice(() => resolveValidateDevice(step.event.output)),
-        [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleValidateDevice(rejectValidateDevice),
-    } satisfies MfaEventExecutors & ValidateDeviceActorEventExecutors;
+        [VALIDATE_DEVICE_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveValidateDevice(step.event.output)),
+        [VALIDATE_DEVICE_ERROR_EVENT_TYPE]: () => settleActor(rejectValidateDevice),
+        [READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE]: (step) => settleActor(() => resolveSoftPromptAcceptance(step.event.output)),
+        [READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE]: () => settleActor(rejectSoftPromptAcceptanceRead),
+    } satisfies MfaEventExecutors & MfaActorEventExecutors;
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -131,6 +141,13 @@ const testConfig = {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.INITIAL_SCREEN)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
+        },
+        [`${MFA_STATE.OPEN}.${MFA_STATE.PREPARING}.${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
+            expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
+            expect(screen.queryAllByTestId(TEST_ID.INITIAL_SCREEN)).toHaveLength(1);
+            expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
+            expect(state.context.accountID).toBeDefined();
+            expect(state.context.error).toBeUndefined();
         },
         // The confirm button and the route are the screen's stable markers. The copy is not asserted
         // because it depends on the platform the operations module resolves to under jest.

--- a/tests/unit/components/MultifactorAuthentication/machine/outcomeGuard.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/outcomeGuard.test.ts
@@ -1,37 +1,18 @@
-import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
-import type {MfaEvent} from '@components/MultifactorAuthentication/machine/types';
-
 import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
 
-import createInitEvent from 'tests/utils/mfa/flowFixtures';
-import {VALIDATE_DEVICE_DONE_EVENT_TYPE} from 'tests/utils/mfa/flowPaths';
-import {createActor} from 'xstate';
+import {createActorAtState, sendValidateDeviceDone} from 'tests/utils/mfa/flowActors';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
 describe('MFA outcome guard', () => {
     it('routes a successful actor result to failure when the context already contains an error', () => {
-        const initEvent = createInitEvent();
         const existingError = createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION, 'Existing flow error');
-        const validatingDeviceSnapshot = mfaMachine.resolveState({
-            value: {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}},
-            context: {
-                error: existingError,
-                scenarioName: initEvent.scenarioName,
-                scenario: initEvent.scenario,
-                payload: initEvent.payload,
-                softPromptApproved: false,
-                isCancelConfirmVisible: false,
-            },
-        });
-        const actor = createActor(mfaMachine, {snapshot: validatingDeviceSnapshot});
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}}, {error: existingError});
 
         actor.start();
-        // Framework actor events are not part of the application's MfaEvent union.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        actor.send({type: VALIDATE_DEVICE_DONE_EVENT_TYPE, output: {success: true}} as unknown as MfaEvent);
+        sendValidateDeviceDone(actor, {success: true});
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);

--- a/tests/unit/components/MultifactorAuthentication/machine/outcomeGuard.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/outcomeGuard.test.ts
@@ -22,6 +22,7 @@ describe('MFA outcome guard', () => {
                 scenarioName: initEvent.scenarioName,
                 scenario: initEvent.scenario,
                 payload: initEvent.payload,
+                softPromptApproved: false,
                 isCancelConfirmVisible: false,
             },
         });

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -1,0 +1,124 @@
+import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
+import type {MfaContext, MfaEvent} from '@components/MultifactorAuthentication/machine/types';
+
+import {getDeviceBiometricsOnyxKey} from '@libs/actions/MultifactorAuthentication';
+
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+import Onyx from 'react-native-onyx';
+import getOnyxValue from 'tests/utils/getOnyxValue';
+import createInitEvent from 'tests/utils/mfa/flowFixtures';
+import {VALIDATE_DEVICE_DONE_EVENT_TYPE} from 'tests/utils/mfa/flowPaths';
+import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
+import {createActor} from 'xstate';
+
+const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
+const TEST_ACCOUNT_ID = 12345;
+
+// The graph-traversal suites generate their expectations from the machine, so a transition pointed at
+// a wrong target adjusts those expectations and still passes. This suite pins the soft-prompt hops by
+// hand: eligible device -> soft prompt, and approval -> success outcome plus the persisted acceptance.
+
+function createCleanContext(): MfaContext {
+    const initEvent = createInitEvent();
+    return {
+        error: undefined,
+        scenarioName: initEvent.scenarioName,
+        scenario: initEvent.scenario,
+        payload: initEvent.payload,
+        softPromptApproved: false,
+        isCancelConfirmVisible: false,
+    };
+}
+
+function createAwaitingSoftPromptActor() {
+    const awaitingSoftPromptSnapshot = mfaMachine.resolveState({
+        value: {[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}},
+        context: createCleanContext(),
+    });
+    return createActor(mfaMachine, {snapshot: awaitingSoftPromptSnapshot});
+}
+
+function createValidatingDeviceActor() {
+    const validatingDeviceSnapshot = mfaMachine.resolveState({
+        value: {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}},
+        context: createCleanContext(),
+    });
+    return createActor(mfaMachine, {snapshot: validatingDeviceSnapshot});
+}
+
+function settleEligibleDevice(actor: ReturnType<typeof createValidatingDeviceActor>) {
+    // Framework actor events are not part of the application's MfaEvent union.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    actor.send({type: VALIDATE_DEVICE_DONE_EVENT_TYPE, output: {success: true}} as unknown as MfaEvent);
+}
+
+describe('MFA soft prompt', () => {
+    afterEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('moves an eligible device to the soft prompt without approving it', () => {
+        const actor = createValidatingDeviceActor();
+
+        actor.start();
+        settleEligibleDevice(actor);
+
+        const result = actor.getSnapshot();
+        expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
+        expect(result.context.softPromptApproved).toBe(false);
+
+        actor.stop();
+    });
+
+    it('skips the soft prompt when the user has already accepted it on this device', async () => {
+        // The skip guard resolves the acceptance through non-reactive Onyx reads, so both the
+        // session and the device-biometrics entry must settle before the device check completes.
+        await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
+        await Onyx.merge(getDeviceBiometricsOnyxKey(TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: true});
+        await waitForBatchedUpdates();
+        const actor = createValidatingDeviceActor();
+
+        actor.start();
+        settleEligibleDevice(actor);
+
+        const result = actor.getSnapshot();
+        expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
+        // The context flag tracks an approval given during this flow, so a skip leaves it false.
+        expect(result.context.softPromptApproved).toBe(false);
+
+        actor.stop();
+    });
+
+    it('reaches the success outcome when the user approves the soft prompt', () => {
+        const actor = createAwaitingSoftPromptActor();
+
+        actor.start();
+        actor.send({type: 'SOFT_PROMPT_APPROVED'});
+
+        const result = actor.getSnapshot();
+        expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
+        expect(result.context.softPromptApproved).toBe(true);
+
+        actor.stop();
+    });
+
+    it('persists the acceptance for the current user when the soft prompt is approved', async () => {
+        // The machine's persist action resolves the account through a non-reactive session read, so
+        // the session must settle before the event fires.
+        await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
+        await waitForBatchedUpdates();
+        const actor = createAwaitingSoftPromptActor();
+
+        actor.start();
+        actor.send({type: 'SOFT_PROMPT_APPROVED'});
+        await waitForBatchedUpdates();
+
+        const deviceBiometrics = await getOnyxValue(getDeviceBiometricsOnyxKey(TEST_ACCOUNT_ID));
+        expect(deviceBiometrics?.hasAcceptedSoftPrompt).toBe(true);
+
+        actor.stop();
+    });
+});

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -1,6 +1,3 @@
-import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
-import type {MfaContext, MfaEvent} from '@components/MultifactorAuthentication/machine/types';
-
 import {getDeviceBiometricsOnyxKey} from '@libs/actions/MultifactorAuthentication';
 
 import CONST from '@src/CONST';
@@ -8,10 +5,8 @@ import ONYXKEYS from '@src/ONYXKEYS';
 
 import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
-import createInitEvent from 'tests/utils/mfa/flowFixtures';
-import {VALIDATE_DEVICE_DONE_EVENT_TYPE} from 'tests/utils/mfa/flowPaths';
+import {createActorAtState, sendValidateDeviceDone} from 'tests/utils/mfa/flowActors';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
-import {createActor} from 'xstate';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 const TEST_ACCOUNT_ID = 12345;
@@ -20,40 +15,6 @@ const TEST_ACCOUNT_ID = 12345;
 // a wrong target adjusts those expectations and still passes. This suite pins the soft-prompt hops by
 // hand: eligible device -> soft prompt, and approval -> success outcome plus the persisted acceptance.
 
-function createCleanContext(): MfaContext {
-    const initEvent = createInitEvent();
-    return {
-        error: undefined,
-        scenarioName: initEvent.scenarioName,
-        scenario: initEvent.scenario,
-        payload: initEvent.payload,
-        softPromptApproved: false,
-        isCancelConfirmVisible: false,
-    };
-}
-
-function createAwaitingSoftPromptActor() {
-    const awaitingSoftPromptSnapshot = mfaMachine.resolveState({
-        value: {[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}},
-        context: createCleanContext(),
-    });
-    return createActor(mfaMachine, {snapshot: awaitingSoftPromptSnapshot});
-}
-
-function createValidatingDeviceActor() {
-    const validatingDeviceSnapshot = mfaMachine.resolveState({
-        value: {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}},
-        context: createCleanContext(),
-    });
-    return createActor(mfaMachine, {snapshot: validatingDeviceSnapshot});
-}
-
-function settleEligibleDevice(actor: ReturnType<typeof createValidatingDeviceActor>) {
-    // Framework actor events are not part of the application's MfaEvent union.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    actor.send({type: VALIDATE_DEVICE_DONE_EVENT_TYPE, output: {success: true}} as unknown as MfaEvent);
-}
-
 describe('MFA soft prompt', () => {
     afterEach(async () => {
         await Onyx.clear();
@@ -61,10 +22,10 @@ describe('MFA soft prompt', () => {
     });
 
     it('moves an eligible device to the soft prompt without approving it', () => {
-        const actor = createValidatingDeviceActor();
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}});
 
         actor.start();
-        settleEligibleDevice(actor);
+        sendValidateDeviceDone(actor, {success: true});
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
@@ -79,10 +40,10 @@ describe('MFA soft prompt', () => {
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
         await Onyx.merge(getDeviceBiometricsOnyxKey(TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: true});
         await waitForBatchedUpdates();
-        const actor = createValidatingDeviceActor();
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}});
 
         actor.start();
-        settleEligibleDevice(actor);
+        sendValidateDeviceDone(actor, {success: true});
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
@@ -93,7 +54,7 @@ describe('MFA soft prompt', () => {
     });
 
     it('reaches the success outcome when the user approves the soft prompt', () => {
-        const actor = createAwaitingSoftPromptActor();
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}});
 
         actor.start();
         actor.send({type: 'SOFT_PROMPT_APPROVED'});
@@ -110,7 +71,7 @@ describe('MFA soft prompt', () => {
         // the session must settle before the event fires.
         await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
         await waitForBatchedUpdates();
-        const actor = createAwaitingSoftPromptActor();
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}});
 
         actor.start();
         actor.send({type: 'SOFT_PROMPT_APPROVED'});

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -1,15 +1,19 @@
+import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
+import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
+
 import {getDeviceBiometricsOnyxKey} from '@libs/actions/MultifactorAuthentication';
+import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
 
 import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
 import {createActorAtState, sendValidateDeviceDone} from 'tests/utils/mfa/flowActors';
+import createInitEvent, {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
+import {createActor, fromPromise} from 'xstate';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
-const TEST_ACCOUNT_ID = 12345;
 
 // The graph-traversal suites generate their expectations from the machine, so a transition pointed at
 // a wrong target adjusts those expectations and still passes. This suite pins the soft-prompt hops by
@@ -21,11 +25,12 @@ describe('MFA soft prompt', () => {
         await waitForBatchedUpdates();
     });
 
-    it('moves an eligible device to the soft prompt without approving it', () => {
+    it('moves an eligible device to the soft prompt when the current account has not accepted it', async () => {
         const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}});
 
         actor.start();
         sendValidateDeviceDone(actor, {success: true});
+        await waitForBatchedUpdates();
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
@@ -35,20 +40,38 @@ describe('MFA soft prompt', () => {
     });
 
     it('skips the soft prompt when the user has already accepted it on this device', async () => {
-        // The skip guard resolves the acceptance through non-reactive Onyx reads, so both the
-        // session and the device-biometrics entry must settle before the device check completes.
-        await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
-        await Onyx.merge(getDeviceBiometricsOnyxKey(TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: true});
-        await waitForBatchedUpdates();
+        await Onyx.merge(getDeviceBiometricsOnyxKey(MFA_TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: true});
         const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}});
 
         actor.start();
         sendValidateDeviceDone(actor, {success: true});
+        await waitForBatchedUpdates();
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
         // The context flag tracks an approval given during this flow, so a skip leaves it false.
         expect(result.context.softPromptApproved).toBe(false);
+
+        actor.stop();
+    });
+
+    it('ends the current flow with an error when reading the soft-prompt flag rejects', async () => {
+        const machine = mfaMachine.provide({
+            actors: {
+                validateDevice: fromPromise<MFAResult, ValidateDeviceInput>(() => Promise.resolve({success: true})),
+                readHasAcceptedSoftPrompt: fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(() => Promise.reject(new Error('Onyx read failed'))),
+            },
+        });
+        const actor = createActor(machine);
+
+        actor.start();
+        actor.send(createInitEvent());
+        await waitForBatchedUpdates();
+
+        const result = actor.getSnapshot();
+        expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
+        expect(result.context.error?.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION);
+        expect(result.context.error?.message).toContain('Soft-prompt acceptance read threw: Onyx read failed');
 
         actor.stop();
     });
@@ -67,17 +90,13 @@ describe('MFA soft prompt', () => {
     });
 
     it('persists the acceptance for the current user when the soft prompt is approved', async () => {
-        // The machine's persist action resolves the account through a non-reactive session read, so
-        // the session must settle before the event fires.
-        await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
-        await waitForBatchedUpdates();
         const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}});
 
         actor.start();
         actor.send({type: 'SOFT_PROMPT_APPROVED'});
         await waitForBatchedUpdates();
 
-        const deviceBiometrics = await getOnyxValue(getDeviceBiometricsOnyxKey(TEST_ACCOUNT_ID));
+        const deviceBiometrics = await getOnyxValue(getDeviceBiometricsOnyxKey(MFA_TEST_ACCOUNT_ID));
         expect(deviceBiometrics?.hasAcceptedSoftPrompt).toBe(true);
 
         actor.stop();

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -16,8 +16,8 @@ import {createActor, fromPromise} from 'xstate';
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
 // The graph-traversal suites generate their expectations from the machine, so a transition pointed at
-// a wrong target adjusts those expectations and still passes. This suite pins the soft-prompt hops by
-// hand: eligible device -> soft prompt, and approval -> success outcome plus the persisted acceptance.
+// a wrong target adjusts those expectations and still passes. This suite pins the soft-prompt
+// transitions and the persisted acceptance by hand.
 
 describe('MFA soft prompt', () => {
     afterEach(async () => {

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -21,6 +21,7 @@ const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
 describe('MFA soft prompt', () => {
     afterEach(async () => {
+        jest.restoreAllMocks();
         await Onyx.clear();
         await waitForBatchedUpdates();
     });
@@ -51,6 +52,24 @@ describe('MFA soft prompt', () => {
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
         // The context flag tracks an approval given during this flow, so a skip leaves it false.
         expect(result.context.softPromptApproved).toBe(false);
+
+        actor.stop();
+    });
+
+    it('disconnects a pending soft-prompt read when the flow closes', () => {
+        const connection = {id: 'soft-prompt-read-test', callbackID: 'soft-prompt-read-test'};
+        jest.spyOn(Onyx, 'connectWithoutView').mockReturnValue(connection);
+        const disconnectSpy = jest.spyOn(Onyx, 'disconnect').mockImplementation();
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.VALIDATING_DEVICE}});
+
+        actor.start();
+        sendValidateDeviceDone(actor, {success: true});
+        expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}})).toBe(true);
+
+        actor.send({type: 'CLOSE_MODAL'});
+
+        expect(disconnectSpy).toHaveBeenCalledTimes(1);
+        expect(disconnectSpy).toHaveBeenCalledWith(connection);
 
         actor.stop();
     });

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -6,12 +6,14 @@ import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
 
+import type {EventObject} from 'xstate';
+
 import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
 import {createActorAtState, sendValidateDeviceDone} from 'tests/utils/mfa/flowActors';
 import createInitEvent, {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
-import {createActor, fromPromise} from 'xstate';
+import {createActor, fromCallback, fromPromise} from 'xstate';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
@@ -55,11 +57,13 @@ describe('MFA soft prompt', () => {
         actor.stop();
     });
 
-    it('ends the current flow with an error when reading the soft-prompt flag rejects', async () => {
+    it('ends the current flow with an error when starting the soft-prompt read actor throws', async () => {
         const machine = mfaMachine.provide({
             actors: {
                 validateDevice: fromPromise<MFAResult, ValidateDeviceInput>(() => Promise.resolve({success: true})),
-                readHasAcceptedSoftPrompt: fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(() => Promise.reject(new Error('Onyx read failed'))),
+                readHasAcceptedSoftPrompt: fromCallback<EventObject, ReadHasAcceptedSoftPromptInput>(() => {
+                    throw new Error('Onyx subscription failed');
+                }),
             },
         });
         const actor = createActor(machine);
@@ -71,7 +75,7 @@ describe('MFA soft prompt', () => {
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
         expect(result.context.error?.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION);
-        expect(result.context.error?.message).toContain('Soft-prompt acceptance read threw: Onyx read failed');
+        expect(result.context.error?.message).toContain('Soft-prompt acceptance read threw: Onyx subscription failed');
 
         actor.stop();
     });

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -6,14 +6,12 @@ import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
 
-import type {EventObject} from 'xstate';
-
 import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
 import {createActorAtState, sendValidateDeviceDone} from 'tests/utils/mfa/flowActors';
 import createInitEvent, {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
-import {createActor, fromCallback, fromPromise} from 'xstate';
+import {createActor, fromPromise} from 'xstate';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
@@ -57,13 +55,11 @@ describe('MFA soft prompt', () => {
         actor.stop();
     });
 
-    it('ends the current flow with an error when starting the soft-prompt read actor throws', async () => {
+    it('ends the current flow with an error when reading the soft-prompt flag rejects', async () => {
         const machine = mfaMachine.provide({
             actors: {
                 validateDevice: fromPromise<MFAResult, ValidateDeviceInput>(() => Promise.resolve({success: true})),
-                readHasAcceptedSoftPrompt: fromCallback<EventObject, ReadHasAcceptedSoftPromptInput>(() => {
-                    throw new Error('Onyx subscription failed');
-                }),
+                readHasAcceptedSoftPrompt: fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(() => Promise.reject(new Error('Onyx read failed'))),
             },
         });
         const actor = createActor(machine);
@@ -75,7 +71,7 @@ describe('MFA soft prompt', () => {
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
         expect(result.context.error?.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION);
-        expect(result.context.error?.message).toContain('Soft-prompt acceptance read threw: Onyx subscription failed');
+        expect(result.context.error?.message).toContain('Soft-prompt acceptance read threw: Onyx read failed');
 
         actor.stop();
     });

--- a/tests/unit/hooks/useSplitContextHooks.test.tsx
+++ b/tests/unit/hooks/useSplitContextHooks.test.tsx
@@ -231,7 +231,6 @@ describe('Split context hooks', () => {
             expect(result.current).toEqual(DEFAULT_STATE);
             expect(result.current.continuableError).toBeUndefined();
             expect(result.current.validateCode).toBeUndefined();
-            expect(result.current.softPromptApproved).toBe(false);
             expect(result.current.isFlowComplete).toBe(false);
         });
 
@@ -264,28 +263,6 @@ describe('Split context hooks', () => {
             });
 
             expect(result.current.state.validateCode).toBe('123456');
-        });
-
-        it('dispatch handles SET_SOFT_PROMPT_APPROVED', () => {
-            function wrapper({children}: PropsWithChildren) {
-                return <MultifactorAuthenticationStateProvider>{children}</MultifactorAuthenticationStateProvider>;
-            }
-
-            const {result} = renderHook(
-                () => ({
-                    state: useMultifactorAuthenticationState(),
-                    actions: useMultifactorAuthenticationActions(),
-                }),
-                {wrapper},
-            );
-
-            expect(result.current.state.softPromptApproved).toBe(false);
-
-            act(() => {
-                result.current.actions.dispatch({type: 'SET_SOFT_PROMPT_APPROVED', payload: true});
-            });
-
-            expect(result.current.state.softPromptApproved).toBe(true);
         });
 
         it('dispatch handles SET_FLOW_COMPLETE', () => {
@@ -323,11 +300,11 @@ describe('Split context hooks', () => {
 
             act(() => {
                 result.current.actions.dispatch({type: 'SET_VALIDATE_CODE', payload: '999'});
-                result.current.actions.dispatch({type: 'SET_SOFT_PROMPT_APPROVED', payload: true});
+                result.current.actions.dispatch({type: 'SET_REGISTRATION_COMPLETE', payload: true});
             });
 
             expect(result.current.state.validateCode).toBe('999');
-            expect(result.current.state.softPromptApproved).toBe(true);
+            expect(result.current.state.isRegistrationComplete).toBe(true);
 
             act(() => {
                 result.current.actions.dispatch({type: 'RESET'});

--- a/tests/utils/mfa/flowActors.ts
+++ b/tests/utils/mfa/flowActors.ts
@@ -1,0 +1,49 @@
+import type createActors from '@components/MultifactorAuthentication/machine/mfaActors';
+import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
+import type {MfaContext, MfaEvent} from '@components/MultifactorAuthentication/machine/types';
+
+import type {OutputFrom, StateValue} from 'xstate';
+
+import {createActor} from 'xstate';
+
+import createInitEvent from './flowFixtures';
+import {VALIDATE_DEVICE_DONE_EVENT_TYPE} from './flowPaths';
+
+type ValidateDeviceOutput = OutputFrom<ReturnType<typeof createActors>['validateDevice']>;
+
+/**
+ * Builds the context a flow carries right after INIT seeds it. Overrides express a spec's starting
+ * variation, such as a stored error.
+ */
+function createFlowContext(overrides: Partial<MfaContext> = {}): MfaContext {
+    const initEvent = createInitEvent();
+    return {
+        error: undefined,
+        scenarioName: initEvent.scenarioName,
+        scenario: initEvent.scenario,
+        payload: initEvent.payload,
+        softPromptApproved: false,
+        isCancelConfirmVisible: false,
+        ...overrides,
+    };
+}
+
+/**
+ * Creates an actor resolved to the given state value over a fresh post-INIT context, so a transition
+ * spec can drive a single hop without walking the whole flow first. The actor is not started.
+ */
+function createActorAtState(value: StateValue, contextOverrides?: Partial<MfaContext>) {
+    const snapshot = mfaMachine.resolveState({value, context: createFlowContext(contextOverrides)});
+    return createActor(mfaMachine, {snapshot});
+}
+
+/**
+ * Completes the invoked device-check actor by sending its done event carrying the given output.
+ */
+function sendValidateDeviceDone(actor: ReturnType<typeof createActorAtState>, output: ValidateDeviceOutput) {
+    // Framework actor events are not part of the application's MfaEvent union.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    actor.send({type: VALIDATE_DEVICE_DONE_EVENT_TYPE, output} as unknown as MfaEvent);
+}
+
+export {createActorAtState, createFlowContext, sendValidateDeviceDone};

--- a/tests/utils/mfa/flowActors.ts
+++ b/tests/utils/mfa/flowActors.ts
@@ -18,6 +18,7 @@ type ValidateDeviceOutput = OutputFrom<ReturnType<typeof createActors>['validate
 function createFlowContext(overrides: Partial<MfaContext> = {}): MfaContext {
     const initEvent = createInitEvent();
     return {
+        accountID: initEvent.accountID,
         error: undefined,
         scenarioName: initEvent.scenarioName,
         scenario: initEvent.scenario,

--- a/tests/utils/mfa/flowFixtures.ts
+++ b/tests/utils/mfa/flowFixtures.ts
@@ -4,6 +4,7 @@ import type {MultifactorAuthenticationInitEvent} from '@components/MultifactorAu
 import CONST from '@src/CONST';
 
 const MFA_TEST_SCENARIO_NAME = CONST.MULTIFACTOR_AUTHENTICATION.SCENARIO.BIOMETRICS_TEST;
+const MFA_TEST_ACCOUNT_ID = 12345;
 
 /**
  * Builds the INIT event fixture for the test scenario.
@@ -11,6 +12,7 @@ const MFA_TEST_SCENARIO_NAME = CONST.MULTIFACTOR_AUTHENTICATION.SCENARIO.BIOMETR
 function createInitEvent(): MultifactorAuthenticationInitEvent<typeof MFA_TEST_SCENARIO_NAME> {
     return {
         type: 'INIT',
+        accountID: MFA_TEST_ACCOUNT_ID,
         scenarioName: MFA_TEST_SCENARIO_NAME,
         scenario: getScenarioConfig(MFA_TEST_SCENARIO_NAME),
         payload: undefined,
@@ -18,3 +20,4 @@ function createInitEvent(): MultifactorAuthenticationInitEvent<typeof MFA_TEST_S
 }
 
 export default createInitEvent;
+export {MFA_TEST_ACCOUNT_ID};

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -113,6 +113,11 @@ type PathSteps = ReadonlyArray<{event: {type: string}}>;
 
 type MfaSnapshot = SnapshotFrom<typeof mfaMachine>;
 
+/**
+ * Tells whether this event happens without a user gesture. Every event that XState synthesizes,
+ * such as actor completion or a delayed transition firing, carries the `xstate.` prefix, and none
+ * of them corresponds to a gesture, so the prefix check matches exactly the framework events.
+ */
 function isAutoDrivenEvent(eventType: string): boolean {
     return eventType.startsWith('xstate.');
 }

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -72,13 +72,8 @@ function hasMfaEventFixtures(type: string): type is MfaEvent['type'] {
 
 type MfaActors = ReturnType<typeof createActors>;
 
-// Callback actors have no done output and must not require done-output fixtures.
-type MfaActorIdWithDoneOutput = {
-    [Id in keyof MfaActors]: undefined extends OutputFrom<MfaActors[Id]> ? never : Id;
-}[keyof MfaActors];
-
 type MfaActorDoneOutputFixtures = {
-    readonly [Id in MfaActorIdWithDoneOutput]: readonly [OutputFrom<MfaActors[Id]>, ...Array<OutputFrom<MfaActors[Id]>>];
+    readonly [Id in keyof MfaActors]: readonly [OutputFrom<MfaActors[Id]>, ...Array<OutputFrom<MfaActors[Id]>>];
 };
 
 /**
@@ -106,7 +101,6 @@ function hasActorDoneOutputFixtures(actorId: string): actorId is keyof typeof MF
     return Object.hasOwn(MFA_ACTOR_DONE_OUTPUT_FIXTURES, actorId);
 }
 
-const INIT_STEP_EVENT_TYPE = 'xstate.init';
 const DELAYED_EVENT_PREFIX = 'xstate.after';
 const ACTOR_DONE_EVENT_PREFIX = 'xstate.done.actor.';
 const ACTOR_ERROR_EVENT_PREFIX = 'xstate.error.actor.';
@@ -120,7 +114,7 @@ type PathSteps = ReadonlyArray<{event: {type: string}}>;
 type MfaSnapshot = SnapshotFrom<typeof mfaMachine>;
 
 function isAutoDrivenEvent(eventType: string): boolean {
-    return eventType === INIT_STEP_EVENT_TYPE || eventType.startsWith(ACTOR_DONE_EVENT_PREFIX) || eventType.startsWith(ACTOR_ERROR_EVENT_PREFIX);
+    return eventType.startsWith('xstate.');
 }
 
 /**

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -63,6 +63,10 @@ const MFA_GRAPH_EVENT_FIXTURES = {
     INIT: [createInitEvent()],
     CLOSE_MODAL: [{type: 'CLOSE_MODAL'}],
     MODAL_CLOSED: [{type: 'MODAL_CLOSED'}],
+    ACTOR_SOFT_PROMPT_ACCEPTANCE_READ: [
+        {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted: false},
+        {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted: true},
+    ],
     SOFT_PROMPT_APPROVED: [{type: 'SOFT_PROMPT_APPROVED'}],
 } satisfies MfaEventFixtures;
 
@@ -99,33 +103,32 @@ const MFA_ACTOR_DONE_OUTPUT_FIXTURES = {
             error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.NO_AUTHENTICATION_METHODS_ENROLLED, 'Graph-traversal device-check enrollment refusal'),
         },
     ],
-    readHasAcceptedSoftPrompt: [false, true],
 } satisfies MfaActorDoneOutputFixtures;
 
 function hasActorDoneOutputFixtures(actorId: string): actorId is keyof typeof MFA_ACTOR_DONE_OUTPUT_FIXTURES {
     return Object.hasOwn(MFA_ACTOR_DONE_OUTPUT_FIXTURES, actorId);
 }
 
-const INIT_STEP_EVENT_TYPE = 'xstate.init';
 const DELAYED_EVENT_PREFIX = 'xstate.after';
 const ACTOR_DONE_EVENT_PREFIX = 'xstate.done.actor.';
 const ACTOR_ERROR_EVENT_PREFIX = 'xstate.error.actor.';
 const VALIDATE_DEVICE_DONE_EVENT_TYPE = `${ACTOR_DONE_EVENT_PREFIX}validateDevice`;
 const VALIDATE_DEVICE_ERROR_EVENT_TYPE = `${ACTOR_ERROR_EVENT_PREFIX}validateDevice`;
-const READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE = `${ACTOR_DONE_EVENT_PREFIX}readHasAcceptedSoftPrompt`;
 const READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE = `${ACTOR_ERROR_EVENT_PREFIX}readHasAcceptedSoftPrompt`;
 
 type PathSteps = ReadonlyArray<{event: {type: string}}>;
 
 type MfaSnapshot = SnapshotFrom<typeof mfaMachine>;
 
+const AUTO_DRIVEN_EVENT_PREFIXES = ['xstate.', 'ACTOR_'];
+
 function isAutoDrivenEvent(eventType: string): boolean {
-    return eventType === INIT_STEP_EVENT_TYPE || eventType.startsWith(ACTOR_DONE_EVENT_PREFIX) || eventType.startsWith(ACTOR_ERROR_EVENT_PREFIX);
+    return AUTO_DRIVEN_EVENT_PREFIXES.some((prefix) => eventType.startsWith(prefix));
 }
 
 /**
  * A path is UI-drivable when the walk can produce every step. A delayed transition would need real
- * timers, so a path containing one is not drivable. Actor completion events stay in the path so their
+ * timers, so a path containing one is not drivable. Actor-produced events stay in the path so their
  * executors can settle the controlled actor mocks at the correct transition.
  */
 function isUiDrivablePath(path: {steps: PathSteps}): boolean {
@@ -202,12 +205,4 @@ function getWalkedPaths() {
 }
 
 export default getWalkedPaths;
-export {
-    getDrivingJourneyPaths,
-    getMfaShortestPaths,
-    isAutoDrivenEvent,
-    READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
-    READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE,
-    VALIDATE_DEVICE_DONE_EVENT_TYPE,
-    VALIDATE_DEVICE_ERROR_EVENT_TYPE,
-};
+export {getDrivingJourneyPaths, getMfaShortestPaths, isAutoDrivenEvent, READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE, VALIDATE_DEVICE_DONE_EVENT_TYPE, VALIDATE_DEVICE_ERROR_EVENT_TYPE};

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -63,10 +63,6 @@ const MFA_GRAPH_EVENT_FIXTURES = {
     INIT: [createInitEvent()],
     CLOSE_MODAL: [{type: 'CLOSE_MODAL'}],
     MODAL_CLOSED: [{type: 'MODAL_CLOSED'}],
-    ACTOR_SOFT_PROMPT_ACCEPTANCE_READ: [
-        {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted: false},
-        {type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted: true},
-    ],
     SOFT_PROMPT_APPROVED: [{type: 'SOFT_PROMPT_APPROVED'}],
 } satisfies MfaEventFixtures;
 
@@ -103,32 +99,33 @@ const MFA_ACTOR_DONE_OUTPUT_FIXTURES = {
             error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.NO_AUTHENTICATION_METHODS_ENROLLED, 'Graph-traversal device-check enrollment refusal'),
         },
     ],
+    readHasAcceptedSoftPrompt: [false, true],
 } satisfies MfaActorDoneOutputFixtures;
 
 function hasActorDoneOutputFixtures(actorId: string): actorId is keyof typeof MFA_ACTOR_DONE_OUTPUT_FIXTURES {
     return Object.hasOwn(MFA_ACTOR_DONE_OUTPUT_FIXTURES, actorId);
 }
 
+const INIT_STEP_EVENT_TYPE = 'xstate.init';
 const DELAYED_EVENT_PREFIX = 'xstate.after';
 const ACTOR_DONE_EVENT_PREFIX = 'xstate.done.actor.';
 const ACTOR_ERROR_EVENT_PREFIX = 'xstate.error.actor.';
 const VALIDATE_DEVICE_DONE_EVENT_TYPE = `${ACTOR_DONE_EVENT_PREFIX}validateDevice`;
 const VALIDATE_DEVICE_ERROR_EVENT_TYPE = `${ACTOR_ERROR_EVENT_PREFIX}validateDevice`;
+const READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE = `${ACTOR_DONE_EVENT_PREFIX}readHasAcceptedSoftPrompt`;
 const READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE = `${ACTOR_ERROR_EVENT_PREFIX}readHasAcceptedSoftPrompt`;
 
 type PathSteps = ReadonlyArray<{event: {type: string}}>;
 
 type MfaSnapshot = SnapshotFrom<typeof mfaMachine>;
 
-const AUTO_DRIVEN_EVENT_PREFIXES = ['xstate.', 'ACTOR_'];
-
 function isAutoDrivenEvent(eventType: string): boolean {
-    return AUTO_DRIVEN_EVENT_PREFIXES.some((prefix) => eventType.startsWith(prefix));
+    return eventType === INIT_STEP_EVENT_TYPE || eventType.startsWith(ACTOR_DONE_EVENT_PREFIX) || eventType.startsWith(ACTOR_ERROR_EVENT_PREFIX);
 }
 
 /**
  * A path is UI-drivable when the walk can produce every step. A delayed transition would need real
- * timers, so a path containing one is not drivable. Actor-produced events stay in the path so their
+ * timers, so a path containing one is not drivable. Actor completion events stay in the path so their
  * executors can settle the controlled actor mocks at the correct transition.
  */
 function isUiDrivablePath(path: {steps: PathSteps}): boolean {
@@ -205,4 +202,12 @@ function getWalkedPaths() {
 }
 
 export default getWalkedPaths;
-export {getDrivingJourneyPaths, getMfaShortestPaths, isAutoDrivenEvent, READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE, VALIDATE_DEVICE_DONE_EVENT_TYPE, VALIDATE_DEVICE_ERROR_EVENT_TYPE};
+export {
+    getDrivingJourneyPaths,
+    getMfaShortestPaths,
+    isAutoDrivenEvent,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE,
+    VALIDATE_DEVICE_DONE_EVENT_TYPE,
+    VALIDATE_DEVICE_ERROR_EVENT_TYPE,
+};

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -72,8 +72,13 @@ function hasMfaEventFixtures(type: string): type is MfaEvent['type'] {
 
 type MfaActors = ReturnType<typeof createActors>;
 
+// Callback actors have no done output and must not require done-output fixtures.
+type MfaActorIdWithDoneOutput = {
+    [Id in keyof MfaActors]: undefined extends OutputFrom<MfaActors[Id]> ? never : Id;
+}[keyof MfaActors];
+
 type MfaActorDoneOutputFixtures = {
-    readonly [Id in keyof MfaActors]: readonly [OutputFrom<MfaActors[Id]>, ...Array<OutputFrom<MfaActors[Id]>>];
+    readonly [Id in MfaActorIdWithDoneOutput]: readonly [OutputFrom<MfaActors[Id]>, ...Array<OutputFrom<MfaActors[Id]>>];
 };
 
 /**
@@ -94,6 +99,7 @@ const MFA_ACTOR_DONE_OUTPUT_FIXTURES = {
             error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.NO_AUTHENTICATION_METHODS_ENROLLED, 'Graph-traversal device-check enrollment refusal'),
         },
     ],
+    readHasAcceptedSoftPrompt: [false, true],
 } satisfies MfaActorDoneOutputFixtures;
 
 function hasActorDoneOutputFixtures(actorId: string): actorId is keyof typeof MFA_ACTOR_DONE_OUTPUT_FIXTURES {
@@ -106,6 +112,8 @@ const ACTOR_DONE_EVENT_PREFIX = 'xstate.done.actor.';
 const ACTOR_ERROR_EVENT_PREFIX = 'xstate.error.actor.';
 const VALIDATE_DEVICE_DONE_EVENT_TYPE = `${ACTOR_DONE_EVENT_PREFIX}validateDevice`;
 const VALIDATE_DEVICE_ERROR_EVENT_TYPE = `${ACTOR_ERROR_EVENT_PREFIX}validateDevice`;
+const READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE = `${ACTOR_DONE_EVENT_PREFIX}readHasAcceptedSoftPrompt`;
+const READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE = `${ACTOR_ERROR_EVENT_PREFIX}readHasAcceptedSoftPrompt`;
 
 type PathSteps = ReadonlyArray<{event: {type: string}}>;
 
@@ -194,4 +202,12 @@ function getWalkedPaths() {
 }
 
 export default getWalkedPaths;
-export {getDrivingJourneyPaths, getMfaShortestPaths, isAutoDrivenEvent, VALIDATE_DEVICE_DONE_EVENT_TYPE, VALIDATE_DEVICE_ERROR_EVENT_TYPE};
+export {
+    getDrivingJourneyPaths,
+    getMfaShortestPaths,
+    isAutoDrivenEvent,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_DONE_EVENT_TYPE,
+    READ_HAS_ACCEPTED_SOFT_PROMPT_ERROR_EVENT_TYPE,
+    VALIDATE_DEVICE_DONE_EVENT_TYPE,
+    VALIDATE_DEVICE_ERROR_EVENT_TYPE,
+};

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -63,6 +63,7 @@ const MFA_GRAPH_EVENT_FIXTURES = {
     INIT: [createInitEvent()],
     CLOSE_MODAL: [{type: 'CLOSE_MODAL'}],
     MODAL_CLOSED: [{type: 'MODAL_CLOSED'}],
+    SOFT_PROMPT_APPROVED: [{type: 'SOFT_PROMPT_APPROVED'}],
 } satisfies MfaEventFixtures;
 
 function hasMfaEventFixtures(type: string): type is MfaEvent['type'] {

--- a/tests/utils/mfa/realUi/harness.tsx
+++ b/tests/utils/mfa/realUi/harness.tsx
@@ -1,6 +1,7 @@
 import {render} from '@testing-library/react-native';
 
 import ComposeProviders from '@components/ComposeProviders';
+import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import {MultifactorAuthenticationContextProviders, useMultifactorAuthentication} from '@components/MultifactorAuthentication/Context';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
@@ -30,14 +31,17 @@ function MfaControlsCapture({controlsRef}: {controlsRef: MfaControlsRef}) {
 
 /**
  * Mounts the production MFA providers and modal navigator. The global safe-area mock provides fixed
- * values without a `SafeAreaProvider`. The returned `executeScenario` reads the captured controls at
- * call time because the provider recreates the context API on every render.
+ * values without a `SafeAreaProvider`. `CurrentUserPersonalDetailsProvider` is required because the
+ * MFA context rejects a flow start while the account is still the context default placeholder, so
+ * each test must also seed `ONYXKEYS.SESSION` with an account ID before starting a flow. The
+ * returned `executeScenario` reads the captured controls at call time because the provider recreates
+ * the context API on every render.
  */
 function renderMfaUi() {
     const controlsRef: MfaControlsRef = {current: undefined};
 
     const renderResult = render(
-        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+        <ComposeProviders components={[OnyxListItemProvider, CurrentUserPersonalDetailsProvider, LocaleContextProvider]}>
             <MultifactorAuthenticationContextProviders>
                 <MfaControlsCapture controlsRef={controlsRef} />
                 <MultifactorAuthenticationModalNavigator />

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -12,12 +12,8 @@ import {fromPromise} from 'xstate';
 
 type CapturedCallback = () => void;
 type NavigationTransitionOverrides = Pick<typeof Navigation, 'runAfterTransition' | 'runAfterUpcomingTransition'>;
-type PendingValidateDevice = {
-    resolve: (result: MFAResult) => void;
-    reject: (error: Error) => void;
-};
-type PendingReadHasAcceptedSoftPrompt = {
-    resolve: (accepted: boolean) => void;
+type PendingCall<TOutput> = {
+    resolve: (output: TOutput) => void;
     reject: (error: Error) => void;
 };
 
@@ -54,68 +50,52 @@ const biometricsMock: Pick<UseBiometricsReturn, 'serverKnownCredentialIDs' | 'ar
     areLocalCredentialsKnownToServer: () => Promise.resolve(false),
 };
 
-let pendingValidateDeviceCall: PendingValidateDevice | undefined;
-let pendingSoftPromptAcceptanceCall: PendingReadHasAcceptedSoftPrompt | undefined;
+/**
+ * Builds a controlled deferred mock for one invoked machine actor. Each machine invocation parks a
+ * pending promise that the test settles later through `resolve` or `reject`, at the exact path step
+ * where the machine expects the actor outcome.
+ */
+function createControlledActor<TOutput, TInput>(actorID: string) {
+    let pendingCall: PendingCall<TOutput> | undefined;
 
-function takePendingValidateDeviceCall(): PendingValidateDevice {
-    const pendingCall = pendingValidateDeviceCall;
-    pendingValidateDeviceCall = undefined;
-    if (!pendingCall) {
-        throw new Error('No pending validateDevice call is available.');
+    function takePendingCall(): PendingCall<TOutput> {
+        const call = pendingCall;
+        pendingCall = undefined;
+        if (!call) {
+            throw new Error(`No pending ${actorID} call is available.`);
+        }
+        return call;
     }
-    return pendingCall;
+
+    return {
+        actor: fromPromise<TOutput, TInput>(
+            () =>
+                new Promise<TOutput>((resolve, reject) => {
+                    pendingCall = {resolve, reject};
+                }),
+        ),
+        resolve: (output: TOutput) => takePendingCall().resolve(output),
+        reject: () => takePendingCall().reject(new Error(`Mock ${actorID} actor rejected for this path`)),
+        reset: () => {
+            pendingCall = undefined;
+        },
+    };
 }
 
-function resolveValidateDevice(result: MFAResult) {
-    takePendingValidateDeviceCall().resolve(result);
-}
-
-function rejectValidateDevice() {
-    takePendingValidateDeviceCall().reject(new Error('Mock validateDevice actor rejected for this path'));
-}
-
-function takePendingSoftPromptAcceptanceCall(): PendingReadHasAcceptedSoftPrompt {
-    const pendingCall = pendingSoftPromptAcceptanceCall;
-    pendingSoftPromptAcceptanceCall = undefined;
-    if (!pendingCall) {
-        throw new Error('No pending readHasAcceptedSoftPrompt call is available.');
-    }
-    return pendingCall;
-}
-
-function resolveSoftPromptAcceptance(accepted: boolean) {
-    takePendingSoftPromptAcceptanceCall().resolve(accepted);
-}
-
-function rejectSoftPromptAcceptanceRead() {
-    takePendingSoftPromptAcceptanceCall().reject(new Error('Mock readHasAcceptedSoftPrompt actor rejected for this path'));
-}
+const validateDeviceControl = createControlledActor<MFAResult, ValidateDeviceInput>('validateDevice');
+const readHasAcceptedSoftPromptControl = createControlledActor<boolean, ReadHasAcceptedSoftPromptInput>('readHasAcceptedSoftPrompt');
 
 function resetMfaUiMocks() {
     pendingModalClose.clear();
-    pendingValidateDeviceCall = undefined;
-    pendingSoftPromptAcceptanceCall = undefined;
+    validateDeviceControl.reset();
+    readHasAcceptedSoftPromptControl.reset();
 }
-
-const validateDeviceMock = fromPromise<MFAResult, ValidateDeviceInput>(
-    () =>
-        new Promise<MFAResult>((resolve, reject) => {
-            pendingValidateDeviceCall = {resolve, reject};
-        }),
-);
-
-const readHasAcceptedSoftPromptMock = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
-    () =>
-        new Promise<boolean>((resolve, reject) => {
-            pendingSoftPromptAcceptanceCall = {resolve, reject};
-        }),
-);
 
 /** Replaces the machine's side-effect actors with controlled test implementations. */
 function mfaActorsMock() {
     const actors = {
-        validateDevice: validateDeviceMock,
-        readHasAcceptedSoftPrompt: readHasAcceptedSoftPromptMock,
+        validateDevice: validateDeviceControl.actor,
+        readHasAcceptedSoftPrompt: readHasAcceptedSoftPromptControl.actor,
     } satisfies ReturnType<typeof createActors>;
 
     return {
@@ -173,16 +153,4 @@ function navigationMock() {
     };
 }
 
-export {
-    pendingModalClose,
-    resolveValidateDevice,
-    rejectValidateDevice,
-    resolveSoftPromptAcceptance,
-    rejectSoftPromptAcceptanceRead,
-    resetMfaUiMocks,
-    mfaActorsMock,
-    biometricsHookMock,
-    renderHtmlMock,
-    syncHistoryMock,
-    navigationMock,
-};
+export {pendingModalClose, validateDeviceControl, readHasAcceptedSoftPromptControl, resetMfaUiMocks, mfaActorsMock, biometricsHookMock, renderHtmlMock, syncHistoryMock, navigationMock};

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -1,6 +1,6 @@
 import type {UseBiometricsReturn} from '@components/MultifactorAuthentication/biometrics/shared/types';
 import type createActors from '@components/MultifactorAuthentication/machine/mfaActors';
-import type {ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
+import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
 
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import type Navigation from '@libs/Navigation/Navigation';
@@ -14,6 +14,10 @@ type CapturedCallback = () => void;
 type NavigationTransitionOverrides = Pick<typeof Navigation, 'runAfterTransition' | 'runAfterUpcomingTransition'>;
 type PendingValidateDevice = {
     resolve: (result: MFAResult) => void;
+    reject: (error: Error) => void;
+};
+type PendingReadHasAcceptedSoftPrompt = {
+    resolve: (accepted: boolean) => void;
     reject: (error: Error) => void;
 };
 
@@ -51,6 +55,7 @@ const biometricsMock: Pick<UseBiometricsReturn, 'serverKnownCredentialIDs' | 'ar
 };
 
 let pendingValidateDeviceCall: PendingValidateDevice | undefined;
+let pendingSoftPromptAcceptanceCall: PendingReadHasAcceptedSoftPrompt | undefined;
 
 function takePendingValidateDeviceCall(): PendingValidateDevice {
     const pendingCall = pendingValidateDeviceCall;
@@ -69,9 +74,27 @@ function rejectValidateDevice() {
     takePendingValidateDeviceCall().reject(new Error('Mock validateDevice actor rejected for this path'));
 }
 
+function takePendingSoftPromptAcceptanceCall(): PendingReadHasAcceptedSoftPrompt {
+    const pendingCall = pendingSoftPromptAcceptanceCall;
+    pendingSoftPromptAcceptanceCall = undefined;
+    if (!pendingCall) {
+        throw new Error('No pending readHasAcceptedSoftPrompt call is available.');
+    }
+    return pendingCall;
+}
+
+function resolveSoftPromptAcceptance(accepted: boolean) {
+    takePendingSoftPromptAcceptanceCall().resolve(accepted);
+}
+
+function rejectSoftPromptAcceptanceRead() {
+    takePendingSoftPromptAcceptanceCall().reject(new Error('Mock readHasAcceptedSoftPrompt actor rejected for this path'));
+}
+
 function resetMfaUiMocks() {
     pendingModalClose.clear();
     pendingValidateDeviceCall = undefined;
+    pendingSoftPromptAcceptanceCall = undefined;
 }
 
 const validateDeviceMock = fromPromise<MFAResult, ValidateDeviceInput>(
@@ -81,10 +104,18 @@ const validateDeviceMock = fromPromise<MFAResult, ValidateDeviceInput>(
         }),
 );
 
+const readHasAcceptedSoftPromptMock = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
+    () =>
+        new Promise<boolean>((resolve, reject) => {
+            pendingSoftPromptAcceptanceCall = {resolve, reject};
+        }),
+);
+
 /** Replaces the machine's side-effect actors with controlled test implementations. */
 function mfaActorsMock() {
     const actors = {
         validateDevice: validateDeviceMock,
+        readHasAcceptedSoftPrompt: readHasAcceptedSoftPromptMock,
     } satisfies ReturnType<typeof createActors>;
 
     return {
@@ -142,4 +173,16 @@ function navigationMock() {
     };
 }
 
-export {pendingModalClose, resolveValidateDevice, rejectValidateDevice, resetMfaUiMocks, mfaActorsMock, biometricsHookMock, renderHtmlMock, syncHistoryMock, navigationMock};
+export {
+    pendingModalClose,
+    resolveValidateDevice,
+    rejectValidateDevice,
+    resolveSoftPromptAcceptance,
+    rejectSoftPromptAcceptanceRead,
+    resetMfaUiMocks,
+    mfaActorsMock,
+    biometricsHookMock,
+    renderHtmlMock,
+    syncHistoryMock,
+    navigationMock,
+};

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -1,11 +1,13 @@
 import type {UseBiometricsReturn} from '@components/MultifactorAuthentication/biometrics/shared/types';
 import type createActors from '@components/MultifactorAuthentication/machine/mfaActors';
-import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
+import type {ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
 
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import type Navigation from '@libs/Navigation/Navigation';
 
-import {fromPromise} from 'xstate';
+import type {EventObject} from 'xstate';
+
+import {fromCallback, fromPromise} from 'xstate';
 
 // This module keeps mutable mock state and factory bodies outside the test so the test stays focused on
 // mock registrations and assertions.
@@ -104,12 +106,14 @@ const validateDeviceMock = fromPromise<MFAResult, ValidateDeviceInput>(
         }),
 );
 
-const readHasAcceptedSoftPromptMock = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
-    () =>
-        new Promise<boolean>((resolve, reject) => {
-            pendingSoftPromptAcceptanceCall = {resolve, reject};
-        }),
-);
+const readHasAcceptedSoftPromptMock = fromCallback<EventObject, ReadHasAcceptedSoftPromptInput>(({sendBack}) => {
+    pendingSoftPromptAcceptanceCall = {
+        resolve: (accepted) => sendBack({type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted} satisfies SoftPromptAcceptanceReadEvent),
+        // Callback actors have no asynchronous error channel, so the controlled mock sends the
+        // framework error event that a synchronous actor setup failure would produce.
+        reject: (error) => sendBack({type: 'xstate.error.actor.readHasAcceptedSoftPrompt', actorId: 'readHasAcceptedSoftPrompt', error}),
+    };
+});
 
 /** Replaces the machine's side-effect actors with controlled test implementations. */
 function mfaActorsMock() {

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -1,13 +1,11 @@
 import type {UseBiometricsReturn} from '@components/MultifactorAuthentication/biometrics/shared/types';
 import type createActors from '@components/MultifactorAuthentication/machine/mfaActors';
-import type {ReadHasAcceptedSoftPromptInput, SoftPromptAcceptanceReadEvent, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
+import type {ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
 
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import type Navigation from '@libs/Navigation/Navigation';
 
-import type {EventObject} from 'xstate';
-
-import {fromCallback, fromPromise} from 'xstate';
+import {fromPromise} from 'xstate';
 
 // This module keeps mutable mock state and factory bodies outside the test so the test stays focused on
 // mock registrations and assertions.
@@ -106,14 +104,12 @@ const validateDeviceMock = fromPromise<MFAResult, ValidateDeviceInput>(
         }),
 );
 
-const readHasAcceptedSoftPromptMock = fromCallback<EventObject, ReadHasAcceptedSoftPromptInput>(({sendBack}) => {
-    pendingSoftPromptAcceptanceCall = {
-        resolve: (accepted) => sendBack({type: 'ACTOR_SOFT_PROMPT_ACCEPTANCE_READ', accepted} satisfies SoftPromptAcceptanceReadEvent),
-        // Callback actors have no asynchronous error channel, so the controlled mock sends the
-        // framework error event that a synchronous actor setup failure would produce.
-        reject: (error) => sendBack({type: 'xstate.error.actor.readHasAcceptedSoftPrompt', actorId: 'readHasAcceptedSoftPrompt', error}),
-    };
-});
+const readHasAcceptedSoftPromptMock = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(
+    () =>
+        new Promise<boolean>((resolve, reject) => {
+            pendingSoftPromptAcceptanceCall = {resolve, reject};
+        }),
+);
 
 /** Replaces the machine's side-effect actors with controlled test implementations. */
 function mfaActorsMock() {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### PR Stack

Part of the MFA flow to XState migration ([#81197](https://github.com/Expensify/App/issues/81197)). The migration lands as a stack of vertical slices on the integration branch `dariusz-81197-mfa-state-machine`, and nothing reaches `main` until the final integration merge. The stack lives on the `software-mansion-labs/expensify-app-fork` remote, so this PR is opened there; its parent slice ([#346](https://github.com/software-mansion-labs/expensify-app-fork/pull/346)) is already merged, so this PR targets the integration branch directly.

| #   | PR                                                                                          | Branch                                                         | Base                              |
| --- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------- |
| -   | [#345](https://github.com/software-mansion-labs/expensify-app-fork/pull/345) (test harness) | `dariusz-biela/refactor/3ds/mfa-test-reachability-and-ui-walk` | `dariusz-81197-mfa-state-machine` |
| -   | [#346](https://github.com/software-mansion-labs/expensify-app-fork/pull/346) (device check) | `dariusz-biela/feat/3ds/mfa-device-check-and-failure-screen`   | `dariusz-81197-mfa-state-machine` |
| -   | **This PR**                                                                                 | `dariusz-biela/feat/3ds/mfa-soft-prompt`                       | `dariusz-81197-mfa-state-machine` |

### Explanation of Change

Adds the soft prompt step to the MFA state machine, migrating the step out of the legacy reducer flow as the next vertical slice of the XState migration.

**In the app**

- After a successful device check, a user who has never accepted the biometrics soft prompt on this device sees the prompt screen with the platform illustration and a confirm button, and confirming moves the flow to the success outcome.
- The acceptance is remembered for the account on the device, so every later flow skips the prompt entirely.

**In the code**

- The machine gains a `prompt` screen state entered after a successful device check. The prompt screen's confirm button sends `SOFT_PROMPT_APPROVED`, which stores the approval in the machine context, persists the acceptance to Onyx through a machine action, and moves the flow to the success outcome.
- The skip decision runs through a `readHasAcceptedSoftPrompt` promise actor: a dedicated machine state invokes it, the actor reads the stored acceptance once through a temporary Onyx connection, and the result decides whether the prompt shows or the flow skips straight to success. A stored context error still wins over a successful device check and resolves to the failure outcome.
- The actor is now the only runtime reader of the flag: the Provider dropped its reactive subscription, and the start-of-flow telemetry no longer reports the soft-prompt acceptance.
- The Provider rejects a flow start until the session account hydrates, so a flow is never keyed to the placeholder account id.
- `PromptPage` simplifies to the static platform copy with an always-visible confirm button; `usePromptContent` stays as an intentionally unused file, since its returning-user and post-registration variants belong to the registration and authorization slices.
- `softPromptApproved` moves from the legacy reducer into the machine context, so the field keeps a single home.
- A focused transition spec pins the new hops (prompt entry, approval, skip, persisted acceptance); the graph-traversal suites pick the new state up automatically through a new event fixture and a prompt-screen assertion.

<img width="1044" height="745" alt="Screenshot 2026-07-21 at 10 51 50" src="https://github.com/user-attachments/assets/8408ee6b-4c8a-4d34-ab81-a3af5f8b86b6" />

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/81197
PROPOSAL: N/A (internal engineering migration, part of the MFA XState refactor)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Run the app in dev on this branch (the soft prompt step is wired here).

1. Reset the stored acceptance for your account in the JS console (browser console on web, React Native DevTools console on iOS and Android):
    ```js
    (async () => {
        const session = await window.Onyx.get('session');
        await window.Onyx.merge(`deviceBiometrics_${session.accountID}`, {hasAcceptedSoftPrompt: false});
        console.log('done for accountID', session.accountID);
    })();
    ```
2. Trigger an MFA scenario (for example Troubleshoot > Biometrics test). Verify the soft prompt screen appears after the device check, with the platform illustration and a confirm button.
3. Press the confirm button. Verify the flow proceeds to the success outcome screen.
4. Trigger the same scenario again without resetting anything. Verify the soft prompt is skipped and the flow goes straight to the success outcome.
5. Verify that no errors appear in the JS console.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A. This slice adds machine transitions and a local Onyx flag only, with no API or network behavior.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
[No QA] - internal stacked PR on the MFA XState integration branch. The flow is intentionally partial between slices and does not reach staging until the final integration merge.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/1e8185ff-ecbb-41b5-ae1e-cddee81a553a


</details>


<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/c1b125fc-2669-4d3c-b3f3-8cfac80a468b



</details>



<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/f9761f57-c12d-4729-99f1-6e04e005e424

</details>


