### PR TITLE
refactor: MenuItem decomposition into a compound component

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -9216,6 +9216,38 @@ const CONST = {
         NEWDOT: 83,
         OAUTH: 86,
     },
+
+    MENU_ITEM: {
+        BADGE_POSITION: {
+            RIGHT: 'right',
+            BELOW_TITLE: 'belowTitle',
+            SEPARATE_ROW: 'separateRow',
+        },
+        TITLE_FORMAT: {
+            MARKDOWN: 'markdown',
+            HTML: 'html',
+        },
+        TITLE_VARIANT: {
+            NORMAL: 'normal',
+            STRONG: 'strong',
+        },
+        VARIANT: {
+            DEFAULT: 'default',
+            SECTION: 'section',
+        },
+        DESCRIPTION_VARIANT: {
+            SUPPORTING: 'supporting',
+            PROMINENT: 'prominent',
+        },
+        ICON_VARIANT: {
+            DEFAULT: 'default',
+            COMPACT: 'compact',
+        },
+        RIGHT_LABEL_VARIANT: {
+            LABEL: 'label',
+            SUBTITLE: 'subtitle',
+        },
+    },
 } as const;
 
 /** Upgrade intro feature ids from UPGRADE_FEATURE_INTRO_MAPPING for Submit workspace */

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -147,4 +147,5 @@ function Badge({
     );
 }
 
+export type {BadgeProps};
 export default Badge;

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,3 +1,27 @@
+import ActivityIndicator from '@components/ActivityIndicator';
+import Avatar from '@components/Avatar';
+import Badge from '@components/Badge';
+import {useIsCompactMenu} from '@components/CompactMenuContext';
+import CopyTextToClipboard from '@components/CopyTextToClipboard';
+import DisplayNames from '@components/DisplayNames';
+import type {DisplayNameWithTooltip} from '@components/DisplayNames/types';
+import FormHelpMessage from '@components/FormHelpMessage';
+import Hoverable from '@components/Hoverable';
+import type HoverableProps from '@components/Hoverable/types';
+import Icon from '@components/Icon';
+import InlineIcon from '@components/Icon/InlineIcon';
+import {useMenuItemGroupActions, useMenuItemGroupState} from '@components/MenuItemGroup';
+import PlaidCardFeedIcon from '@components/PlaidCardFeedIcon';
+import type {PressableRef} from '@components/Pressable/GenericPressable/types';
+import PressableWithSecondaryInteraction from '@components/PressableWithSecondaryInteraction';
+import RadioButton from '@components/RadioButton';
+import RenderHTML from '@components/RenderHTML';
+import ReportActionAvatars from '@components/ReportActionAvatars';
+import Text from '@components/Text';
+import EducationalTooltip from '@components/Tooltip/EducationalTooltip';
+import getContextMenuAccessibilityHint from '@components/utils/getContextMenuAccessibilityHint';
+import getContextMenuAccessibilityProps from '@components/utils/getContextMenuAccessibilityProps';
+
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -37,31 +61,6 @@ import type {ValueOf} from 'type-fest';
 
 import React, {useEffect, useMemo, useRef} from 'react';
 import {View} from 'react-native';
