### PR TITLE
fix: empty line and highlighted sliver below wrapped mention (Android)

### DIFF
--- a/patches/react-native/react-native+0.85.3+039+nested-text-padding.patch
+++ b/patches/react-native/react-native+0.85.3+039+nested-text-padding.patch
@@ -495,7 +495,7 @@ index 86dd1fc7386..2be0a2fd350 100644
        }
  
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
-index e3f19473554..55c4e22aeab 100644
+index e3f19473554..dca0ecb40c2 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
 +++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
 @@ -8,7 +8,9 @@
@@ -508,16 +508,17 @@ index e3f19473554..55c4e22aeab 100644
  import android.graphics.Typeface
  import android.os.Build
  import android.text.BoringLayout
-@@ -21,6 +23,8 @@ import android.text.StaticLayout
+@@ -21,6 +23,9 @@ import android.text.StaticLayout
  import android.text.TextDirectionHeuristics
  import android.text.TextPaint
  import android.text.TextUtils
 +import android.text.style.LeadingMarginSpan
++import android.text.style.LineHeightSpan
 +import android.text.style.ReplacementSpan
  import android.util.LayoutDirection
  import android.view.Gravity
  import android.view.View
-@@ -46,6 +50,7 @@ import com.facebook.react.views.text.internal.span.ReactForegroundColorSpan
+@@ -46,6 +51,7 @@ import com.facebook.react.views.text.internal.span.ReactForegroundColorSpan
  import com.facebook.react.views.text.internal.span.ReactFragmentIndexSpan
  import com.facebook.react.views.text.internal.span.ReactLinkSpan
  import com.facebook.react.views.text.internal.span.ReactOpacitySpan
@@ -525,7 +526,7 @@ index e3f19473554..55c4e22aeab 100644
  import com.facebook.react.views.text.internal.span.ReactStrikethroughSpan
  import com.facebook.react.views.text.internal.span.ReactTagSpan
  import com.facebook.react.views.text.internal.span.ReactTextPaintHolderSpan
-@@ -61,6 +66,35 @@ import kotlin.math.floor
+@@ -61,6 +67,65 @@ import kotlin.math.floor
  import kotlin.math.max
  import kotlin.math.min
  
@@ -536,14 +537,44 @@ index e3f19473554..55c4e22aeab 100644
 +
 +// A zero-content ReplacementSpan that reserves horizontal advance (real space, so neighbours move)
 +// around a bordered / inline-code span — Android has no per-character kern. Draws nothing.
-+private class ReactInlinePaddingSpan(private val spacerWidth: Int) : ReplacementSpan(), ReactSpan {
++private class ReactInlinePaddingSpan(private val spacerWidth: Int) :
++    ReplacementSpan(), ReactSpan, LineHeightSpan {
 +  override fun getSize(
 +      paint: Paint,
 +      text: CharSequence?,
 +      start: Int,
 +      end: Int,
 +      fm: Paint.FontMetricsInt?,
-+  ): Int = spacerWidth
++  ): Int {
++    if (fm != null) {
++      fm.ascent = 0
++      fm.descent = 0
++      fm.top = 0
++      fm.bottom = 0
++      fm.leading = 0
++    }
++    return spacerWidth
++  }
++
++  override fun chooseHeight(
++      text: CharSequence,
++      start: Int,
++      end: Int,
++      spanstartv: Int,
++      lineHeight: Int,
++      fm: Paint.FontMetricsInt,
++  ) {
++    for (i in start until end) {
++      val c = text[i]
++      if (c != '\u2060' && c != '\n') {
++        return
++      }
++    }
++    fm.ascent = 0
++    fm.descent = 0
++    fm.top = 0
++    fm.bottom = 0
++  }
 +
 +  override fun draw(
 +      canvas: Canvas,
@@ -561,7 +592,7 @@ index e3f19473554..55c4e22aeab 100644
  /** Class responsible of creating [Spanned] object for the JS representation of Text */
  internal object TextLayoutManager {
  
-@@ -226,11 +260,56 @@ internal object TextLayoutManager {
+@@ -226,11 +291,57 @@ internal object TextLayoutManager {
    ) {
      for (i in 0 until fragments.count) {
        val fragment = fragments.getMapBuffer(i)
@@ -603,6 +634,7 @@ index e3f19473554..55c4e22aeab 100644
 +        val spacerStart = sb.length
 +        sb.append("\u2060")
 +        ops.add(
++            0,
 +            SetSpanOperation(
 +                spacerStart,
 +                sb.length,
@@ -619,7 +651,7 @@ index e3f19473554..55c4e22aeab 100644
        sb.append(
            TextTransform.apply(fragment.getString(FR_KEY_STRING), textAttributes.textTransform)
        )
-@@ -299,6 +378,8 @@ internal object TextLayoutManager {
+@@ -299,6 +410,8 @@ internal object TextLayoutManager {
                  PixelUtil.toPixelFromDIP(textAttributes.borderRightWidth.takeIf { r -> !r.isNaN() } ?: 0f),
                  PixelUtil.toPixelFromDIP(textAttributes.borderBottomWidth.takeIf { r -> !r.isNaN() } ?: 0f),
                  PixelUtil.toPixelFromDIP(textAttributes.borderLeftWidth.takeIf { r -> !r.isNaN() } ?: 0f),
@@ -628,7 +660,7 @@ index e3f19473554..55c4e22aeab 100644
              )
            } else if (textAttributes.isBackgroundColorSet) {
              textAttributes.backgroundColor?.let { ReactBackgroundColorSpan(it) }
-@@ -373,6 +454,18 @@ internal object TextLayoutManager {
+@@ -373,6 +486,19 @@ internal object TextLayoutManager {
            ops.add(SetSpanOperation(start, end, ReactTagSpan(reactTag)))
          }
        }
@@ -637,6 +669,7 @@ index e3f19473554..55c4e22aeab 100644
 +        val spacerStart = sb.length
 +        sb.append("\u2060")
 +        ops.add(
++            0,
 +            SetSpanOperation(
 +                spacerStart,
 +                sb.length,
@@ -647,7 +680,7 @@ index e3f19473554..55c4e22aeab 100644
      }
    }
  
-@@ -502,6 +595,8 @@ internal object TextLayoutManager {
+@@ -502,6 +628,8 @@ internal object TextLayoutManager {
                  PixelUtil.toPixelFromDIP(fragment.props.borderRightWidth.takeIf { r -> !r.isNaN() } ?: 0f),
                  PixelUtil.toPixelFromDIP(fragment.props.borderBottomWidth.takeIf { r -> !r.isNaN() } ?: 0f),
                  PixelUtil.toPixelFromDIP(fragment.props.borderLeftWidth.takeIf { r -> !r.isNaN() } ?: 0f),
@@ -656,7 +689,7 @@ index e3f19473554..55c4e22aeab 100644
              )
            } else if (fragment.props.isBackgroundColorSet) {
              fragment.props.backgroundColor?.let { ReactBackgroundColorSpan(it) }
-@@ -509,6 +604,20 @@ internal object TextLayoutManager {
+@@ -509,6 +637,20 @@ internal object TextLayoutManager {
              null
            }
            spannable.setSpan(bgSpan, start, end, spanFlags)
@@ -678,7 +711,7 @@ index e3f19473554..55c4e22aeab 100644
  
          if (!fragment.props.opacity.isNaN()) {
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundDrawSpan.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundDrawSpan.kt
-index 80f8d389475..5c188dc9330 100644
+index 80f8d389475..2a55063d2aa 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundDrawSpan.kt
 +++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundDrawSpan.kt
 @@ -38,6 +38,9 @@ internal class ReactBackgroundDrawSpan(
@@ -691,6 +724,15 @@ index 80f8d389475..5c188dc9330 100644
  ) : DrawCommandSpan() {
  
    private val fillPaint =
+@@ -63,7 +66,7 @@ internal class ReactBackgroundDrawSpan(
+     if (start >= end) return
+ 
+     val startLine = layout.getLineForOffset(start)
+-    val endLine = layout.getLineForOffset(end)
++    val endLine = layout.getLineForOffset(end - 1)
+ 
+     for (line in startLine..endLine) {
+       val lineStart = layout.getLineStart(line)
 @@ -99,6 +102,16 @@ internal class ReactBackgroundDrawSpan(
        val isFirstLine = line == startLine
        val isLastLine = line == endLine


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixes an Android-only regression in the `nested-text-padding` RN patch: a wrapping mention/inline-code span left an empty line and a thin highlighted sliver below it. The reserved trailing padding spacer (`ReactInlinePaddingSpan`) could get stranded on its own line; it now collapses to zero height via `LineHeightSpan.chooseHeight` (lowest span priority so it wins over the fragment line-height), and `ReactBackgroundDrawSpan` uses `getLineForOffset(end - 1)` to avoid drawing a degenerate rect at the wrap boundary.

### Fixed Issues
$
PROPOSAL:


### Tests

1. On Android native, open any chat.
2. Send a message mentioning a user with a very long email address, long enough that the mention wraps across two or more lines (e.g. `@rjdjdkdkdkdkdkdkdkdkdkdkdkdkkkdkkdkdkd@gmail.com`).
3. Verify the mention renders as contiguous highlighted lines with **no empty line** and **no thin highlighted sliver** below it.
4. Send a short mention that fits on one line and verify its highlight/padding is unchanged.
5. Send a message containing inline code (backticks) that wraps and verify no stray empty line or sliver appears.

### Offline tests

N/A

### QA Steps

Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