-
-import type {DisplayNameWithTooltip} from './DisplayNames/types';
-import type HoverableProps from './Hoverable/types';
-import type {PressableRef} from './Pressable/GenericPressable/types';
-
-import ActivityIndicator from './ActivityIndicator';
-import Avatar from './Avatar';
-import Badge from './Badge';
-import {useIsCompactMenu} from './CompactMenuContext';
-import CopyTextToClipboard from './CopyTextToClipboard';
-import DisplayNames from './DisplayNames';
-import FormHelpMessage from './FormHelpMessage';
-import Hoverable from './Hoverable';
-import Icon from './Icon';
-import InlineIcon from './Icon/InlineIcon';
-import {useMenuItemGroupActions, useMenuItemGroupState} from './MenuItemGroup';
-import PlaidCardFeedIcon from './PlaidCardFeedIcon';
-import PressableWithSecondaryInteraction from './PressableWithSecondaryInteraction';
-import RadioButton from './RadioButton';
-import RenderHTML from './RenderHTML';
-import ReportActionAvatars from './ReportActionAvatars';
-import Text from './Text';
-import EducationalTooltip from './Tooltip/EducationalTooltip';
-import getContextMenuAccessibilityHint from './utils/getContextMenuAccessibilityHint';
-import getContextMenuAccessibilityProps from './utils/getContextMenuAccessibilityProps';
 
 type IconProps = {
     /** Flag to choose between avatar image or an icon */

--- a/src/components/MenuItem/MenuItemContext.tsx
+++ b/src/components/MenuItem/MenuItemContext.tsx
@@ -1,0 +1,42 @@
+import {createContext, useContext} from 'react';
+
+/**
+ * Interaction state of the menu item row, provided by `<MenuItem>` (the Root) and consumed by leaf
+ * sub-components (e.g. `MenuItem.Icon` derives its fill color, `MenuItem.CopyButton` reveals itself on hover).
+ */
+type MenuItemState = {
+    /** Whether the row is currently hovered */
+    isHovered: boolean;
+
+    /** Whether the row is currently pressed */
+    isPressed: boolean;
+
+    /** Whether the row is focused/active (the selected-row state, not screen focus) */
+    isFocused: boolean;
+
+    /** Whether the row is disabled */
+    isDisabled: boolean;
+
+    /** Whether the row responds to interactions */
+    isInteractive: boolean;
+
+    /** Whether the row uses success (green) styling */
+    isSuccess: boolean;
+
+    /** Whether the row is rendered inside a compact popover menu */
+    isCompact: boolean;
+};
+
+const MenuItemContext = createContext<MenuItemState | undefined>(undefined);
+
+function useMenuItemState(): MenuItemState {
+    const state = useContext(MenuItemContext);
+    if (!state) {
+        throw new Error('MenuItem sub-components must be rendered inside <MenuItem>');
+    }
+    return state;
+}
+
+export default MenuItemContext;
+export {useMenuItemState};
+export type {MenuItemState};

--- a/src/components/MenuItem/compound.tsx
+++ b/src/components/MenuItem/compound.tsx
@@ -7,7 +7,7 @@
  *
  * @example Simple navigation row
  * ```tsx
- * import MenuItem from '@components/decomposition/MenuItem';
+ * import MenuItem from '@components/MenuItem/compound';
  *
  * <MenuItem onPress={onNavigate} accessibilityLabel={translate('common.settings')}>
  *     <MenuItem.Row>

--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -1,0 +1,117 @@
+/**
+ * MenuItem (compound)
+ *
+ * A composable decomposition of the classic `MenuItem`, following the composition-over-configuration
+ * pattern: instead of ~135 props configuring one monolith, the consumer assembles the row from
+ * sub-components and interaction state (hover/press/focus/disabled) is shared through context.
+ *
+ * @example Simple navigation row
+ * ```tsx
+ * import MenuItem from '@components/decomposition/MenuItem';
+ *
+ * <MenuItem onPress={onNavigate} accessibilityLabel={translate('common.settings')}>
+ *     <MenuItem.Row>
+ *         <MenuItem.Icon src={icons.Gear} />
+ *         <MenuItem.Content>
+ *             <MenuItem.Title>{translate('common.settings')}</MenuItem.Title>
+ *         </MenuItem.Content>
+ *         <MenuItem.Trailing>
+ *             <MenuItem.Chevron />
+ *         </MenuItem.Trailing>
+ *     </MenuItem.Row>
+ * </MenuItem>
+ * ```
+ *
+ * @example Field row with a description on top, an error below, and helper text outside the pressable
+ * ```tsx
+ * <MenuItem onPress={onEdit} accessibilityLabel={`${description}, ${title}`}>
+ *     <MenuItem.Row>
+ *         <MenuItem.Content>
+ *             <MenuItem.Description>{description}</MenuItem.Description>
+ *             <MenuItem.Title>{title}</MenuItem.Title>
+ *         </MenuItem.Content>
+ *         <MenuItem.Trailing>
+ *             <MenuItem.BrickRoadIndicator status={CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR} />
+ *             <MenuItem.Chevron />
+ *         </MenuItem.Trailing>
+ *     </MenuItem.Row>
+ *     <MenuItem.Error>{errorText}</MenuItem.Error>
+ * </MenuItem>
+ * <MenuItem.HelperText>{helperText}</MenuItem.HelperText>
+ * ```
+ *
+ * See README.md in this directory for the full design notes and the legacy-prop → composition mapping.
+ */
+import MenuItemContent from './layout/MenuItemContent';
+import MenuItemRoot from './layout/MenuItemRoot';
+import MenuItemRow from './layout/MenuItemRow';
+import MenuItemTrailing from './layout/MenuItemTrailing';
+import MenuItemAvatar from './leaves/leading/MenuItemAvatar';
+import MenuItemIcon from './leaves/leading/MenuItemIcon';
+import MenuItemError from './leaves/messages/MenuItemError';
+import MenuItemHelperText from './leaves/messages/MenuItemHelperText';
+import MenuItemHint from './leaves/messages/MenuItemHint';
+import MenuItemDescription from './leaves/text/MenuItemDescription';
+import MenuItemLabel from './leaves/text/MenuItemLabel';
+import MenuItemTitle from './leaves/text/MenuItemTitle';
+import MenuItemBadge from './leaves/trailing/MenuItemBadge';
+import MenuItemBrickRoadIndicator from './leaves/trailing/MenuItemBrickRoadIndicator';
+import MenuItemChevron from './leaves/trailing/MenuItemChevron';
+import MenuItemCopyButton from './leaves/trailing/MenuItemCopyButton';
+import MenuItemRightLabel from './leaves/trailing/MenuItemRightLabel';
+import {useMenuItemState} from './MenuItemContext';
+
+const MenuItem = Object.assign(MenuItemRoot, {
+    /** The main horizontal line holding the leading, content and trailing cells */
+    Row: MenuItemRow,
+
+    /** The flexible middle cell — stacks Title/Description (in any order) vertically */
+    Content: MenuItemContent,
+
+    /** The right-side cluster for indicators and actions */
+    Trailing: MenuItemTrailing,
+
+    /** Leading icon whose fill follows the row's interaction state */
+    Icon: MenuItemIcon,
+
+    /** Leading user/workspace avatar */
+    Avatar: MenuItemAvatar,
+
+    /** Small supporting label rendered above the main line */
+    Label: MenuItemLabel,
+
+    /** The (bold) title text */
+    Title: MenuItemTitle,
+
+    /** The supporting description text — above or below the title depending on declaration order */
+    Description: MenuItemDescription,
+
+    /** Badge that follows the row's focused state */
+    Badge: MenuItemBadge,
+
+    /** Right arrow (or custom) navigation indicator, dimmed until hovered */
+    Chevron: MenuItemChevron,
+
+    /** Right-aligned supporting text (covers legacy `rightLabel` and `subtitle`) */
+    RightLabel: MenuItemRightLabel,
+
+    /** Red/green dot signalling the row needs attention */
+    BrickRoadIndicator: MenuItemBrickRoadIndicator,
+
+    /** Hover-revealed copy-to-clipboard button (devices with hover support) */
+    CopyButton: MenuItemCopyButton,
+
+    /** Error message rendered under the main line (inside the pressable) */
+    Error: MenuItemError,
+
+    /** Hint message rendered under the main line (inside the pressable) */
+    Hint: MenuItemHint,
+
+    /** Non-interactive helper text — place it AFTER the root, outside the pressable */
+    HelperText: MenuItemHelperText,
+});
+
+export default MenuItem;
+export {useMenuItemState};
+export type {MenuItemRootProps} from './layout/MenuItemRoot';
+export type {MenuItemState} from './MenuItemContext';

--- a/src/components/MenuItem/layout/MenuItemContent.tsx
+++ b/src/components/MenuItem/layout/MenuItemContent.tsx
@@ -1,0 +1,36 @@
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import useStyleUtils from '@hooks/useStyleUtils';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemContentProps = {
+    /** The text blocks of the row (`MenuItem.Title`, `MenuItem.Description`, or any custom content),
+     * stacked vertically in the order they are declared */
+    children: ReactNode;
+
+    /** Any additional styles to apply to the content container */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The flexible middle cell of a `MenuItem.Row`. Stacks its children vertically and takes up all
+ * the horizontal space left over by the leading and trailing cells.
+ */
+function MenuItemContent({children, style}: MenuItemContentProps) {
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    const {isCompact} = useMenuItemState();
+
+    return <View style={[styles.justifyContentCenter, styles.flex1, styles.gap1, StyleUtils.getMenuItemTextContainerStyle(isCompact), style]}>{children}</View>;
+}
+
+MenuItemContent.displayName = 'MenuItemContent';
+
+export type {MenuItemContentProps};
+export default MenuItemContent;

--- a/src/components/MenuItem/layout/MenuItemRoot.tsx
+++ b/src/components/MenuItem/layout/MenuItemRoot.tsx
@@ -1,0 +1,229 @@
+import {useIsCompactMenu} from '@components/CompactMenuContext';
+import Hoverable from '@components/Hoverable';
+import MenuItemContext from '@components/MenuItem/MenuItemContext';
+import {useMenuItemGroupActions, useMenuItemGroupState} from '@components/MenuItemGroup';
+import type {PressableRef} from '@components/Pressable/GenericPressable/types';
+import PressableWithSecondaryInteraction from '@components/PressableWithSecondaryInteraction';
+
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useStyleUtils from '@hooks/useStyleUtils';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import getButtonState from '@libs/getButtonState';
+import mergeRefs from '@libs/mergeRefs';
+
+import variables from '@styles/variables';
+
+import {callFunctionIfActionIsAllowed} from '@userActions/Session';
+
+import CONST from '@src/CONST';
+import type WithSentryLabel from '@src/types/utils/SentryLabel';
+
+import type {ReactNode, Ref} from 'react';
+import type {GestureResponderEvent, Role, StyleProp, ViewStyle} from 'react-native';
+import type {AnimatedStyle} from 'react-native-reanimated';
+import type {ValueOf} from 'type-fest';
+
+import React, {useEffect, useRef} from 'react';
+import {View} from 'react-native';
+
+type MenuItemVariant = ValueOf<typeof CONST.MENU_ITEM.VARIANT>;
+
+type MenuItemRootProps = WithSentryLabel & {
+    /** Sub-components composing the row. Children stack vertically: place a `MenuItem.Row` for the main
+     * line, and full-width blocks (`MenuItem.Label`, `MenuItem.Error`, `MenuItem.Hint`) before/after it. */
+    children: ReactNode;
+
+    /** Reference to the pressable element */
+    ref?: PressableRef | Ref<View>;
+
+    /** Function to fire when the row is pressed */
+    onPress?: (event: GestureResponderEvent | KeyboardEvent) => void | Promise<void>;
+
+    /** The function that should be called when the row is long-pressed or right-clicked */
+    onSecondaryInteraction?: (event: GestureResponderEvent | MouseEvent) => void;
+
+    /** Handles what to do when the row is focused */
+    onFocus?: () => void;
+
+    /** Handles what to do when the row loses focus */
+    onBlur?: () => void;
+
+    /** Whether the row should be interactive at all */
+    interactive?: boolean;
+
+    /** Should we disable this row? */
+    disabled?: boolean;
+
+    /** Whether the row is focused or active (selected-row styling) */
+    focused?: boolean;
+
+    /** A boolean flag that gives the row (and its icon) a green fill if true */
+    success?: boolean;
+
+    /** Whether the screen containing the row is focused (forwarded to Hoverable) */
+    isScreenFocused?: boolean;
+
+    /** The action accepts anonymous users or not */
+    isAnonymousAction?: boolean;
+
+    /** Should check anonymous user in onPress function */
+    shouldCheckActionAllowedOnPress?: boolean;
+
+    /** Style variant. `section` gives the row the full-bleed hover look used inside a `Section`
+     * (horizontal padding + negative margins), replacing the classic `wrapperStyle={styles.sectionMenuItemTopDescription}`. */
+    variant?: MenuItemVariant;
+
+    /**
+     * Any additional styles to apply on the pressable element.
+     */
+    style?: StyleProp<ViewStyle>;
+
+    /** Wrapper styles */
+    wrapperStyle?: StyleProp<AnimatedStyle<ViewStyle>>;
+
+    /** Accessibility label for the row. Required: unlike the classic MenuItem, the chassis cannot derive it from composed children. */
+    accessibilityLabel: string;
+
+    /** Accessibility hint for the row */
+    accessibilityHint?: string;
+
+    /** The accessibility role to use for the row */
+    role?: Role;
+
+    /** Whether the row should be focusable with keyboard */
+    tabIndex?: 0 | -1;
+
+    /** Pressable component Test ID. Used to locate the component in tests. */
+    testID?: string;
+};
+
+function MenuItemRoot({
+    children,
+    ref,
+    onPress,
+    onSecondaryInteraction,
+    onFocus,
+    onBlur,
+    interactive = true,
+    disabled = false,
+    focused = false,
+    success = false,
+    isScreenFocused,
+    isAnonymousAction = false,
+    shouldCheckActionAllowedOnPress = true,
+    variant = CONST.MENU_ITEM.VARIANT.DEFAULT,
+    style,
+    wrapperStyle,
+    accessibilityLabel,
+    accessibilityHint,
+    role = CONST.ROLE.BUTTON,
+    tabIndex = 0,
+    testID,
+    sentryLabel,
+}: MenuItemRootProps) {
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {isSmallScreenWidth} = useResponsiveLayout();
+    const {isExecuting} = useMenuItemGroupState() ?? {};
+    const {singleExecution, waitForNavigate} = useMenuItemGroupActions() ?? {};
+    const pressableRef = useRef<View>(null);
+    const isCompactMenu = useIsCompactMenu();
+    const isCompact = isCompactMenu && !isSmallScreenWidth;
+
+    useEffect(() => {
+        const element = pressableRef.current;
+        if (interactive || !element || typeof HTMLElement === 'undefined' || !(element instanceof HTMLElement) || typeof element.onclick === 'undefined') {
+            return;
+        }
+        // React Native Web's Pressable always attaches an onClick handler to the DOM element.
+        // TalkBack on Android web uses the presence of a click event listener to determine whether
+        // an element is clickable and announces "double tap to activate" even for non-interactive elements.
+        // Removing the onclick property prevents TalkBack from treating the element as clickable.
+        element.onclick = null;
+    }, [interactive]);
+
+    const onPressAction = (event: GestureResponderEvent | KeyboardEvent | undefined) => {
+        if (disabled || !interactive) {
+            return;
+        }
+
+        if (event?.type === 'click' && typeof HTMLElement !== 'undefined' && event.currentTarget instanceof HTMLElement) {
+            event.currentTarget.blur();
+        }
+
+        if (!onPress || !event) {
+            return;
+        }
+
+        if (!singleExecution || !waitForNavigate) {
+            onPress(event);
+            return;
+        }
+        singleExecution(
+            waitForNavigate(() => {
+                onPress(event);
+            }),
+        )();
+    };
+
+    return (
+        <View onBlur={onBlur}>
+            <Hoverable isFocused={isScreenFocused}>
+                {(isHovered) => (
+                    <PressableWithSecondaryInteraction
+                        onPress={shouldCheckActionAllowedOnPress ? callFunctionIfActionIsAllowed(onPressAction, isAnonymousAction) : onPressAction}
+                        onSecondaryInteraction={onSecondaryInteraction}
+                        wrapperStyle={wrapperStyle}
+                        activeOpacity={!interactive ? 1 : variables.pressDimValue}
+                        opacityAnimationDuration={0}
+                        testID={testID}
+                        style={({pressed}) =>
+                            [
+                                styles.popoverMenuItem,
+                                !interactive && styles.cursorDefault,
+                                isCompact && styles.compactPopoverMenuItemBase,
+                                StyleUtils.getButtonBackgroundColorStyle(getButtonState(focused || isHovered, pressed, success, disabled, interactive), true),
+                                variant === CONST.MENU_ITEM.VARIANT.SECTION && styles.sectionMenuItemTopDescription,
+                                style,
+                                disabled && styles.buttonOpacityDisabled,
+                                isHovered && interactive && !focused && !pressed && styles.hoveredComponentBG,
+                            ] as StyleProp<ViewStyle>
+                        }
+                        disabled={disabled || isExecuting}
+                        ref={mergeRefs(ref, pressableRef)}
+                        role={interactive ? role : undefined}
+                        accessibilityLabel={accessibilityLabel}
+                        accessibilityHint={accessibilityHint}
+                        accessibilityState={role === CONST.ROLE.TAB ? {selected: focused} : undefined}
+                        tabIndex={interactive ? tabIndex : -1}
+                        onFocus={onFocus}
+                        sentryLabel={sentryLabel}
+                    >
+                        {({pressed}) => (
+                            <MenuItemContext.Provider
+                                value={{
+                                    isHovered,
+                                    isPressed: pressed,
+                                    isFocused: focused,
+                                    isDisabled: disabled,
+                                    isInteractive: interactive,
+                                    isSuccess: success,
+                                    isCompact,
+                                }}
+                            >
+                                <View style={styles.flex1}>{children}</View>
+                            </MenuItemContext.Provider>
+                        )}
+                    </PressableWithSecondaryInteraction>
+                )}
+            </Hoverable>
+        </View>
+    );
+}
+
+MenuItemRoot.displayName = 'MenuItemRoot';
+
+export type {MenuItemRootProps, MenuItemVariant};
+export default MenuItemRoot;

--- a/src/components/MenuItem/layout/MenuItemRow.tsx
+++ b/src/components/MenuItem/layout/MenuItemRow.tsx
@@ -1,0 +1,33 @@
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemRowProps = {
+    /** The main-line cells: `MenuItem.Icon`/`MenuItem.Avatar`, `MenuItem.Content`, `MenuItem.Trailing` */
+    children: ReactNode;
+
+    /** Any additional styles to apply to the row */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The main horizontal line of a menu item. A plain flex row — it never inspects its children;
+ * the consumer decides which cells to include and in what order.
+ */
+function MenuItemRow({children, style}: MenuItemRowProps) {
+    const styles = useThemeStyles();
+    const {isDisabled, isCompact} = useMenuItemState();
+
+    return <View style={[styles.flexRow, styles.pointerEventsAuto, styles.gap3, isDisabled && styles.cursorDisabled, isCompact && styles.alignItemsCenter, style]}>{children}</View>;
+}
+
+MenuItemRow.displayName = 'MenuItemRow';
+
+export type {MenuItemRowProps};
+export default MenuItemRow;

--- a/src/components/MenuItem/layout/MenuItemTrailing.tsx
+++ b/src/components/MenuItem/layout/MenuItemTrailing.tsx
@@ -1,0 +1,36 @@
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import useStyleUtils from '@hooks/useStyleUtils';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemTrailingProps = {
+    /** The right-aligned cells (`MenuItem.Badge`, `MenuItem.RightLabel`, `MenuItem.BrickRoadIndicator`,
+     * `MenuItem.Chevron`, `MenuItem.CopyButton`, or any custom content), laid out horizontally */
+    children: ReactNode;
+
+    /** Any additional styles to apply to the trailing container */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The right-side cell of a `MenuItem.Row`. A horizontal cluster for indicators and actions —
+ * the consumer decides which to include and in what order.
+ */
+function MenuItemTrailing({children, style}: MenuItemTrailingProps) {
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    const {isCompact} = useMenuItemState();
+
+    return <View style={[styles.flexRow, styles.mlAuto, styles.alignItemsCenter, styles.gap2, StyleUtils.getMenuItemTextContainerStyle(isCompact), style]}>{children}</View>;
+}
+
+MenuItemTrailing.displayName = 'MenuItemTrailing';
+
+export type {MenuItemTrailingProps};
+export default MenuItemTrailing;

--- a/src/components/MenuItem/leaves/leading/MenuItemAvatar.tsx
+++ b/src/components/MenuItem/leaves/leading/MenuItemAvatar.tsx
@@ -1,0 +1,68 @@
+import Avatar from '@components/Avatar';
+
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useStyleUtils from '@hooks/useStyleUtils';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {AvatarSource} from '@libs/UserAvatarUtils';
+
+import CONST from '@src/CONST';
+import type IconAsset from '@src/types/utils/IconAsset';
+
+import type {StyleProp, ViewStyle} from 'react-native';
+import type {ValueOf} from 'type-fest';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemAvatarProps = {
+    /** The source of the avatar image */
+    source: AvatarSource;
+
+    /** Denotes whether it is an avatar or a workspace avatar */
+    type?: typeof CONST.ICON_TYPE_AVATAR | typeof CONST.ICON_TYPE_WORKSPACE;
+
+    /** Account id if it's a user avatar or policy id if it's a workspace avatar */
+    avatarID?: number | string;
+
+    /** A fallback avatar icon to display when there is an error on loading avatar from remote URL */
+    fallbackIcon?: IconAsset;
+
+    /** The size of the avatar */
+    size?: ValueOf<typeof CONST.AVATAR_SIZE>;
+
+    /** Owner name, used as the avatar fallback name */
+    name?: string;
+
+    /** Any additional styles to apply to the avatar container */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The leading avatar cell of a `MenuItem.Row`. Use instead of `MenuItem.Icon` when the row
+ * represents a user or a workspace.
+ */
+function MenuItemAvatar({source, type = CONST.ICON_TYPE_AVATAR, avatarID, fallbackIcon, size = CONST.AVATAR_SIZE.DEFAULT, name, style}: MenuItemAvatarProps) {
+    const icons = useMemoizedLazyExpensifyIcons(['FallbackAvatar']);
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+
+    return (
+        <View style={[styles.popoverMenuIcon, StyleUtils.getAvatarWidthStyle(size), style]}>
+            <Avatar
+                imageStyles={[styles.alignSelfCenter]}
+                source={source}
+                avatarID={avatarID}
+                fallbackIcon={fallbackIcon ?? icons.FallbackAvatar}
+                size={size}
+                name={name}
+                type={type}
+            />
+        </View>
+    );
+}
+
+MenuItemAvatar.displayName = 'MenuItemAvatar';
+
+export type {MenuItemAvatarProps};
+export default MenuItemAvatar;

--- a/src/components/MenuItem/leaves/leading/MenuItemIcon.tsx
+++ b/src/components/MenuItem/leaves/leading/MenuItemIcon.tsx
@@ -1,0 +1,98 @@
+import Icon from '@components/Icon';
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import useStyleUtils from '@hooks/useStyleUtils';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import getButtonState from '@libs/getButtonState';
+
+import CONST from '@src/CONST';
+import type IconAsset from '@src/types/utils/IconAsset';
+
+import type {ImageContentFit} from 'expo-image';
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemIconVariant = (typeof CONST.MENU_ITEM.ICON_VARIANT)[keyof typeof CONST.MENU_ITEM.ICON_VARIANT];
+
+type MenuItemIconProps = {
+    /** Icon to display */
+    src: IconAsset;
+
+    /** The fill color to pass into the icon. When omitted, the fill follows the row's interaction state
+     * (hovered/pressed/focused/disabled), matching the classic MenuItem behavior. */
+    fill?: string | ((isHovered: boolean) => string);
+
+    /** Icon width */
+    width?: number;
+
+    /** Icon height */
+    height?: number;
+
+    /** Icon should be displayed in its own color (e.g. multi-color illustrations) */
+    displayInDefaultIconColor?: boolean;
+
+    /** Determines how the icon should be resized to fit its container */
+    contentFit?: ImageContentFit;
+
+    /** Container variant. `default` reserves the classic fixed-width cell; `compact` hugs the icon.
+     * Rows inside a compact menu are compact regardless of this prop. */
+    variant?: MenuItemIconVariant;
+
+    /** Any additional styles to apply to the icon container */
+    style?: StyleProp<ViewStyle>;
+
+    /** Additional styles to pass to the icon itself */
+    iconStyle?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The leading icon cell of a `MenuItem.Row`. Reads hover/press/focus state from the menu item
+ * context to derive its fill color, exactly like the classic MenuItem left icon.
+ */
+function MenuItemIcon({
+    src,
+    fill,
+    width,
+    height,
+    displayInDefaultIconColor = false,
+    contentFit = 'cover',
+    variant = CONST.MENU_ITEM.ICON_VARIANT.DEFAULT,
+    style,
+    iconStyle,
+}: MenuItemIconProps) {
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    const {isHovered, isPressed, isFocused, isDisabled, isInteractive, isSuccess, isCompact} = useMenuItemState();
+
+    let iconFill: string | undefined;
+    if (!displayInDefaultIconColor) {
+        if (typeof fill === 'function') {
+            iconFill = fill(isHovered);
+        } else {
+            iconFill = fill ?? StyleUtils.getIconFillColor(getButtonState(isFocused || isHovered, isPressed, isSuccess, isDisabled, isInteractive), true, true);
+        }
+    }
+
+    return (
+        <View style={[styles.popoverMenuIcon, (isCompact || variant === CONST.MENU_ITEM.ICON_VARIANT.COMPACT) && styles.popoverMenuIconCompact, style]}>
+            <Icon
+                contentFit={contentFit}
+                hovered={isHovered}
+                pressed={isPressed}
+                src={src}
+                width={width}
+                height={height}
+                fill={iconFill}
+                additionalStyles={iconStyle}
+            />
+        </View>
+    );
+}
+
+MenuItemIcon.displayName = 'MenuItemIcon';
+
+export type {MenuItemIconProps};
+export default MenuItemIcon;

--- a/src/components/MenuItem/leaves/messages/MenuItemError.tsx
+++ b/src/components/MenuItem/leaves/messages/MenuItemError.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import type {MenuItemFormMessageProps} from './MenuItemFormMessage';
+
+import MenuItemFormMessage from './MenuItemFormMessage';
+
+type MenuItemErrorProps = Omit<MenuItemFormMessageProps, 'isError'>;
+
+/**
+ * An error message block. Place it inside the Root, after `MenuItem.Row`, to render it under the main line.
+ */
+function MenuItemError({children, shouldShowRedDotIndicator = false, shouldRenderAsHTML, style}: MenuItemErrorProps) {
+    return (
+        <MenuItemFormMessage
+            isError
+            shouldShowRedDotIndicator={shouldShowRedDotIndicator}
+            shouldRenderAsHTML={shouldRenderAsHTML}
+            style={style}
+        >
+            {children}
+        </MenuItemFormMessage>
+    );
+}
+
+MenuItemError.displayName = 'MenuItemError';
+
+export type {MenuItemErrorProps};
+export default MenuItemError;

--- a/src/components/MenuItem/leaves/messages/MenuItemFormMessage.tsx
+++ b/src/components/MenuItem/leaves/messages/MenuItemFormMessage.tsx
@@ -1,0 +1,47 @@
+import FormHelpMessage from '@components/FormHelpMessage';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+
+type MenuItemFormMessageProps = {
+    /** The message to display */
+    children: string | ReactNode;
+
+    /** Whether the message is styled as an error */
+    isError: boolean;
+
+    /** Should the red dot indicator be shown next to the message */
+    shouldShowRedDotIndicator?: boolean;
+
+    /** Whether the message should be rendered as HTML */
+    shouldRenderAsHTML?: boolean;
+
+    /** Any additional styles to apply to the message */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Shared internals of `MenuItem.Error` and `MenuItem.Hint` — not exported from the barrel.
+ */
+function MenuItemFormMessage({children, isError, shouldShowRedDotIndicator = false, shouldRenderAsHTML = false, style}: MenuItemFormMessageProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <FormHelpMessage
+            isError={isError}
+            shouldShowRedDotIndicator={shouldShowRedDotIndicator}
+            message={children}
+            style={[styles.menuItemError, style]}
+            shouldRenderMessageAsHTML={shouldRenderAsHTML}
+        />
+    );
+}
+
+MenuItemFormMessage.displayName = 'MenuItemFormMessage';
+
+export type {MenuItemFormMessageProps};
+export default MenuItemFormMessage;

--- a/src/components/MenuItem/leaves/messages/MenuItemHelperText.tsx
+++ b/src/components/MenuItem/leaves/messages/MenuItemHelperText.tsx
@@ -1,0 +1,31 @@
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, TextStyle} from 'react-native';
+
+import React from 'react';
+
+type MenuItemHelperTextProps = {
+    /** The helper text */
+    children?: ReactNode;
+
+    /** Any additional styles to apply to the helper text */
+    style?: StyleProp<TextStyle>;
+};
+
+/**
+ * Non-interactive helper text. Place it as a sibling AFTER the Root — it lives outside of the
+ * pressable/hoverable area and therefore does not consume the menu item context.
+ */
+function MenuItemHelperText({children, style}: MenuItemHelperTextProps) {
+    const styles = useThemeStyles();
+
+    return <Text style={[styles.mutedNormalTextLabel, styles.ph5, styles.pb5, style]}>{children}</Text>;
+}
+
+MenuItemHelperText.displayName = 'MenuItemHelperText';
+
+export type {MenuItemHelperTextProps};
+export default MenuItemHelperText;

--- a/src/components/MenuItem/leaves/messages/MenuItemHint.tsx
+++ b/src/components/MenuItem/leaves/messages/MenuItemHint.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import type {MenuItemFormMessageProps} from './MenuItemFormMessage';
+
+import MenuItemFormMessage from './MenuItemFormMessage';
+
+type MenuItemHintProps = Omit<MenuItemFormMessageProps, 'isError' | 'shouldShowRedDotIndicator'>;
+
+/**
+ * A non-error hint message block. Place it inside the Root, after `MenuItem.Row`, to render it under the main line.
+ */
+function MenuItemHint({children, shouldRenderAsHTML, style}: MenuItemHintProps) {
+    return (
+        <MenuItemFormMessage
+            isError={false}
+            shouldShowRedDotIndicator={false}
+            shouldRenderAsHTML={shouldRenderAsHTML}
+            style={style}
+        >
+            {children}
+        </MenuItemFormMessage>
+    );
+}
+
+MenuItemHint.displayName = 'MenuItemHint';
+
+export type {MenuItemHintProps};
+export default MenuItemHint;

--- a/src/components/MenuItem/leaves/text/MenuItemDescription.tsx
+++ b/src/components/MenuItem/leaves/text/MenuItemDescription.tsx
@@ -1,0 +1,55 @@
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, TextStyle} from 'react-native';
+
+import React from 'react';
+
+type MenuItemDescriptionVariant = (typeof CONST.MENU_ITEM.DESCRIPTION_VARIANT)[keyof typeof CONST.MENU_ITEM.DESCRIPTION_VARIANT];
+
+type MenuItemDescriptionProps = {
+    /** The description text */
+    children?: ReactNode;
+
+    /** Used to truncate the description with an ellipsis after computing the text layout */
+    numberOfLines?: number;
+
+    /** Typography variant. `supporting` (default) is the small label look; `prominent` bumps the font
+     * to the normal size — use it for description-only rows (no title), matching the classic MenuItem. */
+    variant?: MenuItemDescriptionVariant;
+
+    /** Any additional styles to apply to the description */
+    style?: StyleProp<TextStyle>;
+};
+
+/**
+ * The supporting text block of a `MenuItem.Content`. Place it before or after `MenuItem.Title`
+ * to render the description above or below the title.
+ */
+function MenuItemDescription({children, numberOfLines = 2, variant = CONST.MENU_ITEM.DESCRIPTION_VARIANT.SUPPORTING, style}: MenuItemDescriptionProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <Text
+            style={[
+                styles.textLabelSupporting,
+                styles.textLineHeightNormal,
+                styles.breakWord,
+                variant === CONST.MENU_ITEM.DESCRIPTION_VARIANT.PROMINENT && styles.textSupportingNormal,
+                style,
+            ]}
+            numberOfLines={numberOfLines}
+        >
+            {children}
+        </Text>
+    );
+}
+
+MenuItemDescription.displayName = 'MenuItemDescription';
+
+export type {MenuItemDescriptionProps, MenuItemDescriptionVariant};
+export default MenuItemDescription;

--- a/src/components/MenuItem/leaves/text/MenuItemLabel.tsx
+++ b/src/components/MenuItem/leaves/text/MenuItemLabel.tsx
@@ -1,0 +1,35 @@
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemLabelProps = {
+    /** The label text */
+    children?: string;
+
+    /** Any additional styles to apply to the label container */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * A small supporting label. Place it inside the Root (before `MenuItem.Row`) to render it above the
+ * main line within the pressable/hoverable area, or before the Root to keep it outside of it.
+ */
+function MenuItemLabel({children, style}: MenuItemLabelProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <View style={style}>
+            <Text style={[styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting, styles.pre]}>{children}</Text>
+        </View>
+    );
+}
+
+MenuItemLabel.displayName = 'MenuItemLabel';
+
+export type {MenuItemLabelProps};
+export default MenuItemLabel;

--- a/src/components/MenuItem/leaves/text/MenuItemTitle.tsx
+++ b/src/components/MenuItem/leaves/text/MenuItemTitle.tsx
@@ -1,0 +1,61 @@
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import convertToLTR from '@libs/convertToLTR';
+
+import CONST from '@src/CONST';
+
+import type {ReactNode} from 'react';
+import type {StyleProp, TextStyle} from 'react-native';
+
+import React from 'react';
+
+type MenuItemTitleVariant = (typeof CONST.MENU_ITEM.TITLE_VARIANT)[keyof typeof CONST.MENU_ITEM.TITLE_VARIANT];
+
+type MenuItemTitleProps = {
+    /** The title text. Strings are converted to LTR; custom nodes are rendered as-is. */
+    children?: ReactNode;
+
+    /** Used to truncate the text with an ellipsis after computing the text layout */
+    numberOfLines?: number;
+
+    /** Font weight variant. `strong` (default) is bold; `normal` uses the default weight. */
+    variant?: MenuItemTitleVariant;
+
+    /** Any additional styles to apply to the title (e.g. pass a non-bold text style for a basic title) */
+    style?: StyleProp<TextStyle>;
+};
+
+/**
+ * The title block of a `MenuItem.Content`. Bold by default, single line by default.
+ */
+function MenuItemTitle({children, numberOfLines = 1, variant = CONST.MENU_ITEM.TITLE_VARIANT.STRONG, style}: MenuItemTitleProps) {
+    const styles = useThemeStyles();
+    const {isDisabled, isInteractive} = useMenuItemState();
+
+    return (
+        <Text
+            style={[
+                styles.flexShrink1,
+                styles.popoverMenuText,
+                variant === CONST.MENU_ITEM.TITLE_VARIANT.STRONG && styles.textStrong,
+                numberOfLines !== 1 ? styles.preWrap : styles.pre,
+                isInteractive && isDisabled && styles.userSelectNone,
+                styles.ltr,
+                styles.mw100,
+                style,
+            ]}
+            numberOfLines={numberOfLines || undefined}
+            dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: isInteractive && isDisabled}}
+        >
+            {typeof children === 'string' ? convertToLTR(children) : children}
+        </Text>
+    );
+}
+
+MenuItemTitle.displayName = 'MenuItemTitle';
+
+export type {MenuItemTitleProps, MenuItemTitleVariant};
+export default MenuItemTitle;

--- a/src/components/MenuItem/leaves/trailing/MenuItemBadge.tsx
+++ b/src/components/MenuItem/leaves/trailing/MenuItemBadge.tsx
@@ -1,0 +1,29 @@
+import Badge from '@components/Badge';
+import type {BadgeProps} from '@components/Badge';
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import React from 'react';
+
+/**
+ * A `Badge` that follows the menu item's focused state. Placement is up to the consumer:
+ * inside `MenuItem.Trailing` (right), inside `MenuItem.Content` (below the title), or as a
+ * direct child of the Root (its own row).
+ */
+function MenuItemBadge({badgeStyles, pressable, ...rest}: BadgeProps) {
+    const styles = useThemeStyles();
+    const {isFocused} = useMenuItemState();
+
+    return (
+        <Badge
+            {...rest}
+            badgeStyles={[badgeStyles, isFocused && !rest.success && styles.badgeDefaultActive]}
+            pressable={pressable ?? !!rest.onPress}
+        />
+    );
+}
+
+MenuItemBadge.displayName = 'MenuItemBadge';
+
+export default MenuItemBadge;

--- a/src/components/MenuItem/leaves/trailing/MenuItemBrickRoadIndicator.tsx
+++ b/src/components/MenuItem/leaves/trailing/MenuItemBrickRoadIndicator.tsx
@@ -1,0 +1,40 @@
+import Icon from '@components/Icon';
+
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
+
+import type {ValueOf} from 'type-fest';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemBrickRoadIndicatorProps = {
+    /** The type of brick road indicator to show */
+    status: ValueOf<typeof CONST.BRICK_ROAD_INDICATOR_STATUS>;
+};
+
+/**
+ * The red/green dot indicator cell for `MenuItem.Trailing`, signalling that the row needs attention.
+ */
+function MenuItemBrickRoadIndicator({status}: MenuItemBrickRoadIndicatorProps) {
+    const icons = useMemoizedLazyExpensifyIcons(['DotIndicator']);
+    const theme = useTheme();
+    const styles = useThemeStyles();
+
+    return (
+        <View style={[styles.alignItemsCenter, styles.justifyContentCenter]}>
+            <Icon
+                src={icons.DotIndicator}
+                fill={status === CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR ? theme.danger : theme.success}
+            />
+        </View>
+    );
+}
+
+MenuItemBrickRoadIndicator.displayName = 'MenuItemBrickRoadIndicator';
+
+export type {MenuItemBrickRoadIndicatorProps};
+export default MenuItemBrickRoadIndicator;

--- a/src/components/MenuItem/leaves/trailing/MenuItemChevron.tsx
+++ b/src/components/MenuItem/leaves/trailing/MenuItemChevron.tsx
@@ -1,0 +1,65 @@
+import Icon from '@components/Icon';
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useStyleUtils from '@hooks/useStyleUtils';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import getButtonState from '@libs/getButtonState';
+
+import variables from '@styles/variables';
+
+import type IconAsset from '@src/types/utils/IconAsset';
+
+import type {StyleProp, ViewStyle} from 'react-native';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemChevronProps = {
+    /** Overrides the default right arrow icon (e.g. NewWindow for external links) */
+    src?: IconAsset;
+
+    /** Any additional styles to apply to the chevron container */
+    style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * The trailing navigation indicator of a `MenuItem.Row`. Renders a right arrow by default,
+ * dimmed until the row is hovered — matching the classic MenuItem right icon.
+ */
+function MenuItemChevron({src, style}: MenuItemChevronProps) {
+    const icons = useMemoizedLazyExpensifyIcons(['ArrowRight']);
+    const theme = useTheme();
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    const {isHovered, isPressed, isFocused, isDisabled, isInteractive, isSuccess} = useMenuItemState();
+
+    const isDefaultChevron = !src || src === icons.ArrowRight;
+
+    return (
+        <View
+            style={[
+                styles.pointerEventsAuto,
+                StyleUtils.getMenuItemIconStyle(true),
+                isDisabled && styles.cursorDisabled,
+                !isHovered && isDefaultChevron && styles.opacitySemiTransparent,
+                styles.alignItemsEnd,
+                style,
+            ]}
+        >
+            <Icon
+                src={src ?? icons.ArrowRight}
+                fill={isDefaultChevron ? theme.icon : StyleUtils.getIconFillColor(getButtonState(isFocused || isHovered, isPressed, isSuccess, isDisabled, isInteractive))}
+                width={variables.iconSizeNormal}
+                height={variables.iconSizeNormal}
+            />
+        </View>
+    );
+}
+
+MenuItemChevron.displayName = 'MenuItemChevron';
+
+export type {MenuItemChevronProps};
+export default MenuItemChevron;

--- a/src/components/MenuItem/leaves/trailing/MenuItemCopyButton.tsx
+++ b/src/components/MenuItem/leaves/trailing/MenuItemCopyButton.tsx
@@ -1,0 +1,47 @@
+import CopyTextToClipboard from '@components/CopyTextToClipboard';
+import {useMenuItemState} from '@components/MenuItem/MenuItemContext';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import {hasHoverSupport} from '@libs/DeviceCapabilities';
+
+import CONST from '@src/CONST';
+
+import React from 'react';
+import {View} from 'react-native';
+
+type MenuItemCopyButtonProps = {
+    /** The value to copy to the clipboard */
+    value: string;
+};
+
+/**
+ * A hover-revealed copy-to-clipboard button for `MenuItem.Trailing` on devices with hover support.
+ * On touch devices, wire copying through `onSecondaryInteraction` on the Root instead.
+ */
+function MenuItemCopyButton({value}: MenuItemCopyButtonProps) {
+    const styles = useThemeStyles();
+    const {isHovered} = useMenuItemState();
+
+    if (!isHovered || !hasHoverSupport()) {
+        return null;
+    }
+
+    return (
+        <View style={styles.justifyContentCenter}>
+            <CopyTextToClipboard
+                urlToCopy={value}
+                shouldHaveActiveBackground
+                iconSize={CONST.ICON_SIZE.EXTRA_SMALL}
+                iconStyles={styles.t0}
+                styles={styles.reportActionContextMenuMiniButton}
+                shouldUseButtonBackground
+            />
+        </View>
+    );
+}
+
+MenuItemCopyButton.displayName = 'MenuItemCopyButton';
+
+export type {MenuItemCopyButtonProps};
+export default MenuItemCopyButton;

--- a/src/components/MenuItem/leaves/trailing/MenuItemRightLabel.tsx
+++ b/src/components/MenuItem/leaves/trailing/MenuItemRightLabel.tsx
@@ -1,0 +1,42 @@
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
+
+import type {StyleProp, TextStyle} from 'react-native';
+
+import React from 'react';
+
+type MenuItemRightLabelVariant = (typeof CONST.MENU_ITEM.RIGHT_LABEL_VARIANT)[keyof typeof CONST.MENU_ITEM.RIGHT_LABEL_VARIANT];
+
+type MenuItemRightLabelProps = {
+    /** The label text. Numbers are allowed so that 0 renders too (e.g. counters). */
+    children?: string | number;
+
+    /** Style variant. `label` (default) is the classic `rightLabel` look; `subtitle` is the classic `subtitle` look. */
+    variant?: MenuItemRightLabelVariant;
+
+    /** Any additional styles to apply to the label */
+    style?: StyleProp<TextStyle>;
+};
+
+/**
+ * A right-aligned supporting text cell for `MenuItem.Trailing` — covers both the classic
+ * `rightLabel` and `subtitle` use cases.
+ */
+function MenuItemRightLabel({children, variant = CONST.MENU_ITEM.RIGHT_LABEL_VARIANT.LABEL, style}: MenuItemRightLabelProps) {
+    const styles = useThemeStyles();
+
+    // Numbers must render too, so only bail out on undefined/null/empty string
+    if (children === undefined || children === null || children === '') {
+        return null;
+    }
+
+    return <Text style={[styles.rightLabelMenuItem, variant === CONST.MENU_ITEM.RIGHT_LABEL_VARIANT.SUBTITLE && styles.textLabelSupporting, style]}>{children}</Text>;
+}
+
+MenuItemRightLabel.displayName = 'MenuItemRightLabel';
+
+export type {MenuItemRightLabelProps, MenuItemRightLabelVariant};
+export default MenuItemRightLabel;

--- a/src/pages/settings/InitialSettingsPage.tsx
+++ b/src/pages/settings/InitialSettingsPage.tsx
@@ -94,19 +94,10 @@ type MenuData = WithSentryLabel & {
     brickRoadIndicator?: ValueOf<typeof CONST.BRICK_ROAD_INDICATOR_STATUS>;
     action: () => void;
     link?: string | (() => Promise<string>);
-    iconType?: typeof CONST.ICON_TYPE_ICON | typeof CONST.ICON_TYPE_AVATAR | typeof CONST.ICON_TYPE_WORKSPACE;
-    iconStyles?: StyleProp<ViewStyle>;
-    fallbackIcon?: IconAsset;
-    shouldStackHorizontally?: boolean;
-    avatarSize?: ValueOf<typeof CONST.AVATAR_SIZE>;
-    floatRightAvatars?: TIcon[];
     title?: string;
-    shouldShowRightIcon?: boolean;
     iconRight?: IconAsset;
     badgeText?: string;
-    badgeStyle?: ViewStyle;
     isBadgeSuccess?: boolean;
-    isBadgeStrong?: boolean;
     isBadgeCondensed?: boolean;
 };
 
@@ -414,7 +405,6 @@ function InitialSettingsPage({currentUserPersonalDetails}: InitialSettingsPagePr
                 translationKey: 'initialSettingsPage.whatIsNew',
                 icon: icons.TreasureChest,
                 iconRight: icons.NewWindow,
-                shouldShowRightIcon: true,
                 sentryLabel: CONST.SENTRY_LABEL.SETTINGS_GENERAL.WHATS_NEW,
                 link: CONST.WHATS_NEW_URL,
                 action: () => {

--- a/src/pages/settings/SettingsMenuItem.tsx
+++ b/src/pages/settings/SettingsMenuItem.tsx
@@ -1,4 +1,8 @@
-import MenuItem from '@components/MenuItem';
+import MenuItem from '@components/MenuItem/compound';
+import getContextMenuAccessibilityHint from '@components/utils/getContextMenuAccessibilityHint';
+import getContextMenuAccessibilityProps from '@components/utils/getContextMenuAccessibilityProps';
+
+import useLocalize from '@hooks/useLocalize';
 
 import {showContextMenu} from '@pages/inbox/report/ContextMenu/ReportActionContextMenu';
 
@@ -21,6 +25,7 @@ type SettingsMenuItemProps = {
 };
 
 function SettingsMenuItem({item, isFocused, keyTitle, isExecuting, isScreenFocused, onPress, wrapperStyle}: SettingsMenuItemProps) {
+    const {translate} = useLocalize();
     const popoverAnchor = useRef(null);
 
     const onSecondaryInteraction = item.link
@@ -49,35 +54,48 @@ function SettingsMenuItem({item, isFocused, keyTitle, isExecuting, isScreenFocus
           }
         : undefined;
 
+    const combinedAccessibilityLabel = [keyTitle, item.brickRoadIndicator ? translate('common.yourReviewIsRequired') : ''].filter(Boolean).join('. ');
+    const contextMenuHint = item.link ? getContextMenuAccessibilityHint({translate}) : undefined;
+    const {accessibilityLabel, accessibilityHint} = getContextMenuAccessibilityProps({accessibilityLabel: combinedAccessibilityLabel, contextMenuHint});
+
+    const hasTrailing = !!item.badgeText || !!item.brickRoadIndicator || !!item.iconRight;
+
     return (
         <MenuItem
-            wrapperStyle={wrapperStyle}
-            title={keyTitle}
-            icon={item.icon}
-            iconType={item.iconType}
-            disabled={isExecuting}
-            onPress={onPress}
-            iconStyles={item.iconStyles}
-            badgeText={item.badgeText}
-            badgeStyle={item.badgeStyle}
-            isBadgeSuccess={item.isBadgeSuccess}
-            isBadgeStrong={item.isBadgeStrong}
-            isBadgeCondensed={item.isBadgeCondensed}
-            fallbackIcon={item.fallbackIcon}
-            brickRoadIndicator={item.brickRoadIndicator}
-            shouldStackHorizontally={item.shouldStackHorizontally}
             ref={popoverAnchor}
-            shouldBlockSelection={!!item.link}
+            style={wrapperStyle}
+            onPress={onPress}
             onSecondaryInteraction={onSecondaryInteraction}
-            shouldShowContextMenuHint={!!item.link}
+            disabled={isExecuting}
             focused={isFocused}
             role={CONST.ROLE.TAB}
-            isPaneMenu
+            accessibilityLabel={accessibilityLabel}
+            accessibilityHint={accessibilityHint}
             sentryLabel={item.sentryLabel}
-            iconRight={item.iconRight}
-            shouldShowRightIcon={item.shouldShowRightIcon}
-            shouldIconUseAutoWidthStyle
-        />
+        >
+            <MenuItem.Row>
+                <MenuItem.Icon
+                    src={item.icon}
+                    variant={CONST.MENU_ITEM.ICON_VARIANT.COMPACT}
+                />
+                <MenuItem.Content>
+                    <MenuItem.Title>{keyTitle}</MenuItem.Title>
+                </MenuItem.Content>
+                {hasTrailing && (
+                    <MenuItem.Trailing>
+                        {!!item.badgeText && (
+                            <MenuItem.Badge
+                                text={item.badgeText}
+                                success={item.isBadgeSuccess}
+                                isCondensed={item.isBadgeCondensed}
+                            />
+                        )}
+                        {!!item.brickRoadIndicator && <MenuItem.BrickRoadIndicator status={item.brickRoadIndicator} />}
+                        {!!item.iconRight && <MenuItem.Chevron src={item.iconRight} />}
+                    </MenuItem.Trailing>
+                )}
+            </MenuItem.Row>
+        </MenuItem>
     );
 }
 

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1990,6 +1990,11 @@ const staticStyles = (theme: ThemeColors) =>
             alignItems: 'center',
         },
 
+        popoverMenuIconCompact: {
+            justifyContent: 'center',
+            alignItems: 'center',
+        },
+
         popoverIconCircle: {
             backgroundColor: theme.buttonDefaultBG,
             borderRadius: variables.buttonBorderRadius,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1991,8 +1991,7 @@ const staticStyles = (theme: ThemeColors) =>
         },
 
         popoverMenuIconCompact: {
-            justifyContent: 'center',
-            alignItems: 'center',
+            width: variables.iconSizeNormal,
         },
 
         popoverIconCircle: {


### PR DESCRIPTION
### Explanation of Change

Decomposes the monolithic `MenuItem` (~135 props) into a composable compound component. Consumers now assemble a row from sub-components (`MenuItem.Row`, `.Icon`, `.Avatar`, `.Content`, `.Title`, `.Description`, `.Trailing`, `.Chevron`, `.BrickRoadIndicator`, etc.), with interaction state (hover/press/focus/disabled) shared via `MenuItemContext`. Moves `MenuItem` into its own directory and migrates `SettingsMenuItem` to the new pattern as the first consumer.

### Fixed Issues

$ https://github.com/Expensify/App/issues/96202
PROPOSAL:


### Tests

1. Open the app and navigate to **Settings** (bottom tab / account menu).
2. Verify the settings menu rows render correctly: leading avatar/icon, title, description, trailing chevron, and any brick-road indicators or badges are aligned and styled as before.
3. Hover over a settings row (web/desktop) and verify hover styling applies (icon fill, chevron reveal, row background).
4. Press a settings row and verify it navigates to the expected screen and the pressed styling appears.
5. Verify a row that shows an error/brick-road indicator still displays the red/green dot and any error text.

### Offline tests

N/A

### QA Steps

Same as tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
