### PR TITLE
[No QA] feat(mfa): add credential creation to the state machine

### DIFF
--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -17,6 +17,7 @@ import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxVa
 import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
 
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 import type {ReactNode} from 'react';
 
@@ -43,8 +44,8 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
     const [snapshot, send] = useInspectedMachine(MFAMachine);
     const state = snapshotToState(snapshot);
 
-    const captureCredentialsState = async (): Promise<CredentialsState> => {
-        const [hasLocalCredentials, deviceBiometrics] = await Promise.all([biometrics.areLocalCredentialsKnownToServer(), readOnyxValueOnce(getDeviceBiometricsOnyxKey(accountID))]);
+    const captureCredentialsState = async (flowAccountID: number): Promise<CredentialsState> => {
+        const [hasLocalCredentials, deviceBiometrics] = await Promise.all([biometrics.areLocalCredentialsKnownToServer(), readOnyxValueOnce(getDeviceBiometricsOnyxKey(flowAccountID))]);
         return {
             hasServerCredentials: biometrics.serverKnownCredentialIDs.length > 0,
             hasLocalCredentials,
@@ -72,7 +73,17 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             return;
         }
 
-        const startCredentialsState = await captureCredentialsState();
+        const flowAccountID = accountID;
+        const startCredentialsState = await captureCredentialsState(flowAccountID);
+
+        // A session switch can happen while the asynchronous credential snapshot is being read. Read
+        // the source of truth again immediately before INIT so stale account data never starts a flow.
+        const currentSession = await readOnyxValueOnce(ONYXKEYS.SESSION);
+        const currentAccountID = currentSession?.accountID ?? CONST.DEFAULT_NUMBER_ID;
+        if (currentAccountID !== flowAccountID) {
+            addMFABreadcrumb('Flow rejected: account changed during initialization', {scenario: scenarioName, flowAccountID, currentAccountID}, 'warning');
+            return;
+        }
 
         addMFABreadcrumb('Flow started', {
             scenario: scenarioName,
@@ -88,7 +99,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
 
         send({
             type: 'INIT',
-            accountID,
+            accountID: flowAccountID,
             scenarioName,
             scenario,
             payload: params && Object.keys(params).length > 0 ? params : undefined,

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -3,7 +3,7 @@ import {getScenarioConfig} from '@components/MultifactorAuthentication/config';
 import type {MultifactorAuthenticationScenario} from '@components/MultifactorAuthentication/config/types';
 import {MFAMachine, snapshotToState} from '@components/MultifactorAuthentication/machine';
 import addMFABreadcrumb from '@components/MultifactorAuthentication/observability/breadcrumbs';
-import type {CredentialsState} from '@components/MultifactorAuthentication/observability/trackMFAFlowOutcome';
+import type {MFARegistrationStateSnapshot} from '@components/MultifactorAuthentication/observability/trackMFAFlowOutcome';
 import trackMFAFlowStart from '@components/MultifactorAuthentication/observability/trackMFAFlowStart';
 import useSyncMfaModalNavigatorWithHistory from '@components/MultifactorAuthentication/useSyncMfaModalNavigatorWithHistory';
 
@@ -44,7 +44,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
     const [snapshot, send] = useInspectedMachine(MFAMachine);
     const state = snapshotToState(snapshot);
 
-    const captureCredentialsState = async (flowAccountID: number): Promise<CredentialsState> => {
+    const captureRegistrationState = async (flowAccountID: number): Promise<MFARegistrationStateSnapshot> => {
         const [hasLocalCredentials, deviceBiometrics] = await Promise.all([biometrics.areLocalCredentialsKnownToServer(), readOnyxValueOnce(getDeviceBiometricsOnyxKey(flowAccountID))]);
         return {
             hasServerCredentials: biometrics.serverKnownCredentialIDs.length > 0,
@@ -61,7 +61,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
         const [params] = args;
 
         // Perf short-circuit: while the modal is open or closing the machine drops INIT, so skip the
-        // redundant captureCredentialsState() native call + breadcrumb on the happy path.
+        // redundant captureRegistrationState() native call + breadcrumb on the happy path.
         if (state.modalState !== MFA_STATE.CLOSED) {
             return;
         }
@@ -74,9 +74,9 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
         }
 
         const flowAccountID = accountID;
-        const startCredentialsState = await captureCredentialsState(flowAccountID);
+        const startRegistrationState = await captureRegistrationState(flowAccountID);
 
-        // A session switch can happen while the asynchronous credential snapshot is being read. Read
+        // A session switch can happen while the asynchronous registration-state snapshot is being read. Read
         // the source of truth again immediately before INIT so stale account data never starts a flow.
         const currentSession = await readOnyxValueOnce(ONYXKEYS.SESSION);
         const currentAccountID = currentSession?.accountID ?? CONST.DEFAULT_NUMBER_ID;
@@ -90,10 +90,10 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             hasPayload: params !== undefined && Object.keys(params).length > 0,
             platform,
             isOffline,
-            serverHasAnyCredentials: startCredentialsState.hasServerCredentials,
-            hasEverAcceptedSoftPrompt: startCredentialsState.hasEverAcceptedSoftPrompt,
+            serverHasAnyCredentials: startRegistrationState.hasServerCredentials,
+            hasEverAcceptedSoftPrompt: startRegistrationState.hasEverAcceptedSoftPrompt,
         });
-        trackMFAFlowStart({scenario: scenarioName, isOffline, credentialsState: startCredentialsState});
+        trackMFAFlowStart({scenario: scenarioName, isOffline, registrationState: startRegistrationState});
 
         const scenario = getScenarioConfig(scenarioName);
 
@@ -103,7 +103,7 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             scenarioName,
             scenario,
             payload: params && Object.keys(params).length > 0 ? params : undefined,
-            hasEverAcceptedSoftPrompt: startCredentialsState.hasEverAcceptedSoftPrompt,
+            hasEverAcceptedSoftPrompt: startRegistrationState.hasEverAcceptedSoftPrompt,
         });
     };
 

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -12,6 +12,9 @@ import useInspectedMachine from '@hooks/useInspectedMachine';
 import useNetwork from '@hooks/useNetwork';
 
 import getPlatform from '@libs/getPlatform';
+import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
+
+import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
 
 import CONST from '@src/CONST';
 
@@ -41,10 +44,11 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
     const state = snapshotToState(snapshot);
 
     const captureCredentialsState = async (): Promise<CredentialsState> => {
-        const hasLocalCredentials = await biometrics.areLocalCredentialsKnownToServer();
+        const [hasLocalCredentials, deviceBiometrics] = await Promise.all([biometrics.areLocalCredentialsKnownToServer(), readOnyxValueOnce(getDeviceBiometricsOnyxKey(accountID))]);
         return {
             hasServerCredentials: biometrics.serverKnownCredentialIDs.length > 0,
             hasLocalCredentials,
+            hasEverAcceptedSoftPrompt: deviceBiometrics?.hasAcceptedSoftPrompt ?? false,
         };
     };
 
@@ -76,12 +80,20 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             platform,
             isOffline,
             serverHasAnyCredentials: startCredentialsState.hasServerCredentials,
+            hasEverAcceptedSoftPrompt: startCredentialsState.hasEverAcceptedSoftPrompt,
         });
         trackMFAFlowStart({scenario: scenarioName, isOffline, credentialsState: startCredentialsState});
 
         const scenario = getScenarioConfig(scenarioName);
 
-        send({type: 'INIT', accountID, scenarioName, scenario, payload: params && Object.keys(params).length > 0 ? params : undefined});
+        send({
+            type: 'INIT',
+            accountID,
+            scenarioName,
+            scenario,
+            payload: params && Object.keys(params).length > 0 ? params : undefined,
+            hasEverAcceptedSoftPrompt: startCredentialsState.hasEverAcceptedSoftPrompt,
+        });
     };
 
     const closeModal = () => send({type: 'CLOSE_MODAL'});

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -21,7 +21,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 
 import type {ReactNode} from 'react';
 
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import type {MultifactorAuthenticationExecuteScenarioArgs, MultifactorAuthenticationExternalAPI} from './MultifactorAuthenticationExternalApiContext';
 import type {MultifactorAuthenticationInternalApi} from './MultifactorAuthenticationInternalApiContext';
@@ -43,6 +43,15 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
 
     const [snapshot, send] = useInspectedMachine(MFAMachine);
     const state = snapshotToState(snapshot);
+
+    useEffect(() => {
+        if (state.modalState !== MFA_STATE.OPEN || state.accountID === undefined || state.accountID === accountID) {
+            return;
+        }
+
+        addMFABreadcrumb('Flow canceled: account changed', {flowAccountID: state.accountID, currentAccountID: accountID}, 'warning');
+        send({type: 'CLOSE_MODAL'});
+    }, [accountID, send, state.accountID, state.modalState]);
 
     const captureRegistrationState = async (flowAccountID: number): Promise<MFARegistrationStateSnapshot> => {
         const [hasLocalCredentials, deviceBiometrics] = await Promise.all([biometrics.areLocalCredentialsKnownToServer(), readOnyxValueOnce(getDeviceBiometricsOnyxKey(flowAccountID))]);

--- a/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
+++ b/src/components/MultifactorAuthentication/Context/MultifactorAuthenticationMainContext.tsx
@@ -103,7 +103,6 @@ function MultifactorAuthenticationContextProvider({children}: MultifactorAuthent
             scenarioName,
             scenario,
             payload: params && Object.keys(params).length > 0 ? params : undefined,
-            hasEverAcceptedSoftPrompt: startRegistrationState.hasEverAcceptedSoftPrompt,
         });
     };
 

--- a/src/components/MultifactorAuthentication/biometrics/operations/index.native.ts
+++ b/src/components/MultifactorAuthentication/biometrics/operations/index.native.ts
@@ -2,19 +2,20 @@ import type {CreateCredentialParams, CreateCredentialResult} from '@components/M
 import addMFABreadcrumb from '@components/MultifactorAuthentication/observability/breadcrumbs';
 
 import {decodeLibraryError, getKeyAlias} from '@libs/MultifactorAuthentication/NativeBiometricsHSM/helpers';
+import type NativeBiometricsHSMKeyInfo from '@libs/MultifactorAuthentication/NativeBiometricsHSM/types';
 import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import Base64URL from '@src/utils/Base64URL';
 
-import {getAllKeys, isSensorAvailable} from '@sbaiahmed1/react-native-biometrics';
+import {createKeys, getAllKeys, isSensorAvailable} from '@sbaiahmed1/react-native-biometrics';
 import {mfaCredentialIDsSelector} from '@selectors/Account';
 
 /**
- * Platform-resolved biometric operations for the MFA machine's pre-screen checks and credential
- * creation ceremony. These functions read no React state, so the machine actors and other
- * non-React callers can import them directly.
+ * Platform-resolved biometric operations for the MFA machine's pre-screen checks and the
+ * credential-creation ceremony. These functions read no React state, so the machine actors and
+ * other non-React callers can import them directly.
  */
 
 /** The authentication method this platform verifies with. Native verifies with HSM-backed biometrics. */
@@ -62,7 +63,38 @@ async function areLocalCredentialsKnownToServer(accountID: number, signal?: Abor
 
 /** Runs the platform HSM key-creation ceremony. */
 async function createCredential(params: CreateCredentialParams): Promise<CreateCredentialResult> {
-    throw new Error('Not implemented');
+    const {accountID, registrationChallenge} = params;
+    try {
+        const keyAlias = getKeyAlias(accountID);
+
+        /**
+         * createKeys called with:
+         * keyAlias - alias associated with the key stored on the device
+         * keyType: 'ec256' - Elliptic Curve P-256 key
+         * biometricStrength: undefined - currently ignored when allowDeviceCredentials is set to true
+         * allowDeviceCredentials: true - allow device credentials fallback when biometrics are unavailable
+         * failIfExists: false - overwrite any existing key for this alias to support re-registration
+         */
+        const {publicKey} = await createKeys(keyAlias, 'ec256', undefined, true, false);
+
+        const credentialID = Base64URL.base64ToBase64url(publicKey);
+        const clientDataJSON = JSON.stringify({challenge: registrationChallenge.challenge});
+        const keyInfo: NativeBiometricsHSMKeyInfo = {
+            rawId: credentialID,
+            type: CONST.MULTIFACTOR_AUTHENTICATION.BIOMETRICS_HSM_TYPE,
+            response: {
+                clientDataJSON: Base64URL.encode(clientDataJSON),
+                biometric: {
+                    publicKey: credentialID,
+                    algorithm: CONST.COSE_ALGORITHM.ES256,
+                },
+            },
+        };
+
+        return {success: true, keyInfo};
+    } catch (error) {
+        return {success: false, error: decodeLibraryError(error)};
+    }
 }
 
 export {areLocalCredentialsKnownToServer, createCredential, deviceVerificationType, deviceCheckFailureReason, doesDeviceSupportAuthenticationMethod};

--- a/src/components/MultifactorAuthentication/biometrics/operations/index.native.ts
+++ b/src/components/MultifactorAuthentication/biometrics/operations/index.native.ts
@@ -1,3 +1,4 @@
+import type {CreateCredentialParams, CreateCredentialResult} from '@components/MultifactorAuthentication/biometrics/shared/types';
 import addMFABreadcrumb from '@components/MultifactorAuthentication/observability/breadcrumbs';
 
 import {decodeLibraryError, getKeyAlias} from '@libs/MultifactorAuthentication/NativeBiometricsHSM/helpers';
@@ -11,8 +12,9 @@ import {getAllKeys, isSensorAvailable} from '@sbaiahmed1/react-native-biometrics
 import {mfaCredentialIDsSelector} from '@selectors/Account';
 
 /**
- * Platform-resolved biometric operations for the MFA machine's pre-screen checks. These functions
- * read no React state, so the machine actors and other non-React callers can import them directly.
+ * Platform-resolved biometric operations for the MFA machine's pre-screen checks and credential
+ * creation ceremony. These functions read no React state, so the machine actors and other
+ * non-React callers can import them directly.
  */
 
 /** The authentication method this platform verifies with. Native verifies with HSM-backed biometrics. */
@@ -58,4 +60,9 @@ async function areLocalCredentialsKnownToServer(accountID: number, signal?: Abor
     return (mfaCredentialIDsSelector(account) ?? []).includes(localCredentialID);
 }
 
-export {areLocalCredentialsKnownToServer, deviceVerificationType, deviceCheckFailureReason, doesDeviceSupportAuthenticationMethod};
+/** Runs the platform HSM key-creation ceremony. */
+async function createCredential(params: CreateCredentialParams): Promise<CreateCredentialResult> {
+    throw new Error('Not implemented');
+}
+
+export {areLocalCredentialsKnownToServer, createCredential, deviceVerificationType, deviceCheckFailureReason, doesDeviceSupportAuthenticationMethod};

--- a/src/components/MultifactorAuthentication/biometrics/operations/index.ts
+++ b/src/components/MultifactorAuthentication/biometrics/operations/index.ts
@@ -107,10 +107,14 @@ async function createCredential(params: CreateCredentialParams): Promise<CreateC
             existingCredentials: reconciledExisting,
         });
     } catch (error) {
-        // A failed local write shouldn't throw away a ceremony that already succeeded — the backend
-        // call below is what matters, and the server stays the source of truth for
-        // `areLocalCredentialsKnownToServer`.
+        // Both `areLocalCredentialsKnownToServer` and `authorize()` resolve which credential to use
+        // from this local Onyx list. Registering with the backend anyway would leave the server
+        // knowing about a credential this device can't find again, so fail before that call happens.
         addMFABreadcrumb('Failed to persist local passkey credential', {message: getErrorMessage(error)}, 'error');
+        return {
+            success: false,
+            error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.LOCAL_PERSISTENCE_FAILED, getErrorMessage(error)),
+        };
     }
 
     return {

--- a/src/components/MultifactorAuthentication/biometrics/operations/index.ts
+++ b/src/components/MultifactorAuthentication/biometrics/operations/index.ts
@@ -1,9 +1,20 @@
 import type {CreateCredentialParams, CreateCredentialResult} from '@components/MultifactorAuthentication/biometrics/shared/types';
+import addMFABreadcrumb from '@components/MultifactorAuthentication/observability/breadcrumbs';
 
-import {isWebAuthnSupported} from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
+import {getErrorMessage} from '@libs/ErrorUtils';
+import {
+    arrayBufferToBase64URL,
+    buildPublicKeyCredentialCreationOptions,
+    createPasskeyCredential,
+    decodeWebAuthnError,
+    extractAAGUID,
+    isSupportedTransport,
+    isWebAuthnSupported,
+} from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
+import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
 
-import {getPasskeyOnyxKey} from '@userActions/Passkey';
+import {addLocalPasskeyCredential, getPasskeyOnyxKey, reconcileLocalPasskeysWithBackend} from '@userActions/Passkey';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -11,9 +22,9 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import {mfaCredentialIDsSelector} from '@selectors/Account';
 
 /**
- * Platform-resolved biometric operations for the MFA machine's pre-screen checks and credential
- * creation ceremony. These functions read no React state, so the machine actors and other
- * non-React callers can import them directly.
+ * Platform-resolved biometric operations for the MFA machine's pre-screen checks and the
+ * credential-creation ceremony. These functions read no React state, so the machine actors and
+ * other non-React callers can import them directly.
  */
 
 /** The authentication method this platform verifies with. Web verifies with passkeys. */
@@ -42,7 +53,76 @@ async function areLocalCredentialsKnownToServer(accountID: number, signal?: Abor
 
 /** Runs the platform passkey ceremony and persists the resulting credential locally. */
 async function createCredential(params: CreateCredentialParams): Promise<CreateCredentialResult> {
-    throw new Error('Not implemented');
+    const {accountID, registrationChallenge, signal} = params;
+    const userId = String(accountID);
+    const [account, localPasskeyCredentials] = await Promise.all([readOnyxValueOnce(ONYXKEYS.ACCOUNT, signal), readOnyxValueOnce(getPasskeyOnyxKey(userId), signal)]);
+
+    const backendCredentials = (mfaCredentialIDsSelector(account) ?? []).map((id) => ({id, type: CONST.PASSKEY_CREDENTIAL_TYPE}));
+    const reconciledExisting = reconcileLocalPasskeysWithBackend({userId, backendCredentials, localCredentials: localPasskeyCredentials ?? null});
+    const publicKeyOptions = buildPublicKeyCredentialCreationOptions(registrationChallenge, reconciledExisting);
+
+    let credential: PublicKeyCredential;
+    try {
+        // Cancelling the flow (CLOSE_MODAL) aborts `signal`, which closes the passkey dialog — the
+        // rejection below then gets handled like any other refusal.
+        credential = await createPasskeyCredential(publicKeyOptions, signal);
+    } catch (error) {
+        return {success: false, error: decodeWebAuthnError(error)};
+    }
+
+    if (!(credential.response instanceof AuthenticatorAttestationResponse)) {
+        return {
+            success: false,
+            error: createLocalMFAError(
+                CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.WEBAUTHN.UNEXPECTED_RESPONSE,
+                'Registration credential response is not AuthenticatorAttestationResponse',
+            ),
+        };
+    }
+    const attestationResponse = credential.response;
+    const credentialId = arrayBufferToBase64URL(credential.rawId);
+    const clientDataJSON = arrayBufferToBase64URL(attestationResponse.clientDataJSON);
+    const attestationObject = arrayBufferToBase64URL(attestationResponse.attestationObject);
+
+    const transports = attestationResponse.getTransports?.().filter(isSupportedTransport);
+
+    // getAuthenticatorData() is a WebAuthn Level 2 method — not available in older browsers.
+    // NOTE: A value of "00000000-0000-0000-0000-000000000000" is expected for Apple iCloud Keychain
+    const aaguid = attestationResponse.getAuthenticatorData ? extractAAGUID(attestationResponse.getAuthenticatorData()) : undefined;
+
+    // Not every browser honors `signal` on create(), so the ceremony can still succeed after the flow
+    // was cancelled. Don't persist or register a credential nobody asked for anymore — the passkey
+    // itself is already on the device either way, that part can't be undone.
+    if (signal?.aborted) {
+        return {success: false, error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.CANCELED, 'MFA flow canceled before the credential could be persisted')};
+    }
+
+    try {
+        // Reconciled list, not the stale pre-reconciliation read — reconciliation may have already
+        // dropped a duplicate id, and checking the stale list would throw for a credential that's
+        // no longer there.
+        await addLocalPasskeyCredential({
+            userId,
+            credential: {id: credentialId, type: CONST.PASSKEY_CREDENTIAL_TYPE, transports, aaguid},
+            existingCredentials: reconciledExisting,
+        });
+    } catch (error) {
+        // A failed local write shouldn't throw away a ceremony that already succeeded — the backend
+        // call below is what matters, and the server stays the source of truth for
+        // `areLocalCredentialsKnownToServer`.
+        addMFABreadcrumb('Failed to persist local passkey credential', {message: getErrorMessage(error)}, 'error');
+    }
+
+    return {
+        success: true,
+        keyInfo: {
+            rawId: credentialId,
+            type: CONST.PASSKEY_CREDENTIAL_TYPE,
+            transports,
+            aaguid,
+            response: {clientDataJSON, attestationObject},
+        },
+    };
 }
 
 export {areLocalCredentialsKnownToServer, createCredential, deviceVerificationType, deviceCheckFailureReason, doesDeviceSupportAuthenticationMethod};

--- a/src/components/MultifactorAuthentication/biometrics/operations/index.ts
+++ b/src/components/MultifactorAuthentication/biometrics/operations/index.ts
@@ -1,3 +1,5 @@
+import type {CreateCredentialParams, CreateCredentialResult} from '@components/MultifactorAuthentication/biometrics/shared/types';
+
 import {isWebAuthnSupported} from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
 import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
 
@@ -9,8 +11,9 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import {mfaCredentialIDsSelector} from '@selectors/Account';
 
 /**
- * Platform-resolved biometric operations for the MFA machine's pre-screen checks. These functions
- * read no React state, so the machine actors and other non-React callers can import them directly.
+ * Platform-resolved biometric operations for the MFA machine's pre-screen checks and credential
+ * creation ceremony. These functions read no React state, so the machine actors and other
+ * non-React callers can import them directly.
  */
 
 /** The authentication method this platform verifies with. Web verifies with passkeys. */
@@ -37,4 +40,9 @@ async function areLocalCredentialsKnownToServer(accountID: number, signal?: Abor
     return (localPasskeyCredentials ?? []).some((credential) => serverKnownCredentialIDs.has(credential.id));
 }
 
-export {areLocalCredentialsKnownToServer, deviceVerificationType, deviceCheckFailureReason, doesDeviceSupportAuthenticationMethod};
+/** Runs the platform passkey ceremony and persists the resulting credential locally. */
+async function createCredential(params: CreateCredentialParams): Promise<CreateCredentialResult> {
+    throw new Error('Not implemented');
+}
+
+export {areLocalCredentialsKnownToServer, createCredential, deviceVerificationType, deviceCheckFailureReason, doesDeviceSupportAuthenticationMethod};

--- a/src/components/MultifactorAuthentication/biometrics/operations/index.ts
+++ b/src/components/MultifactorAuthentication/biometrics/operations/index.ts
@@ -107,13 +107,13 @@ async function createCredential(params: CreateCredentialParams): Promise<CreateC
             existingCredentials: reconciledExisting,
         });
     } catch (error) {
-        // Both `areLocalCredentialsKnownToServer` and `authorize()` resolve which credential to use
-        // from this local Onyx list. Registering with the backend anyway would leave the server
-        // knowing about a credential this device can't find again, so fail before that call happens.
-        addMFABreadcrumb('Failed to persist local passkey credential', {message: getErrorMessage(error)}, 'error');
+        // `addLocalPasskeyCredential` validates the user ID and rejects duplicate
+        // credential IDs before updating Onyx. Don't continue with backend
+        // registration when that local validation fails.
+        addMFABreadcrumb('Failed to update local passkey credentials', {message: getErrorMessage(error)}, 'error');
         return {
             success: false,
-            error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.LOCAL_PERSISTENCE_FAILED, getErrorMessage(error)),
+            error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.LOCAL_CREDENTIAL_UPDATE_FAILED, getErrorMessage(error)),
         };
     }
 

--- a/src/components/MultifactorAuthentication/biometrics/shared/types.ts
+++ b/src/components/MultifactorAuthentication/biometrics/shared/types.ts
@@ -1,5 +1,5 @@
 import type {AuthenticationChallenge, RegistrationChallenge, SignedChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
-import type {MFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
+import type {MFAError, MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import type {AuthTypeInfo, RegistrationKeyInfo} from '@libs/MultifactorAuthentication/shared/types';
 
 type BaseRegisterResult = {
@@ -14,6 +14,18 @@ type RegisterResult =
           success: false;
           error: MFAError;
       } & Partial<BaseRegisterResult>);
+
+/**
+ * Params for the platform-resolved credential-creation ceremony. A params object (not positional
+ * args) keeps both platform signatures identical while native simply ignores `signal`.
+ */
+type CreateCredentialParams = {
+    accountID: number;
+    registrationChallenge: RegistrationChallenge;
+    signal?: AbortSignal;
+};
+
+type CreateCredentialResult = MFAResult<{keyInfo: RegistrationKeyInfo}>;
 
 type AuthorizeParams = {
     challenge: AuthenticationChallenge;
@@ -58,4 +70,4 @@ type UseBiometricsReturn = {
     deleteLocalKeysForAccount: () => Promise<void>;
 };
 
-export type {RegisterResult, AuthorizeParams, AuthorizeResult, UseBiometricsReturn};
+export type {RegisterResult, AuthorizeParams, AuthorizeResult, UseBiometricsReturn, CreateCredentialParams, CreateCredentialResult};

--- a/src/components/MultifactorAuthentication/biometrics/shared/types.ts
+++ b/src/components/MultifactorAuthentication/biometrics/shared/types.ts
@@ -2,19 +2,6 @@ import type {AuthenticationChallenge, RegistrationChallenge, SignedChallenge} fr
 import type {MFAError, MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import type {AuthTypeInfo, RegistrationKeyInfo} from '@libs/MultifactorAuthentication/shared/types';
 
-type BaseRegisterResult = {
-    keyInfo: RegistrationKeyInfo;
-};
-
-type RegisterResult =
-    | ({
-          success: true;
-      } & BaseRegisterResult)
-    | ({
-          success: false;
-          error: MFAError;
-      } & Partial<BaseRegisterResult>);
-
 /**
  * Params for the platform-resolved credential-creation ceremony. A params object (not positional
  * args) keeps both platform signatures identical while native simply ignores `signal`.
@@ -60,9 +47,6 @@ type UseBiometricsReturn = {
     /** Check if local credentials are known to server (local credential exists in server's list) */
     areLocalCredentialsKnownToServer: () => Promise<boolean>;
 
-    /** Register current device for the chosen authentication method */
-    register: (onResult: (result: RegisterResult) => Promise<void> | void, registrationChallenge: RegistrationChallenge) => Promise<void>;
-
     /** Authorize using chosen authentication method */
     authorize: (params: AuthorizeParams, onResult: (result: AuthorizeResult) => Promise<void> | void) => Promise<void>;
 
@@ -70,4 +54,4 @@ type UseBiometricsReturn = {
     deleteLocalKeysForAccount: () => Promise<void>;
 };
 
-export type {RegisterResult, AuthorizeParams, AuthorizeResult, UseBiometricsReturn, CreateCredentialParams, CreateCredentialResult};
+export type {AuthorizeParams, AuthorizeResult, UseBiometricsReturn, CreateCredentialParams, CreateCredentialResult};

--- a/src/components/MultifactorAuthentication/biometrics/useNativeBiometricsHSM.ts
+++ b/src/components/MultifactorAuthentication/biometrics/useNativeBiometricsHSM.ts
@@ -4,7 +4,6 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useLocalize from '@hooks/useLocalize';
 
 import {buildSigningData, decodeLibraryError, getKeyAlias, mapAuthTypeNumber, mapSignErrorCodeToReason} from '@libs/MultifactorAuthentication/NativeBiometricsHSM/helpers';
-import type NativeBiometricsHSMKeyInfo from '@libs/MultifactorAuthentication/NativeBiometricsHSM/types';
 import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import VALUES from '@libs/MultifactorAuthentication/VALUES';
 
@@ -13,9 +12,9 @@ import Base64URL from '@src/utils/Base64URL';
 
 import type {SignatureResult} from '@sbaiahmed1/react-native-biometrics';
 
-import {createKeys, deleteKeys, getAllKeys, InputEncoding, signWithOptions} from '@sbaiahmed1/react-native-biometrics';
+import {deleteKeys, getAllKeys, InputEncoding, signWithOptions} from '@sbaiahmed1/react-native-biometrics';
 
-import type {AuthorizeParams, AuthorizeResult, RegisterResult, UseBiometricsReturn} from './shared/types';
+import type {AuthorizeParams, AuthorizeResult, UseBiometricsReturn} from './shared/types';
 
 import useServerCredentials from './shared/useServerCredentials';
 
@@ -76,47 +75,6 @@ function useNativeBiometricsHSM(): UseBiometricsReturn {
             await deleteKeys(keyAlias);
         } catch (error) {
             addMFABreadcrumb('Failed to delete local keys', decodeLibraryError(error), 'error');
-        }
-    };
-
-    const register = async (onResult: (result: RegisterResult) => Promise<void> | void, registrationChallenge: Parameters<UseBiometricsReturn['register']>[1]) => {
-        try {
-            const keyAlias = getKeyAlias(accountID);
-
-            /**
-             * createKeys called with:
-             * keyAlias - alias associated with the key stored on the device
-             * keyType: 'ec256' - Elliptic Curve P-256 key
-             * biometricStrength: undefined - currently ignored when allowDeviceCredentials is set to true
-             * allowDeviceCredentials: true - allow device credentials fallback when biometrics are unavailable
-             * failIfExists: false - overwrite any existing key for this alias to support re-registration
-             */
-            const {publicKey} = await createKeys(keyAlias, 'ec256', undefined, true, false);
-
-            const credentialID = Base64URL.base64ToBase64url(publicKey);
-
-            const clientDataJSON = JSON.stringify({challenge: registrationChallenge.challenge});
-            const keyInfo: NativeBiometricsHSMKeyInfo = {
-                rawId: credentialID,
-                type: CONST.MULTIFACTOR_AUTHENTICATION.BIOMETRICS_HSM_TYPE,
-                response: {
-                    clientDataJSON: Base64URL.encode(clientDataJSON),
-                    biometric: {
-                        publicKey: credentialID,
-                        algorithm: CONST.COSE_ALGORITHM.ES256,
-                    },
-                },
-            };
-
-            await onResult({
-                success: true,
-                keyInfo,
-            });
-        } catch (error) {
-            onResult({
-                success: false,
-                error: decodeLibraryError(error),
-            });
         }
     };
 
@@ -196,7 +154,6 @@ function useNativeBiometricsHSM(): UseBiometricsReturn {
         getLocalCredentialID,
         hasLocalCredentials,
         areLocalCredentialsKnownToServer,
-        register,
         authorize,
         deleteLocalKeysForAccount,
     };

--- a/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
+++ b/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
@@ -5,23 +5,18 @@ import {
     arrayBufferToBase64URL,
     authenticateWithPasskey,
     buildAllowedCredentialDescriptors,
-    buildPublicKeyCredentialCreationOptions,
     buildPublicKeyCredentialRequestOptions,
-    createPasskeyCredential,
     decodeWebAuthnError,
-    extractAAGUID,
-    isSupportedTransport,
     PASSKEY_AUTH_TYPE,
 } from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
-import type {RegistrationChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
 import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import VALUES from '@libs/MultifactorAuthentication/VALUES';
 
-import {addLocalPasskeyCredential, deleteLocalPasskeyCredentials, getPasskeyOnyxKey, reconcileLocalPasskeysWithBackend} from '@userActions/Passkey';
+import {deleteLocalPasskeyCredentials, getPasskeyOnyxKey, reconcileLocalPasskeysWithBackend} from '@userActions/Passkey';
 
 import CONST from '@src/CONST';
 
-import type {AuthorizeParams, AuthorizeResult, RegisterResult, UseBiometricsReturn} from './shared/types';
+import type {AuthorizeParams, AuthorizeResult, UseBiometricsReturn} from './shared/types';
 
 import useServerCredentials from './shared/useServerCredentials';
 
@@ -49,70 +44,6 @@ function usePasskeys(): UseBiometricsReturn {
 
     const deleteLocalKeysForAccount = async () => {
         deleteLocalPasskeyCredentials(userId);
-    };
-
-    const register = async (onResult: (result: RegisterResult) => Promise<void> | void, registrationChallenge: RegistrationChallenge) => {
-        const backendCredentials = serverKnownCredentialIDs.map((id) => ({id, type: CONST.PASSKEY_CREDENTIAL_TYPE}));
-        const reconciledExisting = reconcileLocalPasskeysWithBackend({
-            userId,
-            backendCredentials,
-            localCredentials: localPasskeyCredentials ?? null,
-        });
-        const publicKeyOptions = buildPublicKeyCredentialCreationOptions(registrationChallenge, reconciledExisting);
-
-        let credential: PublicKeyCredential;
-        try {
-            credential = await createPasskeyCredential(publicKeyOptions);
-        } catch (error) {
-            await onResult({
-                success: false,
-                error: decodeWebAuthnError(error),
-            });
-            return;
-        }
-
-        if (!(credential.response instanceof AuthenticatorAttestationResponse)) {
-            await onResult({
-                success: false,
-                error: createLocalMFAError(VALUES.REASON.LOCAL_ERRORS.WEBAUTHN.UNEXPECTED_RESPONSE, 'Registration credential response is not AuthenticatorAttestationResponse'),
-            });
-            return;
-        }
-        const attestationResponse = credential.response;
-        const credentialId = arrayBufferToBase64URL(credential.rawId);
-        const clientDataJSON = arrayBufferToBase64URL(attestationResponse.clientDataJSON);
-        const attestationObject = arrayBufferToBase64URL(attestationResponse.attestationObject);
-
-        const transports = attestationResponse.getTransports?.().filter(isSupportedTransport);
-
-        // getAuthenticatorData() is a WebAuthn Level 2 method — not available in older browsers.
-        // NOTE: A value of "00000000-0000-0000-0000-000000000000" is expected for Apple iCloud Keychain
-        const aaguid = attestationResponse.getAuthenticatorData ? extractAAGUID(attestationResponse.getAuthenticatorData()) : undefined;
-
-        addLocalPasskeyCredential({
-            userId,
-            credential: {
-                id: credentialId,
-                type: CONST.PASSKEY_CREDENTIAL_TYPE,
-                transports,
-                aaguid,
-            },
-            existingCredentials: localPasskeyCredentials ?? null,
-        });
-
-        await onResult({
-            success: true,
-            keyInfo: {
-                rawId: credentialId,
-                type: CONST.PASSKEY_CREDENTIAL_TYPE,
-                transports,
-                aaguid,
-                response: {
-                    clientDataJSON,
-                    attestationObject,
-                },
-            },
-        });
     };
 
     const authorize = async (params: AuthorizeParams, onResult: (result: AuthorizeResult) => Promise<void> | void) => {
@@ -188,7 +119,6 @@ function usePasskeys(): UseBiometricsReturn {
         getLocalCredentialID,
         hasLocalCredentials,
         areLocalCredentialsKnownToServer,
-        register,
         authorize,
         deleteLocalKeysForAccount,
     };

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -5,9 +5,8 @@ import addMFABreadcrumb from '@components/MultifactorAuthentication/observabilit
 import {isHttpSuccess} from '@libs/MultifactorAuthentication/shared/helpers';
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import {createLocalMFAError, createMFAErrorFromApiResponse} from '@libs/MultifactorAuthentication/shared/MFAResult';
-import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
 
-import {getDeviceBiometricsOnyxKey, requestRegistrationChallenge} from '@userActions/MultifactorAuthentication';
+import {requestRegistrationChallenge} from '@userActions/MultifactorAuthentication';
 import {processRegistration} from '@userActions/MultifactorAuthentication/processing';
 
 import CONST from '@src/CONST';
@@ -18,7 +17,6 @@ import type {
     CheckLocalCredentialsInput,
     CreateCredentialInput,
     CreateCredentialOutput,
-    ReadHasAcceptedSoftPromptInput,
     RequestRegistrationChallengeInput,
     RequestRegistrationChallengeOutput,
     ValidateDeviceInput,
@@ -29,15 +27,6 @@ import type {
  * actor fires only when the platform check throws unexpectedly.
  */
 const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => checkDeviceEligibility(input.allowedAuthenticationMethods));
-
-/**
- * Reads the account's device-local soft-prompt flag once. The temporary Onyx connection is
- * disconnected after the first value or when XState stops the actor.
- */
-const readHasAcceptedSoftPrompt = fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(async ({input, signal}) => {
-    const deviceBiometrics = await readOnyxValueOnce(getDeviceBiometricsOnyxKey(input.accountID), signal);
-    return deviceBiometrics?.hasAcceptedSoftPrompt ?? false;
-});
 
 /**
  * Resolves to whether the account's local credentials are known to the server. A returning user
@@ -87,7 +76,6 @@ const createCredentialActor = fromPromise<CreateCredentialOutput, CreateCredenti
 function createActors() {
     return {
         validateDevice,
-        readHasAcceptedSoftPrompt,
         checkLocalCredentials,
         requestRegistrationChallenge: requestRegistrationChallengeActor,
         createCredential: createCredentialActor,

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -1,12 +1,16 @@
 import checkDeviceEligibility from '@components/MultifactorAuthentication/biometrics/checkDeviceEligibility';
-import {areLocalCredentialsKnownToServer} from '@components/MultifactorAuthentication/biometrics/operations';
+import {areLocalCredentialsKnownToServer, createCredential} from '@components/MultifactorAuthentication/biometrics/operations';
+import addMFABreadcrumb from '@components/MultifactorAuthentication/observability/breadcrumbs';
 
 import {isHttpSuccess} from '@libs/MultifactorAuthentication/shared/helpers';
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
-import {createMFAErrorFromApiResponse} from '@libs/MultifactorAuthentication/shared/MFAResult';
+import {createLocalMFAError, createMFAErrorFromApiResponse} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
 
 import {getDeviceBiometricsOnyxKey, requestRegistrationChallenge} from '@userActions/MultifactorAuthentication';
+import {processRegistration} from '@userActions/MultifactorAuthentication/processing';
+
+import CONST from '@src/CONST';
 
 import {fromPromise} from 'xstate';
 
@@ -54,11 +58,26 @@ const requestRegistrationChallengeActor = fromPromise<RequestRegistrationChallen
 });
 
 /**
- * Turns a pending registration challenge into a real credential: platform ceremony, then backend
- * registration.
+ * Platform ceremony, then backend registration. A refusal on the platform side short-circuits
+ * before the backend is ever called; a backend failure is returned as-is, with no rollback of the
+ * credential the platform already created. Breadcrumb labels match legacy `Main.tsx` for telemetry
+ * continuity.
  */
-const createCredentialActor = fromPromise<CreateCredentialOutput, CreateCredentialInput>(async () => {
-    throw new Error('Not implemented');
+const createCredentialActor = fromPromise<CreateCredentialOutput, CreateCredentialInput>(async ({input, signal}) => {
+    const creationResult = await createCredential({...input, signal});
+    addMFABreadcrumb('Biometric registration completed', creationResult.success ? {success: true} : creationResult.error, creationResult.success ? 'info' : 'error');
+    if (!creationResult.success) {
+        return creationResult;
+    }
+    // The flow may have been cancelled while the ceremony ran. Skip the backend call rather than
+    // registering a key nobody asked for — this only catches it before the request starts, there's
+    // no way to cancel one already in flight.
+    if (signal.aborted) {
+        return {success: false, error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.CANCELED, 'MFA flow canceled before backend registration')};
+    }
+    const registrationResult = await processRegistration({keyInfo: creationResult.keyInfo});
+    addMFABreadcrumb('Backend registration completed', registrationResult.success ? {success: true} : registrationResult.error, registrationResult.success ? 'info' : 'error');
+    return registrationResult;
 });
 
 /**

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -10,7 +10,15 @@ import {getDeviceBiometricsOnyxKey, requestRegistrationChallenge} from '@userAct
 
 import {fromPromise} from 'xstate';
 
-import type {CheckLocalCredentialsInput, ReadHasAcceptedSoftPromptInput, RequestRegistrationChallengeInput, RequestRegistrationChallengeOutput, ValidateDeviceInput} from './types';
+import type {
+    CheckLocalCredentialsInput,
+    CreateCredentialInput,
+    CreateCredentialOutput,
+    ReadHasAcceptedSoftPromptInput,
+    RequestRegistrationChallengeInput,
+    RequestRegistrationChallengeOutput,
+    ValidateDeviceInput,
+} from './types';
 
 /**
  * A refused device resolves as a failed MFAResult, so the machine's onError transition for this
@@ -46,11 +54,25 @@ const requestRegistrationChallengeActor = fromPromise<RequestRegistrationChallen
 });
 
 /**
+ * Turns a pending registration challenge into a real credential: platform ceremony, then backend
+ * registration.
+ */
+const createCredentialActor = fromPromise<CreateCredentialOutput, CreateCredentialInput>(async () => {
+    throw new Error('Not implemented');
+});
+
+/**
  * Builds the side-effect actors that the machine states invoke. The machine is always created with
  * these working implementations, so no caller needs to provide stubs or overrides.
  */
 function createActors() {
-    return {validateDevice, readHasAcceptedSoftPrompt, checkLocalCredentials, requestRegistrationChallenge: requestRegistrationChallengeActor};
+    return {
+        validateDevice,
+        readHasAcceptedSoftPrompt,
+        checkLocalCredentials,
+        requestRegistrationChallenge: requestRegistrationChallengeActor,
+        createCredential: createCredentialActor,
+    };
 }
 
 export default createActors;

--- a/src/components/MultifactorAuthentication/machine/mfaActors.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaActors.ts
@@ -5,8 +5,9 @@ import addMFABreadcrumb from '@components/MultifactorAuthentication/observabilit
 import {isHttpSuccess} from '@libs/MultifactorAuthentication/shared/helpers';
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 import {createLocalMFAError, createMFAErrorFromApiResponse} from '@libs/MultifactorAuthentication/shared/MFAResult';
+import readOnyxValueOnce from '@libs/MultifactorAuthentication/shared/readOnyxValueOnce';
 
-import {requestRegistrationChallenge} from '@userActions/MultifactorAuthentication';
+import {getDeviceBiometricsOnyxKey, requestRegistrationChallenge} from '@userActions/MultifactorAuthentication';
 import {processRegistration} from '@userActions/MultifactorAuthentication/processing';
 
 import CONST from '@src/CONST';
@@ -14,9 +15,10 @@ import CONST from '@src/CONST';
 import {fromPromise} from 'xstate';
 
 import type {
-    CheckLocalCredentialsInput,
     CreateCredentialInput,
     CreateCredentialOutput,
+    LoadRegistrationStateInput,
+    LoadRegistrationStateOutput,
     RequestRegistrationChallengeInput,
     RequestRegistrationChallengeOutput,
     ValidateDeviceInput,
@@ -29,10 +31,20 @@ import type {
 const validateDevice = fromPromise<MFAResult, ValidateDeviceInput>(({input}) => checkDeviceEligibility(input.allowedAuthenticationMethods));
 
 /**
- * Resolves to whether the account's local credentials are known to the server. A returning user
- * (true) skips the registration path entirely.
+ * Loads the account-scoped signals the machine needs to choose registration or authorization.
+ * Keeping this read inside the actor makes INIT independent of Onyx and lets cancellation tear down
+ * the temporary connection.
  */
-const checkLocalCredentials = fromPromise<boolean, CheckLocalCredentialsInput>(({input, signal}) => areLocalCredentialsKnownToServer(input.accountID, signal));
+const loadRegistrationState = fromPromise<LoadRegistrationStateOutput, LoadRegistrationStateInput>(async ({input, signal}) => {
+    const [hasLocalCredentials, deviceBiometrics] = await Promise.all([
+        areLocalCredentialsKnownToServer(input.accountID, signal),
+        readOnyxValueOnce(getDeviceBiometricsOnyxKey(input.accountID), signal),
+    ]);
+    return {
+        hasLocalCredentials,
+        hasEverAcceptedSoftPrompt: deviceBiometrics?.hasAcceptedSoftPrompt ?? false,
+    };
+});
 
 /**
  * Exchanges the submitted validate code for a validated registration challenge. The action normalizes
@@ -76,7 +88,7 @@ const createCredentialActor = fromPromise<CreateCredentialOutput, CreateCredenti
 function createActors() {
     return {
         validateDevice,
-        checkLocalCredentials,
+        loadRegistrationState,
         requestRegistrationChallenge: requestRegistrationChallengeActor,
         createCredential: createCredentialActor,
     };

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -40,13 +40,13 @@ const DEFAULT_CONTEXT: MfaContext = {
     validateCode: undefined,
     registrationChallenge: undefined,
     softPromptApproved: false,
-    hasEverAcceptedSoftPrompt: false,
     isCancelConfirmVisible: false,
 };
 
 /**
- * MFA state machine. The top level models the modal lifecycle (`closed` -> `open` -> `closing`); the
- * child states of `open` map 1:1 to the screen the user currently sees.
+ * MFA state machine. The top level models the modal lifecycle (`closed` -> `open` -> `closing`).
+ * Screen-owning states navigate on entry, while their nested processing states keep that screen
+ * mounted across the related flow steps.
  *
  * No state is `final`: one long-lived actor serves every MFA flow (a top-level final state would
  * stop it).
@@ -79,7 +79,6 @@ const MFAMachine = setup({
                 scenarioName: event.scenarioName,
                 scenario: event.scenario,
                 payload: event.payload,
-                hasEverAcceptedSoftPrompt: event.hasEverAcceptedSoftPrompt,
             };
         }),
         // Deferring the outcome push until the modal-open transition settles lets the screen slide in
@@ -182,28 +181,28 @@ const MFAMachine = setup({
                         },
                         [MFA_STATE.DECIDING_REGISTRATION]: {
                             invoke: {
-                                id: 'checkLocalCredentials',
-                                src: 'checkLocalCredentials',
+                                id: 'loadRegistrationState',
+                                src: 'loadRegistrationState',
                                 input: ({context}) => {
                                     if (context.accountID === undefined) {
                                         throw new Error('MFA account must be initialized before the registration decision');
                                     }
                                     return {accountID: context.accountID};
                                 },
-                                // A fresh (re-)registration always requires soft-prompt approval, regardless of
-                                // `hasEverAcceptedSoftPrompt`. A returning user who already accepted it skips
-                                // straight to the outcome instead of re-confirming.
+                                // A fresh (re-)registration always requires soft-prompt approval. A returning
+                                // user who already accepted it skips straight to the outcome instead of
+                                // re-confirming. Both signals come from the same account-scoped actor read.
                                 //
                                 // Scoped shortcut: production re-authenticates behind a loader before the outcome.
                                 // This slice has no authorization actor yet - revisit this guard once one exists.
                                 onDone: [
-                                    {guard: ({context, event}) => event.output && context.hasEverAcceptedSoftPrompt, target: OUTCOME_TARGET},
-                                    {guard: ({event}) => event.output, target: PROMPT_TARGET},
+                                    {guard: ({event}) => event.output.hasLocalCredentials && event.output.hasEverAcceptedSoftPrompt, target: OUTCOME_TARGET},
+                                    {guard: ({event}) => event.output.hasLocalCredentials, target: PROMPT_TARGET},
                                     {target: VALIDATE_CODE_TARGET, actions: 'requestValidateCode'},
                                 ],
                                 onError: {
                                     target: OUTCOME_TARGET,
-                                    actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Local credentials check', event.error)}),
+                                    actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Registration state check', event.error)}),
                                 },
                             },
                         },
@@ -276,38 +275,36 @@ const MFAMachine = setup({
                     id: MFA_STATE.PROMPT,
                     entry: ['navigateToPrompt'],
                     initial: MFA_STATE.AWAITING_SOFT_PROMPT,
-                    on: {
-                        SOFT_PROMPT_APPROVED: [
-                            {guard: 'hasRegistrationChallenge', target: MFA_STATE.CREATING_CREDENTIAL, actions: SOFT_PROMPT_ACCEPTED_ACTIONS},
-                            {target: MFA_STATE.OUTCOME, actions: SOFT_PROMPT_ACCEPTED_ACTIONS},
-                        ],
-                    },
                     states: {
-                        [MFA_STATE.AWAITING_SOFT_PROMPT]: {},
-                    },
-                },
-                // Turns a pending registration challenge into a real credential: platform ceremony, then
-                // backend registration. Reached from both soft-prompt exits when a challenge is pending.
-                // No `entry` action on purpose — whatever screen is already up (prompt, or nothing) just
-                // stays visible during the ceremony, same as legacy.
-                [MFA_STATE.CREATING_CREDENTIAL]: {
-                    id: MFA_STATE.CREATING_CREDENTIAL,
-                    invoke: {
-                        id: 'createCredential',
-                        src: 'createCredential',
-                        input: ({context}) => {
-                            if (context.accountID === undefined || context.registrationChallenge === undefined) {
-                                throw new Error('MFA account and registration challenge must be stored before creating a credential');
-                            }
-                            return {accountID: context.accountID, registrationChallenge: context.registrationChallenge};
+                        [MFA_STATE.AWAITING_SOFT_PROMPT]: {
+                            on: {
+                                SOFT_PROMPT_APPROVED: [
+                                    {guard: 'hasRegistrationChallenge', target: MFA_STATE.CREATING_CREDENTIAL, actions: SOFT_PROMPT_ACCEPTED_ACTIONS},
+                                    {target: OUTCOME_TARGET, actions: SOFT_PROMPT_ACCEPTED_ACTIONS},
+                                ],
+                            },
                         },
-                        onDone: [
-                            {guard: ({event}) => !event.output.success, target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
-                            {target: OUTCOME_TARGET},
-                        ],
-                        onError: {
-                            target: OUTCOME_TARGET,
-                            actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Credential registration', event.error)}),
+                        // Registration and, in the next slice, authorization stay under `prompt` so the
+                        // prompt screen and its fingerprint animation remain mounted throughout.
+                        [MFA_STATE.CREATING_CREDENTIAL]: {
+                            invoke: {
+                                id: 'createCredential',
+                                src: 'createCredential',
+                                input: ({context}) => {
+                                    if (context.accountID === undefined || context.registrationChallenge === undefined) {
+                                        throw new Error('MFA account and registration challenge must be stored before creating a credential');
+                                    }
+                                    return {accountID: context.accountID, registrationChallenge: context.registrationChallenge};
+                                },
+                                onDone: [
+                                    {guard: ({event}) => !event.output.success, target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
+                                    {target: OUTCOME_TARGET},
+                                ],
+                                onError: {
+                                    target: OUTCOME_TARGET,
+                                    actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Credential registration', event.error)}),
+                                },
+                            },
                         },
                     },
                 },

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -23,11 +23,9 @@ const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 // sibling branch needs an id target rather than a relative one.
 const OUTCOME_TARGET = `#${MFA_STATE.OUTCOME}` as const;
 const PROMPT_TARGET = `#${MFA_STATE.PROMPT}` as const;
-const SOFT_PROMPT_CHECK_TARGET = `#${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}` as const;
 const VALIDATE_CODE_TARGET = `#${MFA_STATE.VALIDATE_CODE}` as const;
-const CREATING_CREDENTIAL_TARGET = `#${MFA_STATE.CREATING_CREDENTIAL}` as const;
 
-// One literal shared by both soft-prompt exits (approval and the persisted-acceptance skip), so they can't drift apart.
+// One literal shared by both branches of an explicit soft-prompt approval, so they can't drift apart.
 const SOFT_PROMPT_ACCEPTED_ACTIONS = ['approveSoftPrompt', 'persistSoftPromptAcceptance'] as const;
 
 // Which prompt variant the screen renders is a device property, resolved once per platform.
@@ -42,6 +40,7 @@ const DEFAULT_CONTEXT: MfaContext = {
     validateCode: undefined,
     registrationChallenge: undefined,
     softPromptApproved: false,
+    hasEverAcceptedSoftPrompt: false,
     isCancelConfirmVisible: false,
 };
 
@@ -80,6 +79,7 @@ const MFAMachine = setup({
                 scenarioName: event.scenarioName,
                 scenario: event.scenario,
                 payload: event.payload,
+                hasEverAcceptedSoftPrompt: event.hasEverAcceptedSoftPrompt,
             };
         }),
         // Deferring the outcome push until the modal-open transition settles lets the screen slide in
@@ -190,38 +190,20 @@ const MFAMachine = setup({
                                     }
                                     return {accountID: context.accountID};
                                 },
-                                // A returning user's credentials are already registered, so only a fresh registration asks for a code.
+                                // A fresh (re-)registration always requires soft-prompt approval, regardless of
+                                // `hasEverAcceptedSoftPrompt`. A returning user who already accepted it skips
+                                // straight to the outcome instead of re-confirming.
+                                //
+                                // Scoped shortcut: production re-authenticates behind a loader before the outcome.
+                                // This slice has no authorization actor yet - revisit this guard once one exists.
                                 onDone: [
-                                    {guard: ({event}) => event.output, target: SOFT_PROMPT_CHECK_TARGET},
+                                    {guard: ({context, event}) => event.output && context.hasEverAcceptedSoftPrompt, target: OUTCOME_TARGET},
+                                    {guard: ({event}) => event.output, target: PROMPT_TARGET},
                                     {target: VALIDATE_CODE_TARGET, actions: 'requestValidateCode'},
                                 ],
                                 onError: {
                                     target: OUTCOME_TARGET,
                                     actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Local credentials check', event.error)}),
-                                },
-                            },
-                        },
-                        [MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE]: {
-                            id: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE,
-                            invoke: {
-                                id: 'readHasAcceptedSoftPrompt',
-                                src: 'readHasAcceptedSoftPrompt',
-                                input: ({context}) => {
-                                    if (context.accountID === undefined) {
-                                        throw new Error('MFA account must be initialized before reading soft-prompt acceptance');
-                                    }
-                                    return {accountID: context.accountID};
-                                },
-                                // Not accepted yet -> show the prompt. Accepted with a challenge pending -> create the
-                                // credential. Accepted, nothing pending -> a returning user, straight to the outcome.
-                                onDone: [
-                                    {guard: ({event}) => !event.output, target: PROMPT_TARGET},
-                                    {guard: 'hasRegistrationChallenge', target: CREATING_CREDENTIAL_TARGET},
-                                    {target: OUTCOME_TARGET},
-                                ],
-                                onError: {
-                                    target: OUTCOME_TARGET,
-                                    actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Soft-prompt acceptance read', event.error)}),
                                 },
                             },
                         },
@@ -270,7 +252,7 @@ const MFAMachine = setup({
                                 onDone: [
                                     {
                                         guard: ({event}) => event.output.success,
-                                        target: SOFT_PROMPT_CHECK_TARGET,
+                                        target: PROMPT_TARGET,
                                         actions: assign({registrationChallenge: ({event}) => (event.output.success ? event.output.challenge : undefined)}),
                                     },
                                     {
@@ -288,7 +270,8 @@ const MFAMachine = setup({
                         },
                     },
                 },
-                // This branch shows the soft prompt when the current account has not accepted it on this device.
+                // Reached for a fresh/re-registration, or a returning user who hasn't accepted the soft
+                // prompt yet - see the routing comment on `decidingRegistration`.
                 [MFA_STATE.PROMPT]: {
                     id: MFA_STATE.PROMPT,
                     entry: ['navigateToPrompt'],

--- a/src/components/MultifactorAuthentication/machine/mfaMachine.ts
+++ b/src/components/MultifactorAuthentication/machine/mfaMachine.ts
@@ -25,6 +25,10 @@ const OUTCOME_TARGET = `#${MFA_STATE.OUTCOME}` as const;
 const PROMPT_TARGET = `#${MFA_STATE.PROMPT}` as const;
 const SOFT_PROMPT_CHECK_TARGET = `#${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}` as const;
 const VALIDATE_CODE_TARGET = `#${MFA_STATE.VALIDATE_CODE}` as const;
+const CREATING_CREDENTIAL_TARGET = `#${MFA_STATE.CREATING_CREDENTIAL}` as const;
+
+// One literal shared by both soft-prompt exits (approval and the persisted-acceptance skip), so they can't drift apart.
+const SOFT_PROMPT_ACCEPTED_ACTIONS = ['approveSoftPrompt', 'persistSoftPromptAcceptance'] as const;
 
 // Which prompt variant the screen renders is a device property, resolved once per platform.
 const PROMPT_TYPE = CONST.MULTIFACTOR_AUTHENTICATION.PROMPT_TYPE_MAP[deviceVerificationType];
@@ -60,6 +64,7 @@ const MFAMachine = setup({
     actors: createActors(),
     guards: {
         hasError: ({context}) => context.error !== undefined,
+        hasRegistrationChallenge: ({context}) => context.registrationChallenge !== undefined,
     },
     actions: {
         // Seeds the flow's context from the INIT event. A named action's event is typed as the full
@@ -207,7 +212,13 @@ const MFAMachine = setup({
                                     }
                                     return {accountID: context.accountID};
                                 },
-                                onDone: [{guard: ({event}) => event.output, target: OUTCOME_TARGET}, {target: PROMPT_TARGET}],
+                                // Not accepted yet -> show the prompt. Accepted with a challenge pending -> create the
+                                // credential. Accepted, nothing pending -> a returning user, straight to the outcome.
+                                onDone: [
+                                    {guard: ({event}) => !event.output, target: PROMPT_TARGET},
+                                    {guard: 'hasRegistrationChallenge', target: CREATING_CREDENTIAL_TARGET},
+                                    {target: OUTCOME_TARGET},
+                                ],
                                 onError: {
                                     target: OUTCOME_TARGET,
                                     actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Soft-prompt acceptance read', event.error)}),
@@ -283,13 +294,38 @@ const MFAMachine = setup({
                     entry: ['navigateToPrompt'],
                     initial: MFA_STATE.AWAITING_SOFT_PROMPT,
                     on: {
-                        SOFT_PROMPT_APPROVED: {
-                            target: MFA_STATE.OUTCOME,
-                            actions: ['approveSoftPrompt', 'persistSoftPromptAcceptance'],
-                        },
+                        SOFT_PROMPT_APPROVED: [
+                            {guard: 'hasRegistrationChallenge', target: MFA_STATE.CREATING_CREDENTIAL, actions: SOFT_PROMPT_ACCEPTED_ACTIONS},
+                            {target: MFA_STATE.OUTCOME, actions: SOFT_PROMPT_ACCEPTED_ACTIONS},
+                        ],
                     },
                     states: {
                         [MFA_STATE.AWAITING_SOFT_PROMPT]: {},
+                    },
+                },
+                // Turns a pending registration challenge into a real credential: platform ceremony, then
+                // backend registration. Reached from both soft-prompt exits when a challenge is pending.
+                // No `entry` action on purpose — whatever screen is already up (prompt, or nothing) just
+                // stays visible during the ceremony, same as legacy.
+                [MFA_STATE.CREATING_CREDENTIAL]: {
+                    id: MFA_STATE.CREATING_CREDENTIAL,
+                    invoke: {
+                        id: 'createCredential',
+                        src: 'createCredential',
+                        input: ({context}) => {
+                            if (context.accountID === undefined || context.registrationChallenge === undefined) {
+                                throw new Error('MFA account and registration challenge must be stored before creating a credential');
+                            }
+                            return {accountID: context.accountID, registrationChallenge: context.registrationChallenge};
+                        },
+                        onDone: [
+                            {guard: ({event}) => !event.output.success, target: OUTCOME_TARGET, actions: assign({error: ({event}) => getMFAFailureError(event.output)})},
+                            {target: OUTCOME_TARGET},
+                        ],
+                        onError: {
+                            target: OUTCOME_TARGET,
+                            actions: assign({error: ({event}) => createUnhandledExceptionMFAError('Credential registration', event.error)}),
+                        },
                     },
                 },
                 [MFA_STATE.OUTCOME]: {

--- a/src/components/MultifactorAuthentication/machine/snapshotToState.ts
+++ b/src/components/MultifactorAuthentication/machine/snapshotToState.ts
@@ -56,7 +56,9 @@ function snapshotToState(snapshot: MfaSnapshot): MfaState {
             },
         }),
         isProcessingPrompt: snapshot.matches({
-            [MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL,
+            [MFA_STATE.OPEN]: {
+                [MFA_STATE.PROMPT]: MFA_STATE.CREATING_CREDENTIAL,
+            },
         }),
         showsInvalidCodeError: snapshot.matches({
             [MFA_STATE.OPEN]: {

--- a/src/components/MultifactorAuthentication/machine/snapshotToState.ts
+++ b/src/components/MultifactorAuthentication/machine/snapshotToState.ts
@@ -22,8 +22,11 @@ type MfaState = MfaContext & {
     /** Whether the validate-code screen currently shows the inline invalid-code error. */
     showsInvalidCodeError: boolean;
 
-    /** Whether the machine currently accepts a soft-prompt approval. The prompt screen shows the confirm button only while this is true. */
-    canApproveSoftPrompt: boolean;
+    /**
+     * Whether the prompt screen is processing a non-interactive biometric step. Credential creation
+     * is the only such step in this slice; authorization will be included once it is migrated.
+     */
+    isProcessingPrompt: boolean;
 };
 
 function getModalState(snapshot: MfaSnapshot): MfaModalState {
@@ -52,7 +55,9 @@ function snapshotToState(snapshot: MfaSnapshot): MfaState {
                 [MFA_STATE.VALIDATE_CODE]: MFA_STATE.REQUESTING_REGISTRATION_CHALLENGE,
             },
         }),
-        canApproveSoftPrompt: snapshot.can({type: 'SOFT_PROMPT_APPROVED'}),
+        isProcessingPrompt: snapshot.matches({
+            [MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL,
+        }),
         showsInvalidCodeError: snapshot.matches({
             [MFA_STATE.OPEN]: {
                 [MFA_STATE.VALIDATE_CODE]: {

--- a/src/components/MultifactorAuthentication/machine/snapshotToState.ts
+++ b/src/components/MultifactorAuthentication/machine/snapshotToState.ts
@@ -21,6 +21,9 @@ type MfaState = MfaContext & {
 
     /** Whether the validate-code screen currently shows the inline invalid-code error. */
     showsInvalidCodeError: boolean;
+
+    /** Whether the machine currently accepts a soft-prompt approval. The prompt screen shows the confirm button only while this is true. */
+    canApproveSoftPrompt: boolean;
 };
 
 function getModalState(snapshot: MfaSnapshot): MfaModalState {
@@ -49,6 +52,7 @@ function snapshotToState(snapshot: MfaSnapshot): MfaState {
                 [MFA_STATE.VALIDATE_CODE]: MFA_STATE.REQUESTING_REGISTRATION_CHALLENGE,
             },
         }),
+        canApproveSoftPrompt: snapshot.can({type: 'SOFT_PROMPT_APPROVED'}),
         showsInvalidCodeError: snapshot.matches({
             [MFA_STATE.OPEN]: {
                 [MFA_STATE.VALIDATE_CODE]: {

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -1,4 +1,5 @@
 import type {AllowedAuthenticationMethods} from '@components/MultifactorAuthentication/biometrics/checkDeviceEligibility';
+import type {CreateCredentialParams} from '@components/MultifactorAuthentication/biometrics/shared/types';
 import type {MultifactorAuthenticationScenarioConfigFor} from '@components/MultifactorAuthentication/config';
 import type {
     MultifactorAuthenticationScenario,
@@ -89,8 +90,16 @@ type RequestRegistrationChallengeInput = {validateCode: string};
 /** A successful response must carry the validated registration challenge. */
 type RequestRegistrationChallengeOutput = MFAResult<{challenge: RegistrationChallenge}>;
 
+/** Input the machine passes to the credential-creation actor: everything `CreateCredentialParams` needs except the abort signal, which the actor supplies itself. */
+type CreateCredentialInput = Omit<CreateCredentialParams, 'signal'>;
+
+/** The credential-creation actor's result. `keyInfo` never leaves the actor, so a success carries no additional data. */
+type CreateCredentialOutput = MFAResult;
+
 export type {
     CheckLocalCredentialsInput,
+    CreateCredentialInput,
+    CreateCredentialOutput,
     MfaContext,
     MfaEvent,
     MfaModalState,

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -43,6 +43,9 @@ type MfaContext = {
     /** Whether the user approved the soft prompt during this flow. The durable acceptance lives in Onyx under the device-biometrics key. */
     softPromptApproved: boolean;
 
+    /** Whether the account had already accepted the soft prompt before this flow started. Captured once from Onyx and immutable for the flow's lifetime. */
+    hasEverAcceptedSoftPrompt: boolean;
+
     /** Whether the cancel-confirmation modal triggered by a back press is currently visible */
     isCancelConfirmVisible: boolean;
 };
@@ -63,6 +66,8 @@ type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScena
     scenarioName: T;
     scenario: MultifactorAuthenticationScenarioConfigFor<T>;
     payload: MultifactorAuthenticationScenarioParams<T> | undefined;
+    /** Snapshot of the account's persisted soft-prompt acceptance, captured just before this event was sent. */
+    hasEverAcceptedSoftPrompt: boolean;
 };
 
 /** Events handled by the MFA state machine. */
@@ -77,9 +82,6 @@ type MfaEvent =
 
 /** Describes the input the machine passes to the device-check actor. */
 type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationMethods};
-
-/** Identifies the per-account Onyx member read by the soft-prompt actor. */
-type ReadHasAcceptedSoftPromptInput = {accountID: number};
 
 /** Identifies the account whose local credentials the registration-decision actor checks. */
 type CheckLocalCredentialsInput = {accountID: number};
@@ -104,7 +106,6 @@ export type {
     MfaEvent,
     MfaModalState,
     MultifactorAuthenticationInitEvent,
-    ReadHasAcceptedSoftPromptInput,
     RequestRegistrationChallengeInput,
     RequestRegistrationChallengeOutput,
     ValidateDeviceInput,

--- a/src/components/MultifactorAuthentication/machine/types.ts
+++ b/src/components/MultifactorAuthentication/machine/types.ts
@@ -43,9 +43,6 @@ type MfaContext = {
     /** Whether the user approved the soft prompt during this flow. The durable acceptance lives in Onyx under the device-biometrics key. */
     softPromptApproved: boolean;
 
-    /** Whether the account had already accepted the soft prompt before this flow started. Captured once from Onyx and immutable for the flow's lifetime. */
-    hasEverAcceptedSoftPrompt: boolean;
-
     /** Whether the cancel-confirmation modal triggered by a back press is currently visible */
     isCancelConfirmVisible: boolean;
 };
@@ -66,8 +63,6 @@ type MultifactorAuthenticationInitEvent<T extends MultifactorAuthenticationScena
     scenarioName: T;
     scenario: MultifactorAuthenticationScenarioConfigFor<T>;
     payload: MultifactorAuthenticationScenarioParams<T> | undefined;
-    /** Snapshot of the account's persisted soft-prompt acceptance, captured just before this event was sent. */
-    hasEverAcceptedSoftPrompt: boolean;
 };
 
 /** Events handled by the MFA state machine. */
@@ -83,8 +78,14 @@ type MfaEvent =
 /** Describes the input the machine passes to the device-check actor. */
 type ValidateDeviceInput = {allowedAuthenticationMethods: AllowedAuthenticationMethods};
 
-/** Identifies the account whose local credentials the registration-decision actor checks. */
-type CheckLocalCredentialsInput = {accountID: number};
+/** Identifies the account whose device-local registration state the machine loads. */
+type LoadRegistrationStateInput = {accountID: number};
+
+/** Device-local signals needed to choose between registration and authorization. */
+type LoadRegistrationStateOutput = {
+    hasLocalCredentials: boolean;
+    hasEverAcceptedSoftPrompt: boolean;
+};
 
 /** Validate code sent to the backend to obtain a registration challenge. */
 type RequestRegistrationChallengeInput = {validateCode: string};
@@ -99,9 +100,10 @@ type CreateCredentialInput = Omit<CreateCredentialParams, 'signal'>;
 type CreateCredentialOutput = MFAResult;
 
 export type {
-    CheckLocalCredentialsInput,
     CreateCredentialInput,
     CreateCredentialOutput,
+    LoadRegistrationStateInput,
+    LoadRegistrationStateOutput,
     MfaContext,
     MfaEvent,
     MfaModalState,

--- a/src/components/MultifactorAuthentication/observability/trackMFAFlowOutcome.ts
+++ b/src/components/MultifactorAuthentication/observability/trackMFAFlowOutcome.ts
@@ -29,6 +29,7 @@ function classifyFailure(reason: MultifactorAuthenticationReason | undefined): F
 type CredentialsState = {
     hasServerCredentials: boolean;
     hasLocalCredentials: boolean;
+    hasEverAcceptedSoftPrompt: boolean;
 };
 
 type MFAFlowOutcomeContext = {

--- a/src/components/MultifactorAuthentication/observability/trackMFAFlowOutcome.ts
+++ b/src/components/MultifactorAuthentication/observability/trackMFAFlowOutcome.ts
@@ -26,7 +26,8 @@ function classifyFailure(reason: MultifactorAuthenticationReason | undefined): F
     return 'unclassified';
 }
 
-type CredentialsState = {
+/** Snapshot of account and device registration signals captured at MFA flow boundaries for routing decisions and telemetry. */
+type MFARegistrationStateSnapshot = {
     hasServerCredentials: boolean;
     hasLocalCredentials: boolean;
     hasEverAcceptedSoftPrompt: boolean;
@@ -41,8 +42,8 @@ type MFAFlowOutcomeContext = {
     isRegistrationComplete: boolean;
     isAuthorizationComplete: boolean;
     softPromptApproved: boolean;
-    startState: CredentialsState;
-    endState: CredentialsState;
+    startState: MFARegistrationStateSnapshot;
+    endState: MFARegistrationStateSnapshot;
 };
 
 function trackMFAFlowOutcome(context: MFAFlowOutcomeContext): void {
@@ -99,4 +100,4 @@ function trackMFAFlowOutcome(context: MFAFlowOutcomeContext): void {
 }
 
 export default trackMFAFlowOutcome;
-export type {CredentialsState};
+export type {MFARegistrationStateSnapshot};

--- a/src/components/MultifactorAuthentication/observability/trackMFAFlowStart.ts
+++ b/src/components/MultifactorAuthentication/observability/trackMFAFlowStart.ts
@@ -1,18 +1,18 @@
 import Log from '@libs/Log';
 
-import type {CredentialsState} from './trackMFAFlowOutcome';
+import type {MFARegistrationStateSnapshot} from './trackMFAFlowOutcome';
 
 type MFAFlowStartContext = {
     scenario: string;
     isOffline: boolean;
-    credentialsState: CredentialsState;
+    registrationState: MFARegistrationStateSnapshot;
 };
 
 function trackMFAFlowStart(context: MFAFlowStartContext): void {
     const extra = {
         scenario: context.scenario,
         isOffline: context.isOffline,
-        ...context.credentialsState,
+        ...context.registrationState,
     };
 
     Log.info('[MFA] Flow started', false, {mfa: extra});

--- a/src/libs/MultifactorAuthentication/Passkeys/WebAuthn.ts
+++ b/src/libs/MultifactorAuthentication/Passkeys/WebAuthn.ts
@@ -81,9 +81,12 @@ function isPublicKeyCredential(credential: Credential): credential is PublicKeyC
     return credential instanceof PublicKeyCredential;
 }
 
-/** Prompts the user to create a new passkey credential via the platform authenticator. */
-async function createPasskeyCredential(options: PublicKeyCredentialCreationOptions): Promise<PublicKeyCredential> {
-    const result = await navigator.credentials.create({publicKey: options});
+/**
+ * Prompts the user to create a new passkey credential via the platform authenticator. `signal` lets
+ * a caller close the dialog early (e.g. flow cancelled) — the promise rejects with an `AbortError`.
+ */
+async function createPasskeyCredential(options: PublicKeyCredentialCreationOptions, signal?: AbortSignal): Promise<PublicKeyCredential> {
+    const result = await navigator.credentials.create({publicKey: options, signal});
     if (!result || !isPublicKeyCredential(result)) {
         throw new Error('navigator.credentials.create did not return a PublicKeyCredential');
     }

--- a/src/libs/MultifactorAuthentication/shared/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/shared/VALUES.ts
@@ -230,6 +230,7 @@ const MFA_STATE = {
     REQUESTING_REGISTRATION_CHALLENGE: 'requestingRegistrationChallenge',
     PROMPT: 'prompt',
     AWAITING_SOFT_PROMPT: 'awaitingSoftPrompt',
+    CREATING_CREDENTIAL: 'creatingCredential',
     OUTCOME: 'outcome',
     RESOLVING_OUTCOME: 'resolvingOutcome',
     SUCCESS: 'success',

--- a/src/libs/MultifactorAuthentication/shared/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/shared/VALUES.ts
@@ -48,8 +48,8 @@ const REASON = {
         CANCELED: 'Local: Flow canceled by user',
         /** No HTTP status code present — typically a network failure, JSON parse error, or unhandled exception in an action function. */
         UNHANDLED_API_RESPONSE: 'Local: Missing HTTP status in API response',
-        /** Onyx write for a newly created passkey credential failed — registering with the backend anyway would desync it from `areLocalCredentialsKnownToServer`/`authorize()`. */
-        LOCAL_PERSISTENCE_FAILED: 'Local: Failed to persist passkey credential locally',
+        /** Updating the local passkey credential list failed before backend registration. */
+        LOCAL_CREDENTIAL_UPDATE_FAILED: 'Local: Failed to update passkey credentials',
         WEBAUTHN: {
             NOT_ALLOWED: 'Local WebAuthn: Operation not allowed',
             INVALID_STATE: 'Local WebAuthn: Invalid state',
@@ -198,7 +198,7 @@ const ANOMALOUS_FAILURES = new Set<ReasonValue>([
     REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION,
     REASON.LOCAL_ERRORS.UNRECOGNIZED,
     REASON.LOCAL_ERRORS.SIGNATURE_MISSING,
-    REASON.LOCAL_ERRORS.LOCAL_PERSISTENCE_FAILED,
+    REASON.LOCAL_ERRORS.LOCAL_CREDENTIAL_UPDATE_FAILED,
     REASON.LOCAL_ERRORS.WEBAUTHN.INVALID_STATE,
     REASON.LOCAL_ERRORS.WEBAUTHN.SECURITY_ERROR,
     REASON.LOCAL_ERRORS.WEBAUTHN.CONSTRAINT_ERROR,

--- a/src/libs/MultifactorAuthentication/shared/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/shared/VALUES.ts
@@ -48,6 +48,8 @@ const REASON = {
         CANCELED: 'Local: Flow canceled by user',
         /** No HTTP status code present — typically a network failure, JSON parse error, or unhandled exception in an action function. */
         UNHANDLED_API_RESPONSE: 'Local: Missing HTTP status in API response',
+        /** Onyx write for a newly created passkey credential failed — registering with the backend anyway would desync it from `areLocalCredentialsKnownToServer`/`authorize()`. */
+        LOCAL_PERSISTENCE_FAILED: 'Local: Failed to persist passkey credential locally',
         WEBAUTHN: {
             NOT_ALLOWED: 'Local WebAuthn: Operation not allowed',
             INVALID_STATE: 'Local WebAuthn: Invalid state',
@@ -196,6 +198,7 @@ const ANOMALOUS_FAILURES = new Set<ReasonValue>([
     REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION,
     REASON.LOCAL_ERRORS.UNRECOGNIZED,
     REASON.LOCAL_ERRORS.SIGNATURE_MISSING,
+    REASON.LOCAL_ERRORS.LOCAL_PERSISTENCE_FAILED,
     REASON.LOCAL_ERRORS.WEBAUTHN.INVALID_STATE,
     REASON.LOCAL_ERRORS.WEBAUTHN.SECURITY_ERROR,
     REASON.LOCAL_ERRORS.WEBAUTHN.CONSTRAINT_ERROR,
@@ -222,7 +225,6 @@ const MFA_STATE = {
     PREPARING: 'preparing',
     VALIDATING_DEVICE: 'validatingDevice',
     DECIDING_REGISTRATION: 'decidingRegistration',
-    CHECKING_SOFT_PROMPT_ACCEPTANCE: 'checkingSoftPromptAcceptance',
     VALIDATE_CODE: 'validateCode',
     AWAITING_VALIDATE_CODE: 'awaitingValidateCode',
     AWAITING_INPUT: 'awaitingInput',

--- a/src/libs/actions/Passkey.ts
+++ b/src/libs/actions/Passkey.ts
@@ -21,12 +21,13 @@ type SetLocalPasskeyCredentialsParams = PasskeyScope & {
  * Sets passkey credentials in Onyx storage.
  * We use Onyx.set() instead of Onyx.merge() because passkey entries contain an array of credentials
  * that needs to be fully replaced, not merged. Using merge() would append to the array instead of replacing it.
+ * Returns the write's promise so callers that care can await it.
  */
-function setLocalPasskeyCredentials({userId, entry}: SetLocalPasskeyCredentialsParams): void {
+function setLocalPasskeyCredentials({userId, entry}: SetLocalPasskeyCredentialsParams): Promise<void> {
     if (!userId) {
         throw new Error('userId is required to store passkey credentials');
     }
-    Onyx.set(getPasskeyOnyxKey(userId), entry);
+    return Onyx.set(getPasskeyOnyxKey(userId), entry);
 }
 
 type AddLocalPasskeyCredentialParams = PasskeyScope & {
@@ -34,14 +35,14 @@ type AddLocalPasskeyCredentialParams = PasskeyScope & {
     existingCredentials: LocalPasskeyCredentialsEntry | null;
 };
 
-function addLocalPasskeyCredential({userId, credential, existingCredentials}: AddLocalPasskeyCredentialParams): void {
+function addLocalPasskeyCredential({userId, credential, existingCredentials}: AddLocalPasskeyCredentialParams): Promise<void> {
     const credentials = existingCredentials ?? [];
 
     if (credentials.some((c) => c.id === credential.id)) {
         throw new Error(`Passkey credential with id "${credential.id}" already exists for user ${userId}`);
     }
 
-    setLocalPasskeyCredentials({userId, entry: [...credentials, credential]});
+    return setLocalPasskeyCredentials({userId, entry: [...credentials, credential]});
 }
 
 /** Deletes all passkey credentials for a user from Onyx storage */

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -22,14 +22,14 @@ import React from 'react';
 type MultifactorAuthenticationPromptPageProps = PlatformStackScreenProps<MultifactorAuthenticationModalNavigatorParamList, typeof SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT>;
 
 /**
- * The machine routes here only when the account has not accepted the soft prompt on this device,
- * so the copy is static and the confirm button is always available.
+ * Once confirmed, the machine moves into credential creation and can no longer accept
+ * `SOFT_PROMPT_APPROVED`, so the button swaps to loading instead of staying pressable.
  */
 function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationPromptPageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {requestCancel, approveSoftPrompt, state} = useMultifactorAuthenticationInternal();
-    const {isCancelConfirmVisible} = state;
+    const {isCancelConfirmVisible, canApproveSoftPrompt} = state;
 
     const {illustration, title, subtitle} = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[route.params.promptType];
     const interceptFocusTrapEscape = useMFACancelOnEscape();
@@ -62,6 +62,7 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
                         variant={CONST.BUTTON_VARIANT.SUCCESS}
                         size={CONST.BUTTON_SIZE.LARGE}
                         onPress={approveSoftPrompt}
+                        isLoading={!canApproveSoftPrompt}
                         testID={CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID.PROMPT_CONFIRM_BUTTON}
                     >
                         <Button.Text>{translate('common.buttonConfirm')}</Button.Text>

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -2,6 +2,7 @@ import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOffli
 import Button from '@components/ButtonComposed';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import LoadingIndicator from '@components/LoadingIndicator';
 import {MULTIFACTOR_AUTHENTICATION_PROMPT_UI} from '@components/MultifactorAuthentication/config';
 import {useMultifactorAuthenticationInternal} from '@components/MultifactorAuthentication/Context/MultifactorAuthenticationInternalApiContext';
 import MultifactorAuthenticationPromptContent from '@components/MultifactorAuthentication/PromptContent';
@@ -14,10 +15,13 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {MultifactorAuthenticationModalNavigatorParamList} from '@libs/Navigation/types';
 
+import variables from '@styles/variables';
+
 import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
 
 import React from 'react';
+import {View} from 'react-native';
 
 type MultifactorAuthenticationPromptPageProps = PlatformStackScreenProps<MultifactorAuthenticationModalNavigatorParamList, typeof SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT>;
 
@@ -54,15 +58,20 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
                     subtitle={subtitle}
                 />
                 <FixedFooter style={[styles.flexColumn, styles.gap3]}>
-                    <Button
-                        variant={CONST.BUTTON_VARIANT.SUCCESS}
-                        size={CONST.BUTTON_SIZE.LARGE}
-                        onPress={approveSoftPrompt}
-                        isLoading={isProcessingPrompt}
-                        testID={CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID.PROMPT_CONFIRM_BUTTON}
-                    >
-                        <Button.Text>{translate('common.buttonConfirm')}</Button.Text>
-                    </Button>
+                    {isProcessingPrompt ? (
+                        <View style={[styles.w100, styles.justifyContentCenter, {height: variables.componentSizeLarge}]}>
+                            <LoadingIndicator iconSize={28} />
+                        </View>
+                    ) : (
+                        <Button
+                            variant={CONST.BUTTON_VARIANT.SUCCESS}
+                            size={CONST.BUTTON_SIZE.LARGE}
+                            onPress={approveSoftPrompt}
+                            testID={CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID.PROMPT_CONFIRM_BUTTON}
+                        >
+                            <Button.Text>{translate('common.buttonConfirm')}</Button.Text>
+                        </Button>
+                    )}
                 </FixedFooter>
             </FullPageOfflineBlockingView>
         </ScreenWrapper>

--- a/src/pages/MultifactorAuthentication/PromptPage.tsx
+++ b/src/pages/MultifactorAuthentication/PromptPage.tsx
@@ -21,15 +21,11 @@ import React from 'react';
 
 type MultifactorAuthenticationPromptPageProps = PlatformStackScreenProps<MultifactorAuthenticationModalNavigatorParamList, typeof SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT>;
 
-/**
- * Once confirmed, the machine moves into credential creation and can no longer accept
- * `SOFT_PROMPT_APPROVED`, so the button swaps to loading instead of staying pressable.
- */
 function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationPromptPageProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {requestCancel, approveSoftPrompt, state} = useMultifactorAuthenticationInternal();
-    const {isCancelConfirmVisible, canApproveSoftPrompt} = state;
+    const {isCancelConfirmVisible, isProcessingPrompt} = state;
 
     const {illustration, title, subtitle} = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[route.params.promptType];
     const interceptFocusTrapEscape = useMFACancelOnEscape();
@@ -62,7 +58,7 @@ function MultifactorAuthenticationPromptPage({route}: MultifactorAuthenticationP
                         variant={CONST.BUTTON_VARIANT.SUCCESS}
                         size={CONST.BUTTON_SIZE.LARGE}
                         onPress={approveSoftPrompt}
-                        isLoading={!canApproveSoftPrompt}
+                        isLoading={isProcessingPrompt}
                         testID={CONST.MULTIFACTOR_AUTHENTICATION.TEST_ID.PROMPT_CONFIRM_BUTTON}
                     >
                         <Button.Text>{translate('common.buttonConfirm')}</Button.Text>

--- a/tests/unit/components/MultifactorAuthentication/ValidateCodePage.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/ValidateCodePage.test.tsx
@@ -8,7 +8,7 @@ import type * as MfaRealUiMocks from 'tests/utils/mfa/realUi/mocks';
 import Onyx from 'react-native-onyx';
 import createInitEvent, {MFA_TEST_ACCOUNT_ID, MFA_TEST_VALIDATE_CODE} from 'tests/utils/mfa/flowFixtures';
 import renderMfaUi from 'tests/utils/mfa/realUi/harness';
-import {checkLocalCredentialsControl, resetMfaUiMocks, validateDeviceControl} from 'tests/utils/mfa/realUi/mocks';
+import {loadRegistrationStateControl, resetMfaUiMocks, validateDeviceControl} from 'tests/utils/mfa/realUi/mocks';
 import {translateLocal} from 'tests/utils/TestHelper';
 import waitForBatchedUpdatesWithAct from 'tests/utils/waitForBatchedUpdatesWithAct';
 
@@ -54,7 +54,7 @@ describe('MultifactorAuthenticationValidateCodePage', () => {
 
         await act(async () => validateDeviceControl.resolve({success: true}));
         await waitForBatchedUpdatesWithAct();
-        await act(async () => checkLocalCredentialsControl.resolve(false));
+        await act(async () => loadRegistrationStateControl.resolve({hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false}));
         await waitForBatchedUpdatesWithAct();
 
         const submitButton = screen.getByTestId(TEST_ID.VALIDATE_CODE_SUBMIT_BUTTON);

--- a/tests/unit/components/MultifactorAuthentication/biometricsOperations.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/biometricsOperations.test.ts
@@ -2,27 +2,33 @@
 // (operations/index.native.ts), which checks the HSM biometric sensor.
 import {
     areLocalCredentialsKnownToServer,
+    createCredential,
     deviceCheckFailureReason,
     deviceVerificationType,
     doesDeviceSupportAuthenticationMethod,
 } from '@components/MultifactorAuthentication/biometrics/operations';
 
+import type {RegistrationChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
 import VALUES from '@libs/MultifactorAuthentication/VALUES';
 
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import Base64URL from '@src/utils/Base64URL';
 
 import Onyx from 'react-native-onyx';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 
 const mockIsSensorAvailable = jest.fn();
 const mockGetAllKeys = jest.fn();
+const mockCreateKeys = jest.fn();
 
 jest.mock('@sbaiahmed1/react-native-biometrics', () => ({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     isSensorAvailable: (...args: unknown[]) => mockIsSensorAvailable(...args),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     getAllKeys: (...args: unknown[]) => mockGetAllKeys(...args),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    createKeys: (...args: unknown[]) => mockCreateKeys(...args),
 }));
 
 const ACCOUNT_ID = 12345;
@@ -30,6 +36,13 @@ const ACCOUNT_ID = 12345;
 // characters below only match after the module's base64url conversion.
 const LOCAL_PUBLIC_KEY_BASE64 = 'Ab+/cd==';
 const LOCAL_CREDENTIAL_ID = 'Ab-_cd';
+const REGISTRATION_CHALLENGE: RegistrationChallenge = {
+    challenge: 'native-registration-challenge',
+    rp: {id: 'expensify.com'},
+    user: {id: 'native-test-user', displayName: 'Native Test User'},
+    pubKeyCredParams: [{type: 'public-key', alg: -7}],
+    timeout: 60000,
+};
 
 describe('biometrics operations (native)', () => {
     beforeEach(() => {
@@ -95,6 +108,51 @@ describe('biometrics operations (native)', () => {
             await Onyx.merge(ONYXKEYS.ACCOUNT, {multifactorAuthenticationPublicKeyIDs: [LOCAL_CREDENTIAL_ID]});
 
             await expect(areLocalCredentialsKnownToServer(ACCOUNT_ID)).resolves.toBe(false);
+        });
+    });
+
+    // Mirrors the `register` cases in useNativeBiometricsHSM.test.ts, which move over here when that
+    // hook is deleted.
+    describe('createCredential', () => {
+        beforeEach(() => {
+            mockCreateKeys.mockResolvedValue({publicKey: LOCAL_PUBLIC_KEY_BASE64});
+        });
+
+        it('creates the HSM key with the account-specific alias', async () => {
+            await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(mockCreateKeys).toHaveBeenCalledWith('12345_HSM_KEY', 'ec256', undefined, true, false);
+        });
+
+        it('returns the exact NativeBiometricsHSMKeyInfo shape on success', async () => {
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result).toEqual({
+                success: true,
+                keyInfo: {
+                    rawId: LOCAL_CREDENTIAL_ID,
+                    type: CONST.MULTIFACTOR_AUTHENTICATION.BIOMETRICS_HSM_TYPE,
+                    response: {
+                        clientDataJSON: Base64URL.encode(JSON.stringify({challenge: REGISTRATION_CHALLENGE.challenge})),
+                        biometric: {
+                            publicKey: LOCAL_CREDENTIAL_ID,
+                            algorithm: CONST.COSE_ALGORITHM.ES256,
+                        },
+                    },
+                },
+            });
+        });
+
+        it('returns a failed result with the mapped reason when the library throws', async () => {
+            mockCreateKeys.mockRejectedValue(Object.assign(new Error('Key creation failed'), {code: 'CREATE_KEYS_ERROR'}));
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result.success).toBe(false);
+            if (result.success) {
+                throw new Error('Expected credential creation to fail');
+            }
+            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.HSM.KEY_CREATION_FAILED);
         });
     });
 });

--- a/tests/unit/components/MultifactorAuthentication/biometricsOperations.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/biometricsOperations.test.ts
@@ -111,8 +111,6 @@ describe('biometrics operations (native)', () => {
         });
     });
 
-    // Mirrors the `register` cases in useNativeBiometricsHSM.test.ts, which move over here when that
-    // hook is deleted.
     describe('createCredential', () => {
         beforeEach(() => {
             mockCreateKeys.mockResolvedValue({publicKey: LOCAL_PUBLIC_KEY_BASE64});

--- a/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
@@ -11,6 +11,7 @@ import type * as WebAuthnModule from '@libs/MultifactorAuthentication/Passkeys/W
 import {arrayBufferToBase64URL, extractAAGUID} from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
 import type {RegistrationChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
 
+import type * as PasskeyActionsModule from '@userActions/Passkey';
 import {getPasskeyOnyxKey} from '@userActions/Passkey';
 
 import CONST from '@src/CONST';
@@ -27,6 +28,15 @@ const mockCreatePasskeyCredential = jest.fn<Promise<PublicKeyCredential>, [Publi
 jest.mock('@libs/MultifactorAuthentication/Passkeys/WebAuthn', () => ({
     ...jest.requireActual<typeof WebAuthnModule>('@libs/MultifactorAuthentication/Passkeys/WebAuthn'),
     createPasskeyCredential: (options: PublicKeyCredentialCreationOptions, signal?: AbortSignal) => mockCreatePasskeyCredential(options, signal),
+}));
+
+const mockAddLocalPasskeyCredential = jest.fn<ReturnType<typeof PasskeyActionsModule.addLocalPasskeyCredential>, Parameters<typeof PasskeyActionsModule.addLocalPasskeyCredential>>();
+
+// Only the local-persistence write is mocked here, and only to simulate it rejecting — every other
+// test relies on this delegating straight through to the real Onyx-backed implementation.
+jest.mock('@userActions/Passkey', () => ({
+    ...jest.requireActual<typeof PasskeyActionsModule>('@userActions/Passkey'),
+    addLocalPasskeyCredential: (params: Parameters<typeof PasskeyActionsModule.addLocalPasskeyCredential>[0]) => mockAddLocalPasskeyCredential(params),
 }));
 
 // jest-expo resolves the native variant by default, so load the web entry point explicitly.
@@ -168,6 +178,9 @@ describe('biometrics operations (web)', () => {
 
         beforeEach(() => {
             mockCreatePasskeyCredential.mockReset();
+            mockAddLocalPasskeyCredential
+                .mockReset()
+                .mockImplementation((params) => jest.requireActual<typeof PasskeyActionsModule>('@userActions/Passkey').addLocalPasskeyCredential(params));
             Object.defineProperty(window, 'AuthenticatorAttestationResponse', {configurable: true, value: FakeAuthenticatorAttestationResponse});
         });
 
@@ -266,6 +279,26 @@ describe('biometrics operations (web)', () => {
             await waitForBatchedUpdates();
             const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));
             expect(storedCredentials?.map((credential) => credential.id)).toEqual([duplicateCredentialId]);
+        });
+
+        it('fails instead of reporting success when the local Onyx write rejects', async () => {
+            // If this were swallowed, the caller would register the credential with the backend
+            // anyway, leaving the server aware of a credential this device can't find in Onyx again --
+            // `areLocalCredentialsKnownToServer` would force the user back into registration.
+            mockAddLocalPasskeyCredential.mockRejectedValueOnce(new Error('Onyx write failed'));
+            mockCreatePasskeyCredential.mockResolvedValue(buildFakeAttestationCredential(bytesToArrayBuffer([11, 22, 33]), buildFakeAttestationResponse()));
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result.success).toBe(false);
+            if (result.success) {
+                throw new Error('Expected credential creation to fail');
+            }
+            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.LOCAL_PERSISTENCE_FAILED);
+
+            await waitForBatchedUpdates();
+            const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));
+            expect(storedCredentials ?? []).toEqual([]);
         });
 
         it('passes the abort signal through to the ceremony, so cancelling the flow can close the passkey dialog', async () => {

--- a/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
@@ -4,7 +4,12 @@
  *
  * @jest-environment jsdom
  */
+/* eslint-disable max-classes-per-file -- two fake DOM globals (`FakeAuthenticatorAttestationResponse`, `PublicKeyCredential`) are each simplest as a class expression. */
 import type * as WebBiometricsOperations from '@components/MultifactorAuthentication/biometrics/operations/index';
+
+import type * as WebAuthnModule from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
+import {arrayBufferToBase64URL, extractAAGUID} from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
+import type {RegistrationChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
 
 import {getPasskeyOnyxKey} from '@userActions/Passkey';
 
@@ -12,15 +17,84 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 import Onyx from 'react-native-onyx';
+import getOnyxValue from 'tests/utils/getOnyxValue';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 
+const mockCreatePasskeyCredential = jest.fn<Promise<PublicKeyCredential>, [PublicKeyCredentialCreationOptions]>();
+
+// The navigator boundary is the only thing mocked here; the real option-building, extraction, and
+// error-decoding helpers stay under test, matching checkDeviceEligibility.test.ts's partial-mock shape.
+jest.mock('@libs/MultifactorAuthentication/Passkeys/WebAuthn', () => ({
+    ...jest.requireActual<typeof WebAuthnModule>('@libs/MultifactorAuthentication/Passkeys/WebAuthn'),
+    createPasskeyCredential: (options: PublicKeyCredentialCreationOptions) => mockCreatePasskeyCredential(options),
+}));
+
 // jest-expo resolves the native variant by default, so load the web entry point explicitly.
-const {areLocalCredentialsKnownToServer, deviceCheckFailureReason, deviceVerificationType, doesDeviceSupportAuthenticationMethod} = jest.requireActual<typeof WebBiometricsOperations>(
-    '@components/MultifactorAuthentication/biometrics/operations/index.ts',
-);
+const {areLocalCredentialsKnownToServer, createCredential, deviceCheckFailureReason, deviceVerificationType, doesDeviceSupportAuthenticationMethod} = jest.requireActual<
+    typeof WebBiometricsOperations
+>('@components/MultifactorAuthentication/biometrics/operations/index.ts');
 
 const ACCOUNT_ID = 12345;
 const LOCAL_PASSKEY_ID = 'local-passkey-credential-id';
+
+/**
+ * jsdom has no `AuthenticatorAttestationResponse` global. `window === globalThis` in jsdom, so
+ * assigning it here lets the operation's bare `instanceof AuthenticatorAttestationResponse` check
+ * resolve against this fake class.
+ */
+class FakeAuthenticatorAttestationResponse {
+    clientDataJSON: ArrayBuffer;
+
+    attestationObject: ArrayBuffer;
+
+    private transports: string[];
+
+    private authenticatorData: ArrayBuffer;
+
+    constructor(clientDataJSON: ArrayBuffer, attestationObject: ArrayBuffer, transports: string[], authenticatorData: ArrayBuffer) {
+        this.clientDataJSON = clientDataJSON;
+        this.attestationObject = attestationObject;
+        this.transports = transports;
+        this.authenticatorData = authenticatorData;
+    }
+
+    getTransports(): string[] {
+        return this.transports;
+    }
+
+    getAuthenticatorData(): ArrayBuffer {
+        return this.authenticatorData;
+    }
+}
+
+function bytesToArrayBuffer(bytes: number[]): ArrayBuffer {
+    return new Uint8Array(bytes).buffer;
+}
+
+/** 55 bytes so the aaguid slice (bytes 37-52) is populated and meaningful. */
+const FAKE_AUTHENTICATOR_DATA = bytesToArrayBuffer(Array.from({length: 55}, (_, index) => index));
+const EXPECTED_AAGUID = extractAAGUID(FAKE_AUTHENTICATOR_DATA);
+
+function buildFakeAttestationCredential(rawId: ArrayBuffer, response: unknown) {
+    // The operation only reads `rawId` and `response` off the WebAuthn credential, so a minimal fake
+    // stands in for the full `PublicKeyCredential` shape jsdom cannot produce.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- see comment above.
+    return {rawId, response} as unknown as PublicKeyCredential;
+}
+
+function buildFakeAttestationResponse(transports: string[] = [CONST.PASSKEY_TRANSPORT.INTERNAL, CONST.PASSKEY_TRANSPORT.HYBRID]) {
+    return new FakeAuthenticatorAttestationResponse(bytesToArrayBuffer([1, 2, 3]), bytesToArrayBuffer([4, 5, 6]), transports, FAKE_AUTHENTICATOR_DATA);
+}
+
+const REGISTRATION_CHALLENGE: RegistrationChallenge = {
+    challenge: 'web-registration-challenge',
+    rp: {id: 'expensify.com'},
+    user: {id: 'web-test-user', displayName: 'Web Test User'},
+    pubKeyCredParams: [{type: 'public-key', alg: -7}],
+    timeout: 60000,
+};
+
+const originalAuthenticatorAttestationResponseDescriptor = Object.getOwnPropertyDescriptor(window, 'AuthenticatorAttestationResponse');
 
 const originalPublicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(window, 'PublicKeyCredential');
 
@@ -82,6 +156,114 @@ describe('biometrics operations (web)', () => {
             await Onyx.merge(ONYXKEYS.ACCOUNT, {multifactorAuthenticationPublicKeyIDs: [LOCAL_PASSKEY_ID]});
 
             await expect(areLocalCredentialsKnownToServer(ACCOUNT_ID)).resolves.toBe(false);
+        });
+    });
+
+    // No coverage exists yet for `usePasskeys.register()`'s ceremony; this pins it at the operation
+    // level ahead of the hook being deleted.
+    describe('createCredential', () => {
+        const KNOWN_CREDENTIAL_ID = 'known-cred-id';
+
+        beforeEach(() => {
+            mockCreatePasskeyCredential.mockReset();
+            Object.defineProperty(window, 'AuthenticatorAttestationResponse', {configurable: true, value: FakeAuthenticatorAttestationResponse});
+        });
+
+        afterEach(async () => {
+            if (originalAuthenticatorAttestationResponseDescriptor) {
+                Object.defineProperty(window, 'AuthenticatorAttestationResponse', originalAuthenticatorAttestationResponseDescriptor);
+            } else {
+                Reflect.deleteProperty(window, 'AuthenticatorAttestationResponse');
+            }
+            await Onyx.clear();
+            await waitForBatchedUpdates();
+        });
+
+        it('creates the passkey, persists it locally, and returns the exact keyInfo shape', async () => {
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {multifactorAuthenticationPublicKeyIDs: [KNOWN_CREDENTIAL_ID, 'server-only-id']});
+            await Onyx.set(getPasskeyOnyxKey(String(ACCOUNT_ID)), [{id: KNOWN_CREDENTIAL_ID, type: CONST.PASSKEY_CREDENTIAL_TYPE}]);
+
+            const rawId = bytesToArrayBuffer([10, 20, 30, 40]);
+            const expectedCredentialId = arrayBufferToBase64URL(rawId);
+            mockCreatePasskeyCredential.mockResolvedValue(buildFakeAttestationCredential(rawId, buildFakeAttestationResponse()));
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result).toEqual({
+                success: true,
+                keyInfo: {
+                    rawId: expectedCredentialId,
+                    type: CONST.PASSKEY_CREDENTIAL_TYPE,
+                    transports: [CONST.PASSKEY_TRANSPORT.INTERNAL, CONST.PASSKEY_TRANSPORT.HYBRID],
+                    aaguid: EXPECTED_AAGUID,
+                    response: {
+                        clientDataJSON: arrayBufferToBase64URL(bytesToArrayBuffer([1, 2, 3])),
+                        attestationObject: arrayBufferToBase64URL(bytesToArrayBuffer([4, 5, 6])),
+                    },
+                },
+            });
+
+            // The reconciled (server-known) local credentials, not the raw local list, are excluded.
+            // `buildAllowedCredentialDescriptors` (the real, unmocked helper) always builds `id` as a
+            // plain ArrayBuffer, even though the DOM lib widens `PublicKeyCredentialDescriptor.id` to
+            // `BufferSource`.
+            const optionsPassedToCeremony = mockCreatePasskeyCredential.mock.calls.at(0)?.[0];
+            const excludedCredentialId = optionsPassedToCeremony?.excludeCredentials?.at(0)?.id;
+            expect(optionsPassedToCeremony?.excludeCredentials).toHaveLength(1);
+            expect(excludedCredentialId).toBeDefined();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- see comment above.
+            expect(arrayBufferToBase64URL((excludedCredentialId ?? new ArrayBuffer(0)) as ArrayBuffer)).toBe(KNOWN_CREDENTIAL_ID);
+
+            await waitForBatchedUpdates();
+            const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));
+            expect(storedCredentials?.map((credential) => credential.id)).toEqual(expect.arrayContaining([KNOWN_CREDENTIAL_ID, expectedCredentialId]));
+        });
+
+        it('maps a WebAuthn DOMException to the corresponding local error reason', async () => {
+            mockCreatePasskeyCredential.mockRejectedValue(new DOMException('The operation was not allowed', 'NotAllowedError'));
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result.success).toBe(false);
+            if (result.success) {
+                throw new Error('Expected credential creation to fail');
+            }
+            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.WEBAUTHN.NOT_ALLOWED);
+        });
+
+        it('rejects an unexpected response type', async () => {
+            const rawId = bytesToArrayBuffer([50, 60, 70]);
+            mockCreatePasskeyCredential.mockResolvedValue(buildFakeAttestationCredential(rawId, {}));
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result.success).toBe(false);
+            if (result.success) {
+                throw new Error('Expected credential creation to fail');
+            }
+            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.WEBAUTHN.UNEXPECTED_RESPONSE);
+        });
+
+        it('still persists the credential when reconciliation has already wiped the duplicate id', async () => {
+            // The backend doesn't know this id, so reconciliation removes it from Onyx before the
+            // ceremony runs. The ceremony then resolves with the same rawId bytes, so the new
+            // credential's id collides with the entry reconciliation just wiped. A duplicate check
+            // against the stale pre-reconciliation list would spuriously throw here and, if swallowed,
+            // would leave the credential registered on the backend but absent from local storage --
+            // the next launch would find no local credential and force re-registration. Success alone
+            // doesn't catch that regression, so this also asserts the credential is actually stored.
+            const rawId = bytesToArrayBuffer([70, 80, 90]);
+            const duplicateCredentialId = arrayBufferToBase64URL(rawId);
+            await Onyx.set(getPasskeyOnyxKey(String(ACCOUNT_ID)), [{id: duplicateCredentialId, type: CONST.PASSKEY_CREDENTIAL_TYPE}]);
+            mockCreatePasskeyCredential.mockResolvedValue(buildFakeAttestationCredential(rawId, buildFakeAttestationResponse()));
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
+
+            expect(result.success).toBe(true);
+
+            await waitForBatchedUpdates();
+            const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));
+            expect(storedCredentials?.map((credential) => credential.id)).toEqual([duplicateCredentialId]);
         });
     });
 });

--- a/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
@@ -20,13 +20,13 @@ import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 
-const mockCreatePasskeyCredential = jest.fn<Promise<PublicKeyCredential>, [PublicKeyCredentialCreationOptions]>();
+const mockCreatePasskeyCredential = jest.fn<Promise<PublicKeyCredential>, [PublicKeyCredentialCreationOptions, AbortSignal | undefined]>();
 
 // The navigator boundary is the only thing mocked here; the real option-building, extraction, and
 // error-decoding helpers stay under test, matching checkDeviceEligibility.test.ts's partial-mock shape.
 jest.mock('@libs/MultifactorAuthentication/Passkeys/WebAuthn', () => ({
     ...jest.requireActual<typeof WebAuthnModule>('@libs/MultifactorAuthentication/Passkeys/WebAuthn'),
-    createPasskeyCredential: (options: PublicKeyCredentialCreationOptions) => mockCreatePasskeyCredential(options),
+    createPasskeyCredential: (options: PublicKeyCredentialCreationOptions, signal?: AbortSignal) => mockCreatePasskeyCredential(options, signal),
 }));
 
 // jest-expo resolves the native variant by default, so load the web entry point explicitly.
@@ -162,7 +162,9 @@ describe('biometrics operations (web)', () => {
     // No coverage exists yet for `usePasskeys.register()`'s ceremony; this pins it at the operation
     // level ahead of the hook being deleted.
     describe('createCredential', () => {
-        const KNOWN_CREDENTIAL_ID = 'known-cred-id';
+        // Length must be a multiple of 4, so the decode/encode round trip below (used to inspect
+        // `excludeCredentials`) is lossless — anything else can silently drop trailing bits.
+        const KNOWN_CREDENTIAL_ID = 'known-cred-idxxx';
 
         beforeEach(() => {
             mockCreatePasskeyCredential.mockReset();
@@ -264,6 +266,38 @@ describe('biometrics operations (web)', () => {
             await waitForBatchedUpdates();
             const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));
             expect(storedCredentials?.map((credential) => credential.id)).toEqual([duplicateCredentialId]);
+        });
+
+        it('passes the abort signal through to the ceremony, so cancelling the flow can close the passkey dialog', async () => {
+            const controller = new AbortController();
+            mockCreatePasskeyCredential.mockResolvedValue(buildFakeAttestationCredential(bytesToArrayBuffer([1, 2, 3]), buildFakeAttestationResponse()));
+
+            await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE, signal: controller.signal});
+
+            expect(mockCreatePasskeyCredential.mock.calls.at(0)?.[1]).toBe(controller.signal);
+        });
+
+        it('does not persist or register a credential when the flow was cancelled while the ceremony resolved anyway', async () => {
+            // Some browsers don't honor `signal` on create(), so the ceremony can still succeed after
+            // the flow was already cancelled — simulated here by aborting from inside the mock.
+            const controller = new AbortController();
+            const rawId = bytesToArrayBuffer([90, 91, 92]);
+            mockCreatePasskeyCredential.mockImplementation(async () => {
+                controller.abort();
+                return buildFakeAttestationCredential(rawId, buildFakeAttestationResponse());
+            });
+
+            const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE, signal: controller.signal});
+
+            expect(result.success).toBe(false);
+            if (result.success) {
+                throw new Error('Expected credential creation to fail');
+            }
+            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.CANCELED);
+
+            await waitForBatchedUpdates();
+            const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));
+            expect(storedCredentials ?? []).toEqual([]);
         });
     });
 });

--- a/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/biometricsOperationsWeb.test.ts
@@ -32,8 +32,8 @@ jest.mock('@libs/MultifactorAuthentication/Passkeys/WebAuthn', () => ({
 
 const mockAddLocalPasskeyCredential = jest.fn<ReturnType<typeof PasskeyActionsModule.addLocalPasskeyCredential>, Parameters<typeof PasskeyActionsModule.addLocalPasskeyCredential>>();
 
-// Only the local-persistence write is mocked here, and only to simulate it rejecting — every other
-// test relies on this delegating straight through to the real Onyx-backed implementation.
+// Only the local credential update is mocked here, and only to simulate its validation throwing —
+// every other test delegates straight through to the real Onyx-backed implementation.
 jest.mock('@userActions/Passkey', () => ({
     ...jest.requireActual<typeof PasskeyActionsModule>('@userActions/Passkey'),
     addLocalPasskeyCredential: (params: Parameters<typeof PasskeyActionsModule.addLocalPasskeyCredential>[0]) => mockAddLocalPasskeyCredential(params),
@@ -169,8 +169,6 @@ describe('biometrics operations (web)', () => {
         });
     });
 
-    // No coverage exists yet for `usePasskeys.register()`'s ceremony; this pins it at the operation
-    // level ahead of the hook being deleted.
     describe('createCredential', () => {
         // Length must be a multiple of 4, so the decode/encode round trip below (used to inspect
         // `excludeCredentials`) is lossless — anything else can silently drop trailing bits.
@@ -281,11 +279,10 @@ describe('biometrics operations (web)', () => {
             expect(storedCredentials?.map((credential) => credential.id)).toEqual([duplicateCredentialId]);
         });
 
-        it('fails instead of reporting success when the local Onyx write rejects', async () => {
-            // If this were swallowed, the caller would register the credential with the backend
-            // anyway, leaving the server aware of a credential this device can't find in Onyx again --
-            // `areLocalCredentialsKnownToServer` would force the user back into registration.
-            mockAddLocalPasskeyCredential.mockRejectedValueOnce(new Error('Onyx write failed'));
+        it('fails instead of reporting success when local credential validation throws', async () => {
+            mockAddLocalPasskeyCredential.mockImplementationOnce(() => {
+                throw new Error('Local credential validation failed');
+            });
             mockCreatePasskeyCredential.mockResolvedValue(buildFakeAttestationCredential(bytesToArrayBuffer([11, 22, 33]), buildFakeAttestationResponse()));
 
             const result = await createCredential({accountID: ACCOUNT_ID, registrationChallenge: REGISTRATION_CHALLENGE});
@@ -294,7 +291,7 @@ describe('biometrics operations (web)', () => {
             if (result.success) {
                 throw new Error('Expected credential creation to fail');
             }
-            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.LOCAL_PERSISTENCE_FAILED);
+            expect(result.error.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.LOCAL_CREDENTIAL_UPDATE_FAILED);
 
             await waitForBatchedUpdates();
             const storedCredentials = await getOnyxValue(getPasskeyOnyxKey(String(ACCOUNT_ID)));

--- a/tests/unit/components/MultifactorAuthentication/machine/createCredentialActor.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/createCredentialActor.test.ts
@@ -1,0 +1,92 @@
+import type * as BiometricsOperations from '@components/MultifactorAuthentication/biometrics/operations';
+import createActors from '@components/MultifactorAuthentication/machine/mfaActors';
+import type {CreateCredentialInput} from '@components/MultifactorAuthentication/machine/types';
+
+import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
+import type {RegistrationKeyInfo} from '@libs/MultifactorAuthentication/shared/types';
+
+import {processRegistration} from '@userActions/MultifactorAuthentication/processing';
+import type * as ProcessingActions from '@userActions/MultifactorAuthentication/processing';
+
+import CONST from '@src/CONST';
+
+import {MFA_TEST_REGISTRATION_CHALLENGE} from 'tests/utils/mfa/flowFixtures';
+import {createActor, waitFor} from 'xstate';
+
+const REASON = CONST.MULTIFACTOR_AUTHENTICATION.REASON;
+
+const mockCreateCredential = jest.fn();
+
+// The actor's own decisions (short-circuit on refusal, forward keyInfo, no rollback on a backend
+// failure) are what this suite pins, so the platform ceremony and the backend call are mocked here.
+jest.mock('@components/MultifactorAuthentication/biometrics/operations', () => ({
+    ...jest.requireActual<typeof BiometricsOperations>('@components/MultifactorAuthentication/biometrics/operations'),
+    createCredential: (...args: unknown[]) => mockCreateCredential(...args),
+}));
+
+jest.mock('@userActions/MultifactorAuthentication/processing', () => ({
+    ...jest.requireActual<typeof ProcessingActions>('@userActions/MultifactorAuthentication/processing'),
+    processRegistration: jest.fn(),
+}));
+
+const processRegistrationMock = jest.mocked(processRegistration);
+
+const ACCOUNT_ID = 12345;
+
+const CREATE_CREDENTIAL_INPUT: CreateCredentialInput = {
+    accountID: ACCOUNT_ID,
+    registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE,
+};
+
+const KEY_INFO: RegistrationKeyInfo = {
+    rawId: 'credential-raw-id',
+    type: 'public-key',
+    response: {clientDataJSON: 'client-data-json', attestationObject: 'attestation-object'},
+};
+
+/** Runs the machine's real `createCredential` actor logic to completion and returns its final snapshot. */
+async function runCreateCredentialActor() {
+    const {createCredential} = createActors();
+    const actorRef = createActor(createCredential, {input: CREATE_CREDENTIAL_INPUT});
+    actorRef.start();
+    await waitFor(actorRef, (snapshot) => snapshot.status !== 'active');
+    return actorRef.getSnapshot();
+}
+
+describe('createCredential actor', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('short-circuits on a platform refusal and never calls processRegistration', async () => {
+        const platformError = createLocalMFAError(REASON.LOCAL_ERRORS.WEBAUTHN.NOT_ALLOWED, 'User dismissed the passkey dialog');
+        mockCreateCredential.mockResolvedValue({success: false, error: platformError});
+
+        const snapshot = await runCreateCredentialActor();
+
+        expect(snapshot.output).toEqual({success: false, error: platformError});
+        expect(processRegistrationMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards the exact keyInfo to processRegistration and returns its result on success', async () => {
+        mockCreateCredential.mockResolvedValue({success: true, keyInfo: KEY_INFO});
+        processRegistrationMock.mockResolvedValue({success: true});
+
+        const snapshot = await runCreateCredentialActor();
+
+        expect(processRegistrationMock).toHaveBeenCalledWith({keyInfo: KEY_INFO});
+        expect(snapshot.output).toEqual({success: true});
+    });
+
+    it('surfaces a backend failure unchanged and performs no rollback', async () => {
+        mockCreateCredential.mockResolvedValue({success: true, keyInfo: KEY_INFO});
+        const backendError = createLocalMFAError(REASON.CLIENT_ERRORS.UNRECOGNIZED, 'Backend rejected the key');
+        processRegistrationMock.mockResolvedValue({success: false, error: backendError});
+
+        const snapshot = await runCreateCredentialActor();
+
+        // No rollback: the actor's contract is to surface the backend result as-is, with no key
+        // deletion and no local-credential clearing attempted on this path.
+        expect(snapshot.output).toEqual({success: false, error: backendError});
+    });
+});

--- a/tests/unit/components/MultifactorAuthentication/machine/createCredentialActor.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/createCredentialActor.test.ts
@@ -11,6 +11,7 @@ import type * as ProcessingActions from '@userActions/MultifactorAuthentication/
 import CONST from '@src/CONST';
 
 import {MFA_TEST_REGISTRATION_CHALLENGE} from 'tests/utils/mfa/flowFixtures';
+import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 import {createActor, waitFor} from 'xstate';
 
 const REASON = CONST.MULTIFACTOR_AUTHENTICATION.REASON;
@@ -21,6 +22,7 @@ const mockCreateCredential = jest.fn();
 // failure) are what this suite pins, so the platform ceremony and the backend call are mocked here.
 jest.mock('@components/MultifactorAuthentication/biometrics/operations', () => ({
     ...jest.requireActual<typeof BiometricsOperations>('@components/MultifactorAuthentication/biometrics/operations'),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     createCredential: (...args: unknown[]) => mockCreateCredential(...args),
 }));
 
@@ -88,5 +90,27 @@ describe('createCredential actor', () => {
         // No rollback: the actor's contract is to surface the backend result as-is, with no key
         // deletion and no local-credential clearing attempted on this path.
         expect(snapshot.output).toEqual({success: false, error: backendError});
+    });
+
+    it('does not call processRegistration once the flow was cancelled while the ceremony was still running', async () => {
+        // Stopping the actor (what CLOSE_MODAL does) can't interrupt the already-running ceremony
+        // promise, only its own reaction to it — this pins that the actor still checks `signal.aborted`
+        // before firing the backend call.
+        let resolveCeremony: (result: {success: true; keyInfo: RegistrationKeyInfo}) => void = () => {};
+        mockCreateCredential.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveCeremony = resolve;
+                }),
+        );
+
+        const {createCredential} = createActors();
+        const actorRef = createActor(createCredential, {input: CREATE_CREDENTIAL_INPUT});
+        actorRef.start();
+        actorRef.stop();
+        resolveCeremony({success: true, keyInfo: KEY_INFO});
+        await waitForBatchedUpdates();
+
+        expect(processRegistrationMock).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
@@ -114,29 +114,33 @@ describe('MFA credential creation', () => {
         });
 
         it('reaches the failure outcome with an unhandled-exception error when the actor rejects', async () => {
+            // `resolveState` can't jump straight into `creatingCredential` and have the invoke fire —
+            // XState only invokes an actor on a live transition into a state, not a snapshot resolved
+            // already inside it. So we start one hop earlier and send the real approval event, which
+            // drives an actual transition and lets the mocked actor genuinely run and reject.
             const machine = mfaMachine.provide({
                 actors: {
                     createCredential: fromPromise<CreateCredentialOutput, CreateCredentialInput>(() => Promise.reject(new Error('Credential registration exploded'))),
                 },
             });
-            const actor = createActor(machine, {
-                snapshot: machine.resolveState({
-                    value: {[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL},
-                    context: {
-                        accountID: 12345,
-                        error: undefined,
-                        scenarioName: createInitEvent().scenarioName,
-                        scenario: createInitEvent().scenario,
-                        payload: undefined,
-                        validateCode: undefined,
-                        registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE,
-                        softPromptApproved: false,
-                        isCancelConfirmVisible: false,
-                    },
-                }),
+            const snapshot = machine.resolveState({
+                value: {[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}},
+                context: {
+                    accountID: 12345,
+                    error: undefined,
+                    scenarioName: createInitEvent().scenarioName,
+                    scenario: createInitEvent().scenario,
+                    payload: undefined,
+                    validateCode: undefined,
+                    registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE,
+                    softPromptApproved: false,
+                    isCancelConfirmVisible: false,
+                },
             });
+            const actor = createActor(machine, {snapshot});
 
             actor.start();
+            actor.send({type: 'SOFT_PROMPT_APPROVED'});
             await waitForBatchedUpdates();
 
             const result = actor.getSnapshot();

--- a/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
@@ -1,0 +1,150 @@
+import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
+import type {CreateCredentialInput, CreateCredentialOutput} from '@components/MultifactorAuthentication/machine/types';
+
+import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
+
+import CONST from '@src/CONST';
+
+import {createActorAtState, sendCreateCredentialDone, sendReadHasAcceptedSoftPromptDone} from 'tests/utils/mfa/flowActors';
+import createInitEvent, {MFA_TEST_REGISTRATION_CHALLENGE} from 'tests/utils/mfa/flowFixtures';
+import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
+import {createActor, fromPromise} from 'xstate';
+
+const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
+const REASON = CONST.MULTIFACTOR_AUTHENTICATION.REASON;
+
+// The graph-traversal suites generate their expectations from the machine, so a transition pointed at
+// a wrong target adjusts those expectations and still passes. This suite pins the two entries into
+// credential creation and the actor-outcome routing by hand. `softPromptTransition.test.ts` keeps
+// passing untouched because `createFlowContext` leaves `registrationChallenge` undefined.
+
+describe('MFA credential creation', () => {
+    describe('soft-prompt approval', () => {
+        it('moves to credential creation when a registration challenge is pending', () => {
+            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
+
+            actor.start();
+            actor.send({type: 'SOFT_PROMPT_APPROVED'});
+
+            const result = actor.getSnapshot();
+            expect(result.matches({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL})).toBe(true);
+            expect(result.context.softPromptApproved).toBe(true);
+
+            actor.stop();
+        });
+
+        it('reaches the success outcome without a pending challenge (returning user)', () => {
+            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}});
+
+            actor.start();
+            actor.send({type: 'SOFT_PROMPT_APPROVED'});
+
+            const result = actor.getSnapshot();
+            expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
+
+            actor.stop();
+        });
+    });
+
+    describe('soft-prompt acceptance read', () => {
+        it('moves to credential creation when acceptance was already stored and a challenge is pending', () => {
+            const actor = createActorAtState(
+                {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}},
+                {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE},
+            );
+
+            actor.start();
+            sendReadHasAcceptedSoftPromptDone(actor, true);
+
+            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL})).toBe(true);
+
+            actor.stop();
+        });
+
+        it('reaches the success outcome when acceptance was stored without a pending challenge', () => {
+            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}});
+
+            actor.start();
+            sendReadHasAcceptedSoftPromptDone(actor, true);
+
+            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
+
+            actor.stop();
+        });
+
+        it('shows the prompt when acceptance was not stored, regardless of a pending challenge', () => {
+            const actor = createActorAtState(
+                {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}},
+                {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE},
+            );
+
+            actor.start();
+            sendReadHasAcceptedSoftPromptDone(actor, false);
+
+            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
+
+            actor.stop();
+        });
+    });
+
+    describe('createCredential actor outcome', () => {
+        it('reaches the success outcome when the actor resolves successfully', () => {
+            const actor = createActorAtState({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
+
+            actor.start();
+            sendCreateCredentialDone(actor, {success: true});
+
+            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
+
+            actor.stop();
+        });
+
+        it('reaches the failure outcome carrying the exact reason when the actor resolves with a failure', () => {
+            const actor = createActorAtState({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
+            const failureError = createLocalMFAError(REASON.LOCAL_ERRORS.HSM.KEY_CREATION_FAILED, 'Credential creation transition spec failure');
+
+            actor.start();
+            sendCreateCredentialDone(actor, {success: false, error: failureError});
+
+            const result = actor.getSnapshot();
+            expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
+            expect(result.context.error).toBe(failureError);
+
+            actor.stop();
+        });
+
+        it('reaches the failure outcome with an unhandled-exception error when the actor rejects', async () => {
+            const machine = mfaMachine.provide({
+                actors: {
+                    createCredential: fromPromise<CreateCredentialOutput, CreateCredentialInput>(() => Promise.reject(new Error('Credential registration exploded'))),
+                },
+            });
+            const actor = createActor(machine, {
+                snapshot: machine.resolveState({
+                    value: {[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL},
+                    context: {
+                        accountID: 12345,
+                        error: undefined,
+                        scenarioName: createInitEvent().scenarioName,
+                        scenario: createInitEvent().scenario,
+                        payload: undefined,
+                        validateCode: undefined,
+                        registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE,
+                        softPromptApproved: false,
+                        isCancelConfirmVisible: false,
+                    },
+                }),
+            });
+
+            actor.start();
+            await waitForBatchedUpdates();
+
+            const result = actor.getSnapshot();
+            expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
+            expect(result.context.error?.reason).toBe(REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION);
+            expect(result.context.error?.message).toContain('Credential registration threw:');
+
+            actor.stop();
+        });
+    });
+});

--- a/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
@@ -5,7 +5,7 @@ import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFARes
 
 import CONST from '@src/CONST';
 
-import {createActorAtState, sendCreateCredentialDone, sendReadHasAcceptedSoftPromptDone} from 'tests/utils/mfa/flowActors';
+import {createActorAtState, sendCreateCredentialDone} from 'tests/utils/mfa/flowActors';
 import createInitEvent, {MFA_TEST_REGISTRATION_CHALLENGE} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 import {createActor, fromPromise} from 'xstate';
@@ -14,7 +14,7 @@ const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 const REASON = CONST.MULTIFACTOR_AUTHENTICATION.REASON;
 
 // The graph-traversal suites generate their expectations from the machine, so a transition pointed at
-// a wrong target adjusts those expectations and still passes. This suite pins the two entries into
+// a wrong target adjusts those expectations and still passes. This suite pins the single entry into
 // credential creation and the actor-outcome routing by hand. `softPromptTransition.test.ts` keeps
 // passing untouched because `createFlowContext` leaves `registrationChallenge` undefined.
 
@@ -41,47 +41,6 @@ describe('MFA credential creation', () => {
 
             const result = actor.getSnapshot();
             expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
-
-            actor.stop();
-        });
-    });
-
-    describe('soft-prompt acceptance read', () => {
-        it('moves to credential creation when acceptance was already stored and a challenge is pending', () => {
-            const actor = createActorAtState(
-                {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}},
-                {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE},
-            );
-
-            actor.start();
-            sendReadHasAcceptedSoftPromptDone(actor, true);
-
-            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL})).toBe(true);
-
-            actor.stop();
-        });
-
-        it('reaches the success outcome when acceptance was stored without a pending challenge', () => {
-            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}});
-
-            actor.start();
-            sendReadHasAcceptedSoftPromptDone(actor, true);
-
-            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
-
-            actor.stop();
-        });
-
-        it('shows the prompt when acceptance was not stored, regardless of a pending challenge', () => {
-            const actor = createActorAtState(
-                {[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}},
-                {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE},
-            );
-
-            actor.start();
-            sendReadHasAcceptedSoftPromptDone(actor, false);
-
-            expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
 
             actor.stop();
         });
@@ -134,6 +93,7 @@ describe('MFA credential creation', () => {
                     validateCode: undefined,
                     registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE,
                     softPromptApproved: false,
+                    hasEverAcceptedSoftPrompt: false,
                     isCancelConfirmVisible: false,
                 },
             });

--- a/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
@@ -28,7 +28,7 @@ describe('MFA credential creation', () => {
             actor.send({type: 'SOFT_PROMPT_APPROVED'});
 
             const result = actor.getSnapshot();
-            expect(result.matches({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL})).toBe(true);
+            expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.CREATING_CREDENTIAL}})).toBe(true);
             expect(snapshotToState(result).isProcessingPrompt).toBe(true);
             expect(result.context.softPromptApproved).toBe(true);
 
@@ -64,7 +64,7 @@ describe('MFA credential creation', () => {
 
     describe('createCredential actor outcome', () => {
         it('reaches the success outcome when the actor resolves successfully', () => {
-            const actor = createActorAtState({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
+            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.CREATING_CREDENTIAL}}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
 
             actor.start();
             sendCreateCredentialDone(actor, {success: true});
@@ -75,7 +75,7 @@ describe('MFA credential creation', () => {
         });
 
         it('reaches the failure outcome carrying the exact reason when the actor resolves with a failure', () => {
-            const actor = createActorAtState({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
+            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.CREATING_CREDENTIAL}}, {registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE});
             const failureError = createLocalMFAError(REASON.LOCAL_ERRORS.HSM.KEY_CREATION_FAILED, 'Credential creation transition spec failure');
 
             actor.start();
@@ -109,7 +109,6 @@ describe('MFA credential creation', () => {
                     validateCode: undefined,
                     registrationChallenge: MFA_TEST_REGISTRATION_CHALLENGE,
                     softPromptApproved: false,
-                    hasEverAcceptedSoftPrompt: false,
                     isCancelConfirmVisible: false,
                 },
             });

--- a/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/credentialCreationTransition.test.ts
@@ -1,4 +1,5 @@
 import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
+import snapshotToState from '@components/MultifactorAuthentication/machine/snapshotToState';
 import type {CreateCredentialInput, CreateCredentialOutput} from '@components/MultifactorAuthentication/machine/types';
 
 import {createLocalMFAError} from '@libs/MultifactorAuthentication/shared/MFAResult';
@@ -28,6 +29,7 @@ describe('MFA credential creation', () => {
 
             const result = actor.getSnapshot();
             expect(result.matches({[MFA_STATE.OPEN]: MFA_STATE.CREATING_CREDENTIAL})).toBe(true);
+            expect(snapshotToState(result).isProcessingPrompt).toBe(true);
             expect(result.context.softPromptApproved).toBe(true);
 
             actor.stop();
@@ -41,6 +43,20 @@ describe('MFA credential creation', () => {
 
             const result = actor.getSnapshot();
             expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
+            expect(snapshotToState(result).isProcessingPrompt).toBe(false);
+
+            actor.stop();
+        });
+
+        it('does not mark the prompt as processing when the flow is cancelled', () => {
+            const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}});
+
+            actor.start();
+            actor.send({type: 'CLOSE_MODAL'});
+
+            const result = actor.getSnapshot();
+            expect(result.matches(MFA_STATE.CLOSING)).toBe(true);
+            expect(snapshotToState(result).isProcessingPrompt).toBe(false);
 
             actor.stop();
         });

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -21,6 +21,7 @@ import renderMfaUi from 'tests/utils/mfa/realUi/harness';
 import {
     checkLocalCredentialsControl,
     createCredentialControl,
+    credentialsStateCaptureControl,
     pendingModalClose,
     requestRegistrationChallengeControl,
     resetMfaUiMocks,
@@ -320,6 +321,40 @@ describe('the real MFA modal matches the machine at every step of every generate
         const {executeScenario} = renderMfaUi();
         await waitForBatchedUpdatesWithAct();
         await path.test({...testConfig, events: createMfaEventExecutors(executeScenario)});
+    });
+});
+
+describe('MFA flow initialization', () => {
+    beforeEach(async () => {
+        resetMfaUiMocks();
+        await act(async () => {
+            await Onyx.clear();
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: MFA_TEST_ACCOUNT_ID});
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('does not initialize a flow when the account changes while credentials are being captured', async () => {
+        const {executeScenario} = renderMfaUi();
+        await waitForBatchedUpdatesWithAct();
+        credentialsStateCaptureControl.defer();
+
+        const flowPromise = executeScenario(CONST.MULTIFACTOR_AUTHENTICATION.SCENARIO.BIOMETRICS_TEST);
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: MFA_TEST_ACCOUNT_ID + 1});
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        credentialsStateCaptureControl.resolve(false);
+        await act(async () => flowPromise);
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.queryByTestId(TEST_ID.MODAL_BACKDROP)).not.toBeOnTheScreen();
     });
 });
 

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -21,7 +21,7 @@ import renderMfaUi from 'tests/utils/mfa/realUi/harness';
 import {
     checkLocalCredentialsControl,
     createCredentialControl,
-    credentialsStateCaptureControl,
+    registrationStateCaptureControl,
     pendingModalClose,
     requestRegistrationChallengeControl,
     resetMfaUiMocks,
@@ -338,10 +338,10 @@ describe('MFA flow initialization', () => {
         jest.clearAllMocks();
     });
 
-    it('does not initialize a flow when the account changes while credentials are being captured', async () => {
+    it('does not initialize a flow when the account changes while registration state is being captured', async () => {
         const {executeScenario} = renderMfaUi();
         await waitForBatchedUpdatesWithAct();
-        credentialsStateCaptureControl.defer();
+        registrationStateCaptureControl.defer();
 
         const flowPromise = executeScenario(CONST.MULTIFACTOR_AUTHENTICATION.SCENARIO.BIOMETRICS_TEST);
 
@@ -350,7 +350,7 @@ describe('MFA flow initialization', () => {
         });
         await waitForBatchedUpdatesWithAct();
 
-        credentialsStateCaptureControl.resolve(false);
+        registrationStateCaptureControl.resolve(false);
         await act(async () => flowPromise);
         await waitForBatchedUpdatesWithAct();
 

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -18,6 +18,7 @@ import {getSettleableLeafStates} from 'tests/utils/mfa/leafStates';
 import renderMfaUi from 'tests/utils/mfa/realUi/harness';
 import {
     checkLocalCredentialsControl,
+    createCredentialControl,
     pendingModalClose,
     readHasAcceptedSoftPromptControl,
     requestRegistrationChallengeControl,
@@ -167,6 +168,8 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
         [actorErrorEventType('checkLocalCredentials')]: () => settleActor(checkLocalCredentialsControl.reject),
         [actorDoneEventType('requestRegistrationChallenge')]: (step) => settleActor(() => requestRegistrationChallengeControl.resolve(getActorDoneOutput(step))),
         [actorErrorEventType('requestRegistrationChallenge')]: () => settleActor(requestRegistrationChallengeControl.reject),
+        [actorDoneEventType('createCredential')]: (step) => settleActor(() => createCredentialControl.resolve(getActorDoneOutput(step))),
+        [actorErrorEventType('createCredential')]: () => settleActor(createCredentialControl.reject),
     } satisfies MfaEventExecutors;
 }
 /* eslint-enable @typescript-eslint/naming-convention */
@@ -246,6 +249,20 @@ const testConfig = {
             expect(screen.getByText(translateLocal('multifactorAuthentication.enableQuickVerification.biometrics'))).toBeOnTheScreen();
             expect(state.context.error).toBeUndefined();
             expect(state.context.softPromptApproved).toBe(false);
+        },
+        // No entry navigation action fires for this state, so whatever screen was already on the
+        // stack stays up during the ceremony: the prompt when the user just approved it in this
+        // flow, or the magic-code screen (last navigated) when the persisted acceptance skipped it.
+        [`${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
+            expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
+            expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
+            expect(state.context.registrationChallenge).toBeDefined();
+            expect(state.context.error).toBeUndefined();
+            if (state.context.softPromptApproved) {
+                expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
+            } else {
+                expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.MAGIC_CODE);
+            }
         },
         [`${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -244,7 +244,7 @@ const testConfig = {
             expect(state.context.error).toBeUndefined();
             expect(state.context.softPromptApproved).toBe(true);
             expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
-            // The machine can no longer accept SOFT_PROMPT_APPROVED here, so the button must be disabled rather than pressable.
+            // The prompt stays mounted during credential creation, so its button must show loading and remain disabled.
             expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeDisabled();
         },
         [`${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`]: (state: SnapshotFrom<typeof mfaMachine>) => {

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -4,8 +4,6 @@ import type {MfaActorDoneEvent, MfaInternalEvent, MfaMachineEvent} from '@compon
 import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
 import {mfaNavigationRef} from '@components/MultifactorAuthentication/mfaNavigation';
 
-import {getDeviceBiometricsOnyxKey} from '@libs/actions/MultifactorAuthentication';
-
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
@@ -19,8 +17,8 @@ import getWalkedPaths, {actorDoneEventType, actorErrorEventType, isAutoDrivenEve
 import {getSettleableLeafStates} from 'tests/utils/mfa/leafStates';
 import renderMfaUi from 'tests/utils/mfa/realUi/harness';
 import {
-    checkLocalCredentialsControl,
     createCredentialControl,
+    loadRegistrationStateControl,
     registrationStateCaptureControl,
     pendingModalClose,
     requestRegistrationChallengeControl,
@@ -122,10 +120,6 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
     return {
         INIT: async (step) => {
             const event = getInitEvent(step);
-            // The real Provider reads this flag from Onyx, so it must land there before `executeScenario` runs.
-            await act(async () => {
-                await Onyx.merge(getDeviceBiometricsOnyxKey(MFA_TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: event.hasEverAcceptedSoftPrompt});
-            });
             await act(async () => {
                 await executeScenario(event.scenarioName, event.payload);
             });
@@ -168,8 +162,8 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
         },
         [actorDoneEventType('validateDevice')]: (step) => settleActor(() => validateDeviceControl.resolve(getActorDoneOutput(step))),
         [actorErrorEventType('validateDevice')]: () => settleActor(validateDeviceControl.reject),
-        [actorDoneEventType('checkLocalCredentials')]: (step) => settleActor(() => checkLocalCredentialsControl.resolve(getActorDoneOutput(step))),
-        [actorErrorEventType('checkLocalCredentials')]: () => settleActor(checkLocalCredentialsControl.reject),
+        [actorDoneEventType('loadRegistrationState')]: (step) => settleActor(() => loadRegistrationStateControl.resolve(getActorDoneOutput(step))),
+        [actorErrorEventType('loadRegistrationState')]: () => settleActor(loadRegistrationStateControl.reject),
         [actorDoneEventType('requestRegistrationChallenge')]: (step) => settleActor(() => requestRegistrationChallengeControl.resolve(getActorDoneOutput(step))),
         [actorErrorEventType('requestRegistrationChallenge')]: () => settleActor(requestRegistrationChallengeControl.reject),
         [actorDoneEventType('createCredential')]: (step) => settleActor(() => createCredentialControl.resolve(getActorDoneOutput(step))),
@@ -231,21 +225,21 @@ const testConfig = {
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
             expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
             expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeOnTheScreen();
+            expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeEnabled();
             expect(screen.getByText(translateLocal('multifactorAuthentication.verifyYourself.biometrics'))).toBeOnTheScreen();
             expect(screen.getByText(translateLocal('multifactorAuthentication.enableQuickVerification.biometrics'))).toBeOnTheScreen();
             expect(state.context.error).toBeUndefined();
             expect(state.context.softPromptApproved).toBe(false);
         },
-        // No entry navigation action fires for this state, so the prompt screen the user just approved stays up during the ceremony.
-        [`${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
+        [`${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.CREATING_CREDENTIAL}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
             expect(state.context.registrationChallenge).toBeDefined();
             expect(state.context.error).toBeUndefined();
             expect(state.context.softPromptApproved).toBe(true);
             expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
-            // The prompt stays mounted during credential creation, so its button must show loading and remain disabled.
-            expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeDisabled();
+            // The prompt stays mounted during credential creation, but the already-approved action is removed.
+            expect(screen.queryByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).not.toBeOnTheScreen();
         },
         [`${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -350,6 +350,24 @@ describe('MFA flow initialization', () => {
 
         expect(screen.queryByTestId(TEST_ID.MODAL_BACKDROP)).not.toBeOnTheScreen();
     });
+
+    it('cancels an active flow when the session account changes', async () => {
+        const {executeScenario} = renderMfaUi();
+        await waitForBatchedUpdatesWithAct();
+
+        await act(async () => executeScenario(CONST.MULTIFACTOR_AUTHENTICATION.SCENARIO.BIOMETRICS_TEST));
+        await waitForBatchedUpdatesWithAct();
+        expect(screen.getByTestId(TEST_ID.MODAL_BACKDROP)).toBeOnTheScreen();
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: MFA_TEST_ACCOUNT_ID + 1});
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        act(() => pendingModalClose.run());
+        await waitForBatchedUpdatesWithAct();
+        expect(screen.queryByTestId(TEST_ID.MODAL_BACKDROP)).not.toBeOnTheScreen();
+    });
 });
 
 // Every settleable leaf must occur in a path that the walk above drives. `everyStateReachable.test.ts`

--- a/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
+++ b/tests/unit/components/MultifactorAuthentication/machine/graphTraversal/viewMatchesMachine.test.tsx
@@ -4,6 +4,8 @@ import type {MfaActorDoneEvent, MfaInternalEvent, MfaMachineEvent} from '@compon
 import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
 import {mfaNavigationRef} from '@components/MultifactorAuthentication/mfaNavigation';
 
+import {getDeviceBiometricsOnyxKey} from '@libs/actions/MultifactorAuthentication';
+
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
@@ -20,7 +22,6 @@ import {
     checkLocalCredentialsControl,
     createCredentialControl,
     pendingModalClose,
-    readHasAcceptedSoftPromptControl,
     requestRegistrationChallengeControl,
     resetMfaUiMocks,
     validateDeviceControl,
@@ -120,6 +121,10 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
     return {
         INIT: async (step) => {
             const event = getInitEvent(step);
+            // The real Provider reads this flag from Onyx, so it must land there before `executeScenario` runs.
+            await act(async () => {
+                await Onyx.merge(getDeviceBiometricsOnyxKey(MFA_TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: event.hasEverAcceptedSoftPrompt});
+            });
             await act(async () => {
                 await executeScenario(event.scenarioName, event.payload);
             });
@@ -162,8 +167,6 @@ function createMfaEventExecutors(executeScenario: ExecuteScenario) {
         },
         [actorDoneEventType('validateDevice')]: (step) => settleActor(() => validateDeviceControl.resolve(getActorDoneOutput(step))),
         [actorErrorEventType('validateDevice')]: () => settleActor(validateDeviceControl.reject),
-        [actorDoneEventType('readHasAcceptedSoftPrompt')]: (step) => settleActor(() => readHasAcceptedSoftPromptControl.resolve(getActorDoneOutput(step))),
-        [actorErrorEventType('readHasAcceptedSoftPrompt')]: () => settleActor(readHasAcceptedSoftPromptControl.reject),
         [actorDoneEventType('checkLocalCredentials')]: (step) => settleActor(() => checkLocalCredentialsControl.resolve(getActorDoneOutput(step))),
         [actorErrorEventType('checkLocalCredentials')]: () => settleActor(checkLocalCredentialsControl.reject),
         [actorDoneEventType('requestRegistrationChallenge')]: (step) => settleActor(() => requestRegistrationChallengeControl.resolve(getActorDoneOutput(step))),
@@ -190,24 +193,6 @@ const testConfig = {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.INITIAL_SCREEN)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
-            expect(state.context.error).toBeUndefined();
-        },
-        [`${MFA_STATE.OPEN}.${MFA_STATE.PREPARING}.${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
-            expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
-            expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
-            expect(state.context.validateCode).toBeUndefined();
-            // A registration challenge means the flow re-entered this check from the validate-code
-            // screen, which stays visible while the read runs; a first pass has no challenge and
-            // runs behind the transparent initial screen.
-            if (state.context.registrationChallenge === undefined) {
-                expect(screen.queryAllByTestId(TEST_ID.INITIAL_SCREEN)).toHaveLength(1);
-            } else {
-                expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.VALIDATE_CODE);
-                // The validate-code screen stays visible during this read, but the machine no longer
-                // accepts resend requests after a valid code has advanced the flow.
-                expect(screen.getByTestId(TEST_ID.VALIDATE_CODE_RESEND_BUTTON)).toBeDisabled();
-            }
-            expect(state.context.accountID).toBeDefined();
             expect(state.context.error).toBeUndefined();
         },
         [`${MFA_STATE.OPEN}.${MFA_STATE.VALIDATE_CODE}.${MFA_STATE.AWAITING_VALIDATE_CODE}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
@@ -250,19 +235,16 @@ const testConfig = {
             expect(state.context.error).toBeUndefined();
             expect(state.context.softPromptApproved).toBe(false);
         },
-        // No entry navigation action fires for this state, so whatever screen was already on the
-        // stack stays up during the ceremony: the prompt when the user just approved it in this
-        // flow, or the magic-code screen (last navigated) when the persisted acceptance skipped it.
+        // No entry navigation action fires for this state, so the prompt screen the user just approved stays up during the ceremony.
         [`${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);
             expect(screen.queryAllByTestId(TEST_ID.OUTCOME_SCREEN)).toHaveLength(0);
             expect(state.context.registrationChallenge).toBeDefined();
             expect(state.context.error).toBeUndefined();
-            if (state.context.softPromptApproved) {
-                expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
-            } else {
-                expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.MAGIC_CODE);
-            }
+            expect(state.context.softPromptApproved).toBe(true);
+            expect(mfaNavigationRef.getCurrentRoute()?.name).toBe(SCREENS.MULTIFACTOR_AUTHENTICATION.PROMPT);
+            // The machine can no longer accept SOFT_PROMPT_APPROVED here, so the button must be disabled rather than pressable.
+            expect(screen.getByTestId(TEST_ID.PROMPT_CONFIRM_BUTTON)).toBeDisabled();
         },
         [`${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`]: (state: SnapshotFrom<typeof mfaMachine>) => {
             expect(screen.queryAllByTestId(TEST_ID.MODAL_BACKDROP)).toHaveLength(1);

--- a/tests/unit/components/MultifactorAuthentication/machine/loadRegistrationStateActor.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/loadRegistrationStateActor.test.ts
@@ -1,0 +1,52 @@
+import type * as BiometricsOperations from '@components/MultifactorAuthentication/biometrics/operations';
+import createActors from '@components/MultifactorAuthentication/machine/mfaActors';
+
+import {getDeviceBiometricsOnyxKey} from '@userActions/MultifactorAuthentication';
+
+import Onyx from 'react-native-onyx';
+import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
+import {createActor, waitFor} from 'xstate';
+
+const mockAreLocalCredentialsKnownToServer = jest.fn();
+
+jest.mock('@components/MultifactorAuthentication/biometrics/operations', () => ({
+    ...jest.requireActual<typeof BiometricsOperations>('@components/MultifactorAuthentication/biometrics/operations'),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    areLocalCredentialsKnownToServer: (...args: unknown[]) => mockAreLocalCredentialsKnownToServer(...args),
+}));
+
+const ACCOUNT_ID = 12345;
+
+async function runLoadRegistrationStateActor() {
+    const {loadRegistrationState} = createActors();
+    const actorRef = createActor(loadRegistrationState, {input: {accountID: ACCOUNT_ID}});
+    actorRef.start();
+    await waitFor(actorRef, (snapshot) => snapshot.status !== 'active');
+    return actorRef.getSnapshot();
+}
+
+describe('loadRegistrationState actor', () => {
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
+    it('loads the credential match and persisted soft-prompt acceptance for the requested account', async () => {
+        mockAreLocalCredentialsKnownToServer.mockResolvedValue(true);
+        await Onyx.merge(getDeviceBiometricsOnyxKey(ACCOUNT_ID), {hasAcceptedSoftPrompt: true});
+
+        const snapshot = await runLoadRegistrationStateActor();
+
+        expect(mockAreLocalCredentialsKnownToServer).toHaveBeenCalledWith(ACCOUNT_ID, expect.any(AbortSignal));
+        expect(snapshot.output).toEqual({hasLocalCredentials: true, hasEverAcceptedSoftPrompt: true});
+    });
+
+    it('defaults soft-prompt acceptance to false when the account has no persisted value', async () => {
+        mockAreLocalCredentialsKnownToServer.mockResolvedValue(false);
+
+        const snapshot = await runLoadRegistrationStateActor();
+
+        expect(snapshot.output).toEqual({hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false});
+    });
+});

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -4,7 +4,7 @@ import CONST from '@src/CONST';
 
 import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
-import {createActorAtState, sendCheckLocalCredentialsDone} from 'tests/utils/mfa/flowActors';
+import {createActorAtState, sendLoadRegistrationStateDone} from 'tests/utils/mfa/flowActors';
 import {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 
@@ -25,7 +25,7 @@ describe('MFA soft prompt', () => {
         const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
 
         actor.start();
-        sendCheckLocalCredentialsDone(actor, true);
+        sendLoadRegistrationStateDone(actor, {hasLocalCredentials: true, hasEverAcceptedSoftPrompt: false});
         await waitForBatchedUpdates();
 
         const result = actor.getSnapshot();
@@ -36,10 +36,10 @@ describe('MFA soft prompt', () => {
     });
 
     it('skips the soft prompt and reaches the outcome directly for a returning user who already accepted it on this device', () => {
-        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}}, {hasEverAcceptedSoftPrompt: true});
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
 
         actor.start();
-        sendCheckLocalCredentialsDone(actor, true);
+        sendLoadRegistrationStateDone(actor, {hasLocalCredentials: true, hasEverAcceptedSoftPrompt: true});
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
@@ -49,10 +49,10 @@ describe('MFA soft prompt', () => {
     });
 
     it('still shows the soft prompt for a fresh registration even though the account already accepted it on this device before (production parity: a new registration always needs approval in this flow)', () => {
-        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}}, {hasEverAcceptedSoftPrompt: true});
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
 
         actor.start();
-        sendCheckLocalCredentialsDone(actor, false);
+        sendLoadRegistrationStateDone(actor, {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: true});
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.VALIDATE_CODE]: MFA_STATE.AWAITING_VALIDATE_CODE}})).toBe(true);

--- a/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/softPromptTransition.test.ts
@@ -1,17 +1,12 @@
-import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
-import type {CheckLocalCredentialsInput, ReadHasAcceptedSoftPromptInput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
-
 import {getDeviceBiometricsOnyxKey} from '@libs/actions/MultifactorAuthentication';
-import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
 
 import Onyx from 'react-native-onyx';
 import getOnyxValue from 'tests/utils/getOnyxValue';
 import {createActorAtState, sendCheckLocalCredentialsDone} from 'tests/utils/mfa/flowActors';
-import createInitEvent, {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
+import {MFA_TEST_ACCOUNT_ID} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
-import {createActor, fromPromise} from 'xstate';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
@@ -40,59 +35,27 @@ describe('MFA soft prompt', () => {
         actor.stop();
     });
 
-    it('skips the soft prompt when the user has already accepted it on this device', async () => {
-        await Onyx.merge(getDeviceBiometricsOnyxKey(MFA_TEST_ACCOUNT_ID), {hasAcceptedSoftPrompt: true});
-        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
+    it('skips the soft prompt and reaches the outcome directly for a returning user who already accepted it on this device', () => {
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}}, {hasEverAcceptedSoftPrompt: true});
 
         actor.start();
         sendCheckLocalCredentialsDone(actor, true);
-        await waitForBatchedUpdates();
 
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.SUCCESS}})).toBe(true);
-        // The context flag tracks an approval given during this flow, so a skip leaves it false.
         expect(result.context.softPromptApproved).toBe(false);
 
         actor.stop();
     });
 
-    it('disconnects a pending soft-prompt read when the flow closes', () => {
-        const connection = {id: 'soft-prompt-read-test', callbackID: 'soft-prompt-read-test'};
-        jest.spyOn(Onyx, 'connectWithoutView').mockReturnValue(connection);
-        const disconnectSpy = jest.spyOn(Onyx, 'disconnect').mockImplementation();
-        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
+    it('still shows the soft prompt for a fresh registration even though the account already accepted it on this device before (production parity: a new registration always needs approval in this flow)', () => {
+        const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}}, {hasEverAcceptedSoftPrompt: true});
 
         actor.start();
-        sendCheckLocalCredentialsDone(actor, true);
-        expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}})).toBe(true);
-
-        actor.send({type: 'CLOSE_MODAL'});
-
-        expect(disconnectSpy).toHaveBeenCalledTimes(1);
-        expect(disconnectSpy).toHaveBeenCalledWith(connection);
-
-        actor.stop();
-    });
-
-    it('ends the current flow with an error when reading the soft-prompt flag rejects', async () => {
-        const machine = mfaMachine.provide({
-            actors: {
-                validateDevice: fromPromise<MFAResult, ValidateDeviceInput>(() => Promise.resolve({success: true})),
-                // A registered account routes the flow straight to the soft-prompt read under test.
-                checkLocalCredentials: fromPromise<boolean, CheckLocalCredentialsInput>(() => Promise.resolve(true)),
-                readHasAcceptedSoftPrompt: fromPromise<boolean, ReadHasAcceptedSoftPromptInput>(() => Promise.reject(new Error('Onyx read failed'))),
-            },
-        });
-        const actor = createActor(machine);
-
-        actor.start();
-        actor.send(createInitEvent());
-        await waitForBatchedUpdates();
+        sendCheckLocalCredentialsDone(actor, false);
 
         const result = actor.getSnapshot();
-        expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
-        expect(result.context.error?.reason).toBe(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION);
-        expect(result.context.error?.message).toContain('Soft-prompt acceptance read threw: Onyx read failed');
+        expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.VALIDATE_CODE]: MFA_STATE.AWAITING_VALIDATE_CODE}})).toBe(true);
 
         actor.stop();
     });

--- a/tests/unit/components/MultifactorAuthentication/machine/validateCodeTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/validateCodeTransition.test.ts
@@ -1,6 +1,6 @@
 import mfaMachine from '@components/MultifactorAuthentication/machine/mfaMachine';
 import snapshotToState from '@components/MultifactorAuthentication/machine/snapshotToState';
-import type {CheckLocalCredentialsInput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
+import type {LoadRegistrationStateInput, LoadRegistrationStateOutput, ValidateDeviceInput} from '@components/MultifactorAuthentication/machine/types';
 
 import type {MFAResult} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
@@ -12,7 +12,7 @@ import type * as UserActions from '@userActions/User';
 import CONST from '@src/CONST';
 
 import {CONST as COMMON_CONST} from 'expensify-common';
-import {createActorAtState, sendCheckLocalCredentialsDone} from 'tests/utils/mfa/flowActors';
+import {createActorAtState, sendLoadRegistrationStateDone} from 'tests/utils/mfa/flowActors';
 import createInitEvent, {MFA_TEST_REGISTRATION_CHALLENGE, MFA_TEST_VALIDATE_CODE} from 'tests/utils/mfa/flowFixtures';
 import waitForBatchedUpdates from 'tests/utils/waitForBatchedUpdates';
 import {createActor, fromPromise} from 'xstate';
@@ -83,7 +83,7 @@ describe('MFA validate code and registration decision', () => {
         const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
 
         actor.start();
-        sendCheckLocalCredentialsDone(actor, false);
+        sendLoadRegistrationStateDone(actor, {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false});
 
         expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.VALIDATE_CODE]: MFA_STATE.AWAITING_VALIDATE_CODE}})).toBe(true);
         expect(requestValidateCodeActionMock).toHaveBeenCalledTimes(1);
@@ -96,7 +96,7 @@ describe('MFA validate code and registration decision', () => {
         const actor = createActorAtState({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.DECIDING_REGISTRATION}});
 
         actor.start();
-        sendCheckLocalCredentialsDone(actor, true);
+        sendLoadRegistrationStateDone(actor, {hasLocalCredentials: true, hasEverAcceptedSoftPrompt: false});
 
         expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
         expect(requestValidateCodeActionMock).not.toHaveBeenCalled();
@@ -266,7 +266,7 @@ describe('MFA validate code and registration decision', () => {
         const machine = mfaMachine.provide({
             actors: {
                 validateDevice: fromPromise<MFAResult, ValidateDeviceInput>(() => Promise.resolve({success: true})),
-                checkLocalCredentials: fromPromise<boolean, CheckLocalCredentialsInput>(() => Promise.reject(new Error('Keystore read failed'))),
+                loadRegistrationState: fromPromise<LoadRegistrationStateOutput, LoadRegistrationStateInput>(() => Promise.reject(new Error('Keystore read failed'))),
             },
         });
         const actor = createActor(machine);
@@ -278,7 +278,7 @@ describe('MFA validate code and registration decision', () => {
         const result = actor.getSnapshot();
         expect(result.matches({[MFA_STATE.OPEN]: {[MFA_STATE.OUTCOME]: MFA_STATE.FAILURE}})).toBe(true);
         expect(result.context.error?.reason).toBe(REASON.LOCAL_ERRORS.UNHANDLED_EXCEPTION);
-        expect(result.context.error?.message).toContain('Local credentials check threw: Keystore read failed');
+        expect(result.context.error?.message).toContain('Registration state check threw: Keystore read failed');
 
         actor.stop();
     });

--- a/tests/unit/components/MultifactorAuthentication/machine/validateCodeTransition.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/machine/validateCodeTransition.test.ts
@@ -98,7 +98,7 @@ describe('MFA validate code and registration decision', () => {
         actor.start();
         sendCheckLocalCredentialsDone(actor, true);
 
-        expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PREPARING]: MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}})).toBe(true);
+        expect(actor.getSnapshot().matches({[MFA_STATE.OPEN]: {[MFA_STATE.PROMPT]: MFA_STATE.AWAITING_SOFT_PROMPT}})).toBe(true);
         expect(requestValidateCodeActionMock).not.toHaveBeenCalled();
 
         actor.stop();

--- a/tests/unit/components/MultifactorAuthentication/useNativeBiometricsHSM.test.ts
+++ b/tests/unit/components/MultifactorAuthentication/useNativeBiometricsHSM.test.ts
@@ -32,15 +32,12 @@ jest.mock('@hooks/useOnyx', () => ({
 
 jest.mock('@userActions/MultifactorAuthentication');
 
-const mockCreateKeys = jest.fn();
 const mockDeleteKeys = jest.fn();
 const mockGetAllKeys = jest.fn();
 const mockSignWithOptions = jest.fn();
 const mockSha256 = jest.fn();
 
 jest.mock('@sbaiahmed1/react-native-biometrics', () => ({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    createKeys: (...args: unknown[]) => mockCreateKeys(...args),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     deleteKeys: (...args: unknown[]) => mockDeleteKeys(...args),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -78,13 +75,12 @@ describe('useNativeBiometricsHSM hook', () => {
         it('should return hook with required properties', () => {
             // Given a device with biometrics available and an authenticated user
             // When the hook is initialized
-            // Then it should expose all required interface methods so consumers can register, authorize, and manage biometric credentials
+            // Then it should expose all required interface methods so consumers can authorize and manage biometric credentials
             const {result} = renderHook(() => useNativeBiometricsHSM());
 
             expect(result.current).toHaveProperty('serverKnownCredentialIDs');
             expect(result.current).toHaveProperty('getLocalCredentialID');
             expect(result.current).toHaveProperty('areLocalCredentialsKnownToServer');
-            expect(result.current).toHaveProperty('register');
             expect(result.current).toHaveProperty('authorize');
             expect(result.current).toHaveProperty('deleteLocalKeysForAccount');
         });
@@ -194,76 +190,6 @@ describe('useNativeBiometricsHSM hook', () => {
             const {result} = renderHook(() => useNativeBiometricsHSM());
 
             expect(result.current.haveCredentialsEverBeenConfigured).toBe(true);
-        });
-    });
-
-    describe('register', () => {
-        const mockRegistrationChallenge = {
-            challenge: 'test-challenge-string',
-            rp: {id: 'expensify.com'},
-            user: {id: 'user-123', displayName: 'Test User'},
-            pubKeyCredParams: [{type: 'public-key' as const, alg: -7}],
-            timeout: 60000,
-        };
-
-        beforeEach(() => {
-            mockCreateKeys.mockResolvedValue({publicKey: 'abc+def/ghi='});
-        });
-
-        it('should create keys with correct alias', async () => {
-            // Given a valid registration challenge from the server
-            // When registering a new biometric credential
-            // Then it should create an HSM key with the account-specific alias so the key is uniquely tied to the current user
-            const {result} = renderHook(() => useNativeBiometricsHSM());
-            const onResult = jest.fn();
-
-            await act(async () => {
-                await result.current.register(onResult, mockRegistrationChallenge);
-            });
-
-            expect(mockCreateKeys).toHaveBeenCalledWith('12345_HSM_KEY', 'ec256', undefined, true, false);
-        });
-
-        it('should call onResult with success and keyInfo on successful registration', async () => {
-            // Given a valid registration challenge and the biometric library successfully creates an HSM key pair
-            // When the registration completes
-            // Then onResult should receive a success result with the base64url-encoded public key as rawId and HSM type for server registration
-            const {result} = renderHook(() => useNativeBiometricsHSM());
-            const onResult = jest.fn();
-
-            await act(async () => {
-                await result.current.register(onResult, mockRegistrationChallenge);
-            });
-
-            expect(onResult).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    success: true,
-                    keyInfo: expect.objectContaining({
-                        rawId: 'abc-def_ghi',
-                        type: CONST.MULTIFACTOR_AUTHENTICATION.BIOMETRICS_HSM_TYPE,
-                    }),
-                }),
-            );
-        });
-
-        it('should call onResult with failure when createKeys throws', async () => {
-            // Given the biometric library fails to create keys
-            // When the registration is attempted
-            // Then onResult should receive a failure result
-            mockCreateKeys.mockRejectedValue(new Error('Key creation failed'));
-
-            const {result} = renderHook(() => useNativeBiometricsHSM());
-            const onResult = jest.fn();
-
-            await act(async () => {
-                await result.current.register(onResult, mockRegistrationChallenge);
-            });
-
-            expect(onResult).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    success: false,
-                }),
-            );
         });
     });
 

--- a/tests/utils/mfa/flowActors.ts
+++ b/tests/utils/mfa/flowActors.ts
@@ -24,6 +24,7 @@ function createFlowContext(overrides: Partial<MfaContext> = {}): MfaContext {
         validateCode: undefined,
         registrationChallenge: undefined,
         softPromptApproved: false,
+        hasEverAcceptedSoftPrompt: initEvent.hasEverAcceptedSoftPrompt,
         isCancelConfirmVisible: false,
         ...overrides,
     };
@@ -53,17 +54,10 @@ function sendCheckLocalCredentialsDone(actor: ReturnType<typeof createActorAtSta
 }
 
 /**
- * Completes the invoked soft-prompt-acceptance-read actor by sending its done event carrying the given output.
- */
-function sendReadHasAcceptedSoftPromptDone(actor: ReturnType<typeof createActorAtState>, output: MfaActorOutput<'readHasAcceptedSoftPrompt'>) {
-    actor.send(createActorDoneEvent('readHasAcceptedSoftPrompt', output));
-}
-
-/**
  * Completes the invoked credential-creation actor by sending its done event carrying the given output.
  */
 function sendCreateCredentialDone(actor: ReturnType<typeof createActorAtState>, output: MfaActorOutput<'createCredential'>) {
     actor.send(createActorDoneEvent('createCredential', output));
 }
 
-export {createActorAtState, createFlowContext, sendCheckLocalCredentialsDone, sendCreateCredentialDone, sendReadHasAcceptedSoftPromptDone, sendValidateDeviceDone};
+export {createActorAtState, createFlowContext, sendCheckLocalCredentialsDone, sendCreateCredentialDone, sendValidateDeviceDone};

--- a/tests/utils/mfa/flowActors.ts
+++ b/tests/utils/mfa/flowActors.ts
@@ -52,4 +52,18 @@ function sendCheckLocalCredentialsDone(actor: ReturnType<typeof createActorAtSta
     actor.send(createActorDoneEvent('checkLocalCredentials', output));
 }
 
-export {createActorAtState, createFlowContext, sendCheckLocalCredentialsDone, sendValidateDeviceDone};
+/**
+ * Completes the invoked soft-prompt-acceptance-read actor by sending its done event carrying the given output.
+ */
+function sendReadHasAcceptedSoftPromptDone(actor: ReturnType<typeof createActorAtState>, output: MfaActorOutput<'readHasAcceptedSoftPrompt'>) {
+    actor.send(createActorDoneEvent('readHasAcceptedSoftPrompt', output));
+}
+
+/**
+ * Completes the invoked credential-creation actor by sending its done event carrying the given output.
+ */
+function sendCreateCredentialDone(actor: ReturnType<typeof createActorAtState>, output: MfaActorOutput<'createCredential'>) {
+    actor.send(createActorDoneEvent('createCredential', output));
+}
+
+export {createActorAtState, createFlowContext, sendCheckLocalCredentialsDone, sendCreateCredentialDone, sendReadHasAcceptedSoftPromptDone, sendValidateDeviceDone};

--- a/tests/utils/mfa/flowActors.ts
+++ b/tests/utils/mfa/flowActors.ts
@@ -24,7 +24,6 @@ function createFlowContext(overrides: Partial<MfaContext> = {}): MfaContext {
         validateCode: undefined,
         registrationChallenge: undefined,
         softPromptApproved: false,
-        hasEverAcceptedSoftPrompt: initEvent.hasEverAcceptedSoftPrompt,
         isCancelConfirmVisible: false,
         ...overrides,
     };
@@ -49,8 +48,8 @@ function sendValidateDeviceDone(actor: ReturnType<typeof createActorAtState>, ou
 /**
  * Completes the invoked credentials-check actor by sending its done event carrying the given output.
  */
-function sendCheckLocalCredentialsDone(actor: ReturnType<typeof createActorAtState>, output: MfaActorOutput<'checkLocalCredentials'>) {
-    actor.send(createActorDoneEvent('checkLocalCredentials', output));
+function sendLoadRegistrationStateDone(actor: ReturnType<typeof createActorAtState>, output: MfaActorOutput<'loadRegistrationState'>) {
+    actor.send(createActorDoneEvent('loadRegistrationState', output));
 }
 
 /**
@@ -60,4 +59,4 @@ function sendCreateCredentialDone(actor: ReturnType<typeof createActorAtState>, 
     actor.send(createActorDoneEvent('createCredential', output));
 }
 
-export {createActorAtState, createFlowContext, sendCheckLocalCredentialsDone, sendCreateCredentialDone, sendValidateDeviceDone};
+export {createActorAtState, createFlowContext, sendCreateCredentialDone, sendLoadRegistrationStateDone, sendValidateDeviceDone};

--- a/tests/utils/mfa/flowFixtures.ts
+++ b/tests/utils/mfa/flowFixtures.ts
@@ -2,7 +2,7 @@ import {getScenarioConfig} from '@components/MultifactorAuthentication/config';
 import type {MultifactorAuthenticationInitEvent} from '@components/MultifactorAuthentication/machine/types';
 
 import type {RegistrationChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
-import {createMFAErrorFromApiResponse} from '@libs/MultifactorAuthentication/shared/MFAResult';
+import {createLocalMFAError, createMFAErrorFromApiResponse} from '@libs/MultifactorAuthentication/shared/MFAResult';
 
 import CONST from '@src/CONST';
 
@@ -22,6 +22,8 @@ const MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR = createMFAErrorFromApiRespons
     CONST.MULTIFACTOR_AUTHENTICATION.REASON.CLIENT_ERRORS.UNRECOGNIZED,
     'Graph-traversal fatal registration challenge rejection',
 );
+// A reason outside the two device-check reasons, so the walk lands on the generic failure copy.
+const MFA_TEST_CREDENTIAL_CREATION_ERROR = createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.HSM.KEY_CREATION_FAILED, 'Graph-traversal credential creation failure');
 
 /**
  * Builds the INIT event fixture for the test scenario.
@@ -37,4 +39,11 @@ function createInitEvent(): MultifactorAuthenticationInitEvent<typeof MFA_TEST_S
 }
 
 export default createInitEvent;
-export {MFA_TEST_ACCOUNT_ID, MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR, MFA_TEST_INVALID_CODE_ERROR, MFA_TEST_REGISTRATION_CHALLENGE, MFA_TEST_VALIDATE_CODE};
+export {
+    MFA_TEST_ACCOUNT_ID,
+    MFA_TEST_CREDENTIAL_CREATION_ERROR,
+    MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR,
+    MFA_TEST_INVALID_CODE_ERROR,
+    MFA_TEST_REGISTRATION_CHALLENGE,
+    MFA_TEST_VALIDATE_CODE,
+};

--- a/tests/utils/mfa/flowFixtures.ts
+++ b/tests/utils/mfa/flowFixtures.ts
@@ -25,16 +25,15 @@ const MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR = createMFAErrorFromApiRespons
 // A reason outside the two device-check reasons, so the walk lands on the generic failure copy.
 const MFA_TEST_CREDENTIAL_CREATION_ERROR = createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.HSM.KEY_CREATION_FAILED, 'Graph-traversal credential creation failure');
 
-/**
- * Builds the INIT event fixture for the test scenario.
- */
-function createInitEvent(): MultifactorAuthenticationInitEvent<typeof MFA_TEST_SCENARIO_NAME> {
+/** Builds the INIT event fixture. `hasEverAcceptedSoftPrompt` defaults to `false`; pass `true` for a returning-user flow that already accepted the soft prompt. */
+function createInitEvent(hasEverAcceptedSoftPrompt = false): MultifactorAuthenticationInitEvent<typeof MFA_TEST_SCENARIO_NAME> {
     return {
         type: 'INIT',
         accountID: MFA_TEST_ACCOUNT_ID,
         scenarioName: MFA_TEST_SCENARIO_NAME,
         scenario: getScenarioConfig(MFA_TEST_SCENARIO_NAME),
         payload: undefined,
+        hasEverAcceptedSoftPrompt,
     };
 }
 

--- a/tests/utils/mfa/flowFixtures.ts
+++ b/tests/utils/mfa/flowFixtures.ts
@@ -25,15 +25,14 @@ const MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR = createMFAErrorFromApiRespons
 // A reason outside the two device-check reasons, so the walk lands on the generic failure copy.
 const MFA_TEST_CREDENTIAL_CREATION_ERROR = createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.HSM.KEY_CREATION_FAILED, 'Graph-traversal credential creation failure');
 
-/** Builds the INIT event fixture. `hasEverAcceptedSoftPrompt` defaults to `false`; pass `true` for a returning-user flow that already accepted the soft prompt. */
-function createInitEvent(hasEverAcceptedSoftPrompt = false): MultifactorAuthenticationInitEvent<typeof MFA_TEST_SCENARIO_NAME> {
+/** Builds the INIT event fixture. Device-local registration state is loaded by the machine after initialization. */
+function createInitEvent(): MultifactorAuthenticationInitEvent<typeof MFA_TEST_SCENARIO_NAME> {
     return {
         type: 'INIT',
         accountID: MFA_TEST_ACCOUNT_ID,
         scenarioName: MFA_TEST_SCENARIO_NAME,
         scenario: getScenarioConfig(MFA_TEST_SCENARIO_NAME),
         payload: undefined,
-        hasEverAcceptedSoftPrompt,
     };
 }
 

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -105,7 +105,7 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
         ],
-        endState: `${MFA_STATE.OPEN}.${MFA_STATE.PREPARING}.${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}`,
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.AWAITING_SOFT_PROMPT}`,
     },
     {
         description: 'the invalid-code journey clears the inline error and accepts a corrected code',
@@ -119,35 +119,38 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
         ],
-        endState: `${MFA_STATE.OPEN}.${MFA_STATE.PREPARING}.${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}`,
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.AWAITING_SOFT_PROMPT}`,
     },
-    // creatingCredential has two entries (a persisted-acceptance skip and a live prompt approval), and
-    // the state's UI assertion differs between them, so both routes need a driving journey: the
-    // generated shortest paths would otherwise only ever walk one of the two.
     {
-        description: 'the credential-creation journey via the persisted soft-prompt acceptance skips the prompt',
+        description: 'the credential-creation journey reaches creatingCredential after the user accepts the soft prompt',
         events: [
             createInitEvent(),
             createActorDoneEvent('validateDevice', {success: true}),
             createActorDoneEvent('checkLocalCredentials', false),
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
-            createActorDoneEvent('readHasAcceptedSoftPrompt', true),
-        ],
-        endState: `${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`,
-    },
-    {
-        description: 'the credential-creation journey via soft-prompt approval reaches creatingCredential after the user accepts',
-        events: [
-            createInitEvent(),
-            createActorDoneEvent('validateDevice', {success: true}),
-            createActorDoneEvent('checkLocalCredentials', false),
-            {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
-            createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
-            createActorDoneEvent('readHasAcceptedSoftPrompt', false),
             {type: 'SOFT_PROMPT_APPROVED'},
         ],
         endState: `${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`,
+    },
+    // A (re-)registration always requires approval, even if the account accepted the soft prompt
+    // before - `hasEverAcceptedSoftPrompt` only matters on the returning-user branch below.
+    {
+        description: 'the registration journey still requires soft-prompt approval even though the account already accepted it before',
+        events: [
+            createInitEvent(true),
+            createActorDoneEvent('validateDevice', {success: true}),
+            createActorDoneEvent('checkLocalCredentials', false),
+            {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
+            createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
+        ],
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.AWAITING_SOFT_PROMPT}`,
+    },
+    // A returning user who already accepted the soft prompt skips straight to the outcome instead of re-confirming.
+    {
+        description: 'the returning-user journey skips the soft prompt when the account already accepted it on this device',
+        events: [createInitEvent(true), createActorDoneEvent('validateDevice', {success: true}), createActorDoneEvent('checkLocalCredentials', true)],
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`,
     },
 ];
 
@@ -166,7 +169,9 @@ type MfaActorEventFixtures = {
  * `{type}` and potentially bypass event-dependent behavior.
  */
 const MFA_GRAPH_EVENT_FIXTURES = {
-    INIT: [createInitEvent()],
+    // Both acceptance-flag variants are offered so the traversal covers the guard on
+    // `decidingRegistration` that skips the soft prompt for a returning user who already accepted it.
+    INIT: [createInitEvent(), createInitEvent(true)],
     CLOSE_MODAL: [{type: 'CLOSE_MODAL'}],
     MODAL_CLOSED: [{type: 'MODAL_CLOSED'}],
     SOFT_PROMPT_APPROVED: [{type: 'SOFT_PROMPT_APPROVED'}],
@@ -193,7 +198,6 @@ const MFA_ACTOR_EVENT_FIXTURES = {
             error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.NO_AUTHENTICATION_METHODS_ENROLLED, 'Graph-traversal device-check enrollment refusal'),
         },
     ),
-    readHasAcceptedSoftPrompt: createActorEvents('readHasAcceptedSoftPrompt', false, true),
     checkLocalCredentials: createActorEvents('checkLocalCredentials', false, true),
     requestRegistrationChallenge: createActorEvents(
         'requestRegistrationChallenge',

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -11,7 +11,13 @@ import type {ActorLogic, DoneActorEvent, ErrorActorEvent, InputFrom, SnapshotFro
 import {matchesState} from 'xstate';
 import {getShortestPaths, TestModel} from 'xstate/graph';
 
-import createInitEvent, {MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR, MFA_TEST_INVALID_CODE_ERROR, MFA_TEST_REGISTRATION_CHALLENGE, MFA_TEST_VALIDATE_CODE} from './flowFixtures';
+import createInitEvent, {
+    MFA_TEST_CREDENTIAL_CREATION_ERROR,
+    MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR,
+    MFA_TEST_INVALID_CODE_ERROR,
+    MFA_TEST_REGISTRATION_CHALLENGE,
+    MFA_TEST_VALIDATE_CODE,
+} from './flowFixtures';
 
 const MFA_STATE = CONST.MULTIFACTOR_AUTHENTICATION.MFA_STATE;
 
@@ -115,6 +121,34 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
         ],
         endState: `${MFA_STATE.OPEN}.${MFA_STATE.PREPARING}.${MFA_STATE.CHECKING_SOFT_PROMPT_ACCEPTANCE}`,
     },
+    // creatingCredential has two entries (a persisted-acceptance skip and a live prompt approval), and
+    // the state's UI assertion differs between them, so both routes need a driving journey: the
+    // generated shortest paths would otherwise only ever walk one of the two.
+    {
+        description: 'the credential-creation journey via the persisted soft-prompt acceptance skips the prompt',
+        events: [
+            createInitEvent(),
+            createActorDoneEvent('validateDevice', {success: true}),
+            createActorDoneEvent('checkLocalCredentials', false),
+            {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
+            createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
+            createActorDoneEvent('readHasAcceptedSoftPrompt', true),
+        ],
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`,
+    },
+    {
+        description: 'the credential-creation journey via soft-prompt approval reaches creatingCredential after the user accepts',
+        events: [
+            createInitEvent(),
+            createActorDoneEvent('validateDevice', {success: true}),
+            createActorDoneEvent('checkLocalCredentials', false),
+            {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
+            createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
+            createActorDoneEvent('readHasAcceptedSoftPrompt', false),
+            {type: 'SOFT_PROMPT_APPROVED'},
+        ],
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`,
+    },
 ];
 
 type MfaEventFixtures = {
@@ -167,6 +201,7 @@ const MFA_ACTOR_EVENT_FIXTURES = {
         {success: false, error: MFA_TEST_INVALID_CODE_ERROR},
         {success: false, error: MFA_TEST_FATAL_REGISTRATION_CHALLENGE_ERROR},
     ),
+    createCredential: createActorEvents('createCredential', {success: true}, {success: false, error: MFA_TEST_CREDENTIAL_CREATION_ERROR}),
 } satisfies MfaActorEventFixtures;
 
 /** Every concrete event the traversal can offer, in the order its fixtures declare them. */

--- a/tests/utils/mfa/flowPaths.ts
+++ b/tests/utils/mfa/flowPaths.ts
@@ -100,7 +100,7 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
         events: [
             createInitEvent(),
             createActorDoneEvent('validateDevice', {success: true}),
-            createActorDoneEvent('checkLocalCredentials', false),
+            createActorDoneEvent('loadRegistrationState', {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false}),
             {type: 'RESEND_VALIDATE_CODE'},
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
@@ -112,7 +112,7 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
         events: [
             createInitEvent(),
             createActorDoneEvent('validateDevice', {success: true}),
-            createActorDoneEvent('checkLocalCredentials', false),
+            createActorDoneEvent('loadRegistrationState', {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false}),
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: false, error: MFA_TEST_INVALID_CODE_ERROR}),
             {type: 'VALIDATE_CODE_CHANGED'},
@@ -126,21 +126,21 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
         events: [
             createInitEvent(),
             createActorDoneEvent('validateDevice', {success: true}),
-            createActorDoneEvent('checkLocalCredentials', false),
+            createActorDoneEvent('loadRegistrationState', {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false}),
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
             {type: 'SOFT_PROMPT_APPROVED'},
         ],
-        endState: `${MFA_STATE.OPEN}.${MFA_STATE.CREATING_CREDENTIAL}`,
+        endState: `${MFA_STATE.OPEN}.${MFA_STATE.PROMPT}.${MFA_STATE.CREATING_CREDENTIAL}`,
     },
     // A (re-)registration always requires approval, even if the account accepted the soft prompt
-    // before - `hasEverAcceptedSoftPrompt` only matters on the returning-user branch below.
+    // before - the persisted flag only matters on the returning-user branch below.
     {
         description: 'the registration journey still requires soft-prompt approval even though the account already accepted it before',
         events: [
-            createInitEvent(true),
+            createInitEvent(),
             createActorDoneEvent('validateDevice', {success: true}),
-            createActorDoneEvent('checkLocalCredentials', false),
+            createActorDoneEvent('loadRegistrationState', {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: true}),
             {type: 'VALIDATE_CODE_ENTERED', validateCode: MFA_TEST_VALIDATE_CODE},
             createActorDoneEvent('requestRegistrationChallenge', {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE}),
         ],
@@ -149,7 +149,11 @@ const DRIVING_JOURNEYS: DrivingJourney[] = [
     // A returning user who already accepted the soft prompt skips straight to the outcome instead of re-confirming.
     {
         description: 'the returning-user journey skips the soft prompt when the account already accepted it on this device',
-        events: [createInitEvent(true), createActorDoneEvent('validateDevice', {success: true}), createActorDoneEvent('checkLocalCredentials', true)],
+        events: [
+            createInitEvent(),
+            createActorDoneEvent('validateDevice', {success: true}),
+            createActorDoneEvent('loadRegistrationState', {hasLocalCredentials: true, hasEverAcceptedSoftPrompt: true}),
+        ],
         endState: `${MFA_STATE.OPEN}.${MFA_STATE.OUTCOME}.${MFA_STATE.SUCCESS}`,
     },
 ];
@@ -169,9 +173,7 @@ type MfaActorEventFixtures = {
  * `{type}` and potentially bypass event-dependent behavior.
  */
 const MFA_GRAPH_EVENT_FIXTURES = {
-    // Both acceptance-flag variants are offered so the traversal covers the guard on
-    // `decidingRegistration` that skips the soft prompt for a returning user who already accepted it.
-    INIT: [createInitEvent(), createInitEvent(true)],
+    INIT: [createInitEvent()],
     CLOSE_MODAL: [{type: 'CLOSE_MODAL'}],
     MODAL_CLOSED: [{type: 'MODAL_CLOSED'}],
     SOFT_PROMPT_APPROVED: [{type: 'SOFT_PROMPT_APPROVED'}],
@@ -198,7 +200,13 @@ const MFA_ACTOR_EVENT_FIXTURES = {
             error: createLocalMFAError(CONST.MULTIFACTOR_AUTHENTICATION.REASON.LOCAL_ERRORS.NO_AUTHENTICATION_METHODS_ENROLLED, 'Graph-traversal device-check enrollment refusal'),
         },
     ),
-    checkLocalCredentials: createActorEvents('checkLocalCredentials', false, true),
+    loadRegistrationState: createActorEvents(
+        'loadRegistrationState',
+        {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: false},
+        {hasLocalCredentials: false, hasEverAcceptedSoftPrompt: true},
+        {hasLocalCredentials: true, hasEverAcceptedSoftPrompt: false},
+        {hasLocalCredentials: true, hasEverAcceptedSoftPrompt: true},
+    ),
     requestRegistrationChallenge: createActorEvents(
         'requestRegistrationChallenge',
         {success: true, challenge: MFA_TEST_REGISTRATION_CHALLENGE},

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -4,7 +4,6 @@ import type {
     CheckLocalCredentialsInput,
     CreateCredentialInput,
     CreateCredentialOutput,
-    ReadHasAcceptedSoftPromptInput,
     RequestRegistrationChallengeInput,
     RequestRegistrationChallengeOutput,
     ValidateDeviceInput,
@@ -92,7 +91,6 @@ function createControlledActor<TOutput, TInput>(actorID: string) {
 }
 
 const validateDeviceControl = createControlledActor<MFAResult, ValidateDeviceInput>('validateDevice');
-const readHasAcceptedSoftPromptControl = createControlledActor<boolean, ReadHasAcceptedSoftPromptInput>('readHasAcceptedSoftPrompt');
 const checkLocalCredentialsControl = createControlledActor<boolean, CheckLocalCredentialsInput>('checkLocalCredentials');
 const requestRegistrationChallengeControl = createControlledActor<RequestRegistrationChallengeOutput, RequestRegistrationChallengeInput>('requestRegistrationChallenge');
 const createCredentialControl = createControlledActor<CreateCredentialOutput, CreateCredentialInput>('createCredential');
@@ -100,7 +98,6 @@ const createCredentialControl = createControlledActor<CreateCredentialOutput, Cr
 function resetMfaUiMocks() {
     pendingModalClose.clear();
     validateDeviceControl.reset();
-    readHasAcceptedSoftPromptControl.reset();
     checkLocalCredentialsControl.reset();
     requestRegistrationChallengeControl.reset();
     createCredentialControl.reset();
@@ -110,7 +107,6 @@ function resetMfaUiMocks() {
 function mfaActorsMock() {
     const actors = {
         validateDevice: validateDeviceControl.actor,
-        readHasAcceptedSoftPrompt: readHasAcceptedSoftPromptControl.actor,
         checkLocalCredentials: checkLocalCredentialsControl.actor,
         requestRegistrationChallenge: requestRegistrationChallengeControl.actor,
         createCredential: createCredentialControl.actor,
@@ -205,7 +201,6 @@ function navigationMock() {
 export {
     pendingModalClose,
     validateDeviceControl,
-    readHasAcceptedSoftPromptControl,
     checkLocalCredentialsControl,
     requestRegistrationChallengeControl,
     createCredentialControl,

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -2,6 +2,8 @@ import type {UseBiometricsReturn} from '@components/MultifactorAuthentication/bi
 import type createActors from '@components/MultifactorAuthentication/machine/mfaActors';
 import type {
     CheckLocalCredentialsInput,
+    CreateCredentialInput,
+    CreateCredentialOutput,
     ReadHasAcceptedSoftPromptInput,
     RequestRegistrationChallengeInput,
     RequestRegistrationChallengeOutput,
@@ -93,6 +95,7 @@ const validateDeviceControl = createControlledActor<MFAResult, ValidateDeviceInp
 const readHasAcceptedSoftPromptControl = createControlledActor<boolean, ReadHasAcceptedSoftPromptInput>('readHasAcceptedSoftPrompt');
 const checkLocalCredentialsControl = createControlledActor<boolean, CheckLocalCredentialsInput>('checkLocalCredentials');
 const requestRegistrationChallengeControl = createControlledActor<RequestRegistrationChallengeOutput, RequestRegistrationChallengeInput>('requestRegistrationChallenge');
+const createCredentialControl = createControlledActor<CreateCredentialOutput, CreateCredentialInput>('createCredential');
 
 function resetMfaUiMocks() {
     pendingModalClose.clear();
@@ -100,6 +103,7 @@ function resetMfaUiMocks() {
     readHasAcceptedSoftPromptControl.reset();
     checkLocalCredentialsControl.reset();
     requestRegistrationChallengeControl.reset();
+    createCredentialControl.reset();
 }
 
 /** Replaces the machine's side-effect actors with controlled test implementations. */
@@ -109,6 +113,7 @@ function mfaActorsMock() {
         readHasAcceptedSoftPrompt: readHasAcceptedSoftPromptControl.actor,
         checkLocalCredentials: checkLocalCredentialsControl.actor,
         requestRegistrationChallenge: requestRegistrationChallengeControl.actor,
+        createCredential: createCredentialControl.actor,
     } satisfies ReturnType<typeof createActors>;
 
     return {
@@ -203,6 +208,7 @@ export {
     readHasAcceptedSoftPromptControl,
     checkLocalCredentialsControl,
     requestRegistrationChallengeControl,
+    createCredentialControl,
     resetMfaUiMocks,
     mfaActorsMock,
     userActionsMock,

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -58,6 +58,30 @@ const biometricsMock: Pick<UseBiometricsReturn, 'serverKnownCredentialIDs' | 'ar
     areLocalCredentialsKnownToServer: () => Promise.resolve(false),
 };
 
+let pendingCredentialsStateCapture: ((hasLocalCredentials: boolean) => void) | undefined;
+
+/** Lets a test hold the Provider's pre-INIT credential snapshot across an account switch. */
+const credentialsStateCaptureControl = {
+    defer: () => {
+        biometricsMock.areLocalCredentialsKnownToServer = () =>
+            new Promise<boolean>((resolve) => {
+                pendingCredentialsStateCapture = resolve;
+            });
+    },
+    resolve: (hasLocalCredentials: boolean) => {
+        const resolve = pendingCredentialsStateCapture;
+        pendingCredentialsStateCapture = undefined;
+        if (!resolve) {
+            throw new Error('No pending credentials-state capture is available.');
+        }
+        resolve(hasLocalCredentials);
+    },
+    reset: () => {
+        pendingCredentialsStateCapture = undefined;
+        biometricsMock.areLocalCredentialsKnownToServer = () => Promise.resolve(false);
+    },
+};
+
 /**
  * Builds a controlled deferred mock for one invoked machine actor. Each machine invocation parks a
  * pending promise that the test settles later through `resolve` or `reject`, at the exact path step
@@ -97,6 +121,7 @@ const createCredentialControl = createControlledActor<CreateCredentialOutput, Cr
 
 function resetMfaUiMocks() {
     pendingModalClose.clear();
+    credentialsStateCaptureControl.reset();
     validateDeviceControl.reset();
     checkLocalCredentialsControl.reset();
     requestRegistrationChallengeControl.reset();
@@ -200,6 +225,7 @@ function navigationMock() {
 
 export {
     pendingModalClose,
+    credentialsStateCaptureControl,
     validateDeviceControl,
     checkLocalCredentialsControl,
     requestRegistrationChallengeControl,

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -58,26 +58,26 @@ const biometricsMock: Pick<UseBiometricsReturn, 'serverKnownCredentialIDs' | 'ar
     areLocalCredentialsKnownToServer: () => Promise.resolve(false),
 };
 
-let pendingCredentialsStateCapture: ((hasLocalCredentials: boolean) => void) | undefined;
+let pendingRegistrationStateCapture: ((hasLocalCredentials: boolean) => void) | undefined;
 
-/** Lets a test hold the Provider's pre-INIT credential snapshot across an account switch. */
-const credentialsStateCaptureControl = {
+/** Lets a test hold the Provider's pre-INIT registration-state snapshot across an account switch. */
+const registrationStateCaptureControl = {
     defer: () => {
         biometricsMock.areLocalCredentialsKnownToServer = () =>
             new Promise<boolean>((resolve) => {
-                pendingCredentialsStateCapture = resolve;
+                pendingRegistrationStateCapture = resolve;
             });
     },
     resolve: (hasLocalCredentials: boolean) => {
-        const resolve = pendingCredentialsStateCapture;
-        pendingCredentialsStateCapture = undefined;
+        const resolve = pendingRegistrationStateCapture;
+        pendingRegistrationStateCapture = undefined;
         if (!resolve) {
-            throw new Error('No pending credentials-state capture is available.');
+            throw new Error('No pending registration-state capture is available.');
         }
         resolve(hasLocalCredentials);
     },
     reset: () => {
-        pendingCredentialsStateCapture = undefined;
+        pendingRegistrationStateCapture = undefined;
         biometricsMock.areLocalCredentialsKnownToServer = () => Promise.resolve(false);
     },
 };
@@ -121,7 +121,7 @@ const createCredentialControl = createControlledActor<CreateCredentialOutput, Cr
 
 function resetMfaUiMocks() {
     pendingModalClose.clear();
-    credentialsStateCaptureControl.reset();
+    registrationStateCaptureControl.reset();
     validateDeviceControl.reset();
     checkLocalCredentialsControl.reset();
     requestRegistrationChallengeControl.reset();
@@ -225,7 +225,7 @@ function navigationMock() {
 
 export {
     pendingModalClose,
-    credentialsStateCaptureControl,
+    registrationStateCaptureControl,
     validateDeviceControl,
     checkLocalCredentialsControl,
     requestRegistrationChallengeControl,

--- a/tests/utils/mfa/realUi/mocks.ts
+++ b/tests/utils/mfa/realUi/mocks.ts
@@ -1,9 +1,10 @@
 import type {UseBiometricsReturn} from '@components/MultifactorAuthentication/biometrics/shared/types';
 import type createActors from '@components/MultifactorAuthentication/machine/mfaActors';
 import type {
-    CheckLocalCredentialsInput,
     CreateCredentialInput,
     CreateCredentialOutput,
+    LoadRegistrationStateInput,
+    LoadRegistrationStateOutput,
     RequestRegistrationChallengeInput,
     RequestRegistrationChallengeOutput,
     ValidateDeviceInput,
@@ -115,7 +116,7 @@ function createControlledActor<TOutput, TInput>(actorID: string) {
 }
 
 const validateDeviceControl = createControlledActor<MFAResult, ValidateDeviceInput>('validateDevice');
-const checkLocalCredentialsControl = createControlledActor<boolean, CheckLocalCredentialsInput>('checkLocalCredentials');
+const loadRegistrationStateControl = createControlledActor<LoadRegistrationStateOutput, LoadRegistrationStateInput>('loadRegistrationState');
 const requestRegistrationChallengeControl = createControlledActor<RequestRegistrationChallengeOutput, RequestRegistrationChallengeInput>('requestRegistrationChallenge');
 const createCredentialControl = createControlledActor<CreateCredentialOutput, CreateCredentialInput>('createCredential');
 
@@ -123,7 +124,7 @@ function resetMfaUiMocks() {
     pendingModalClose.clear();
     registrationStateCaptureControl.reset();
     validateDeviceControl.reset();
-    checkLocalCredentialsControl.reset();
+    loadRegistrationStateControl.reset();
     requestRegistrationChallengeControl.reset();
     createCredentialControl.reset();
 }
@@ -132,7 +133,7 @@ function resetMfaUiMocks() {
 function mfaActorsMock() {
     const actors = {
         validateDevice: validateDeviceControl.actor,
-        checkLocalCredentials: checkLocalCredentialsControl.actor,
+        loadRegistrationState: loadRegistrationStateControl.actor,
         requestRegistrationChallenge: requestRegistrationChallengeControl.actor,
         createCredential: createCredentialControl.actor,
     } satisfies ReturnType<typeof createActors>;
@@ -227,7 +228,7 @@ export {
     pendingModalClose,
     registrationStateCaptureControl,
     validateDeviceControl,
-    checkLocalCredentialsControl,
+    loadRegistrationStateControl,
     requestRegistrationChallengeControl,
     createCredentialControl,
     resetMfaUiMocks,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### PR Stack

Part of the MFA flow to XState migration ([#81197](https://github.com/Expensify/App/issues/81197)). The migration lands as a stack of vertical slices on the integration branch `dariusz-81197-mfa-state-machine`, and nothing reaches `main` until the final integration merge. The stack lives on the `software-mansion-labs/expensify-app-fork` remote, so this PR is opened there; its parent slice ([#355](https://github.com/software-mansion-labs/expensify-app-fork/pull/355)) is still open, so this PR targets the parent branch directly.

| # | PR | Branch | Base |
| --- | --- | --- | --- |
| - | [#345](https://github.com/software-mansion-labs/expensify-app-fork/pull/345) (test harness) | `dariusz-biela/refactor/3ds/mfa-test-reachability-and-ui-walk` | `dariusz-81197-mfa-state-machine` |
| - | [#346](https://github.com/software-mansion-labs/expensify-app-fork/pull/346) (device check) | `dariusz-biela/feat/3ds/mfa-device-check-and-failure-screen` | `dariusz-81197-mfa-state-machine` |
| - | [#352](https://github.com/software-mansion-labs/expensify-app-fork/pull/352) (soft prompt) | `dariusz-biela/feat/3ds/mfa-soft-prompt` | `dariusz-81197-mfa-state-machine` |
| - | [#355](https://github.com/software-mansion-labs/expensify-app-fork/pull/355) (magic code) | `dariusz-biela/feat/3ds/mfa-magic-code-and-registration-decision` | `dariusz-81197-mfa-state-machine` |
| - | **This PR** (credential creation) | `jakubstec/3ds/mfa-registration` | `dariusz-biela/feat/3ds/mfa-magic-code-and-registration-decision` |

### Explanation of Change

Migrates credential creation and backend registration from the legacy MFA flow into the XState machine.

The previous slice exchanges a valid magic code for a registration challenge. This slice consumes that challenge: after the user explicitly accepts the soft prompt, the machine runs the platform credential ceremony and registers the resulting credential with the backend.

The migrated registration path is now:

```text
registration decision
    → validate code
    → request registration challenge
    → soft prompt
    → create platform credential
    → register credential with backend
    → outcome
```

**In the app**

- A fresh registration or re-registration always shows the soft prompt before creating a credential, even if the account accepted the prompt during an earlier flow. This matches production behavior: every new credential ceremony is preceded by an explanation of what the user is about to approve.
- After the user presses Confirm:
    - web opens the browser passkey ceremony;
    - native opens the HSM-backed biometric/device-credential ceremony.
- The Confirm button enters a loading state after approval, preventing repeated submissions while credential creation is running.
- A successful platform ceremony is followed by `RegisterAuthenticationKey`. The flow reaches the success outcome only after both operations succeed.
- A platform refusal, malformed credential response, local persistence failure, backend rejection, or unexpected exception reaches the failure outcome with the corresponding MFA error.
- Cancelling on web passes XState's abort signal into `navigator.credentials.create()`, allowing supported browsers to close the passkey dialog.
- The actor checks the abort signal again before backend registration, covering browsers or native operations that finish after the flow has already been cancelled.

**In the state machine**

- A new `creatingCredential` state is entered after `SOFT_PROMPT_APPROVED` when the context contains a registration challenge.
- The state invokes a new `createCredential` actor, which performs two ordered steps:
    1. the platform credential ceremony;
    2. backend registration through `processRegistration()`.

  These steps are sequential and fail-fast: backend registration never starts if platform credential creation fails. They intentionally live in one orchestration actor because the second step requires the `keyInfo` produced by the first one.

  This is not a transaction. A credential already created by the platform cannot always be rolled back. Therefore, a backend failure is surfaced unchanged without attempting to delete the credential.
- A successful actor result reaches `outcome.success`.
- A failed `MFAResult` reaches `outcome.failure` while preserving the exact error.
- A rejected actor promise is converted into an `UNHANDLED_EXCEPTION` error.
- `snapshotToState()` now exposes `canApproveSoftPrompt` through `snapshot.can({type: 'SOFT_PROMPT_APPROVED'})`. `PromptPage` uses it to replace the Confirm button with a loading state once the machine leaves `awaitingSoftPrompt`.

**Platform credential creation**

On web:

- Reconciles locally stored passkeys against the server-known credential IDs before creating another passkey.
- Builds `PublicKeyCredentialCreationOptions` from the registration challenge and the reconciled credential list.
- Calls `navigator.credentials.create()` through `createPasskeyCredential()`, forwarding the abort signal.
- Validates that WebAuthn returned an `AuthenticatorAttestationResponse`.
- Extracts and encodes:
    - credential ID;
    - `clientDataJSON`;
    - attestation object;
    - supported transports;
    - AAGUID when exposed by the browser.
- Persists the new passkey in the account-scoped Onyx entry before backend registration. Both the registration decision and authorization locate usable passkeys through this entry, so registering with the backend after a failed local write would leave the server knowing a credential that the client could not find again.
- If the Onyx write rejects, the operation returns the new `LOCAL_PERSISTENCE_FAILED` error and stops before calling the backend.
- `setLocalPasskeyCredentials()` and `addLocalPasskeyCredential()` now return their Onyx promises so credential creation can await and handle persistence failures.

On native:

- Creates an account-scoped EC P-256 HSM key through `createKeys()`.
- Allows device-credential fallback when biometrics are unavailable.
- Uses `failIfExists: false`, allowing re-registration to replace the existing key stored under the account alias.
- Converts the generated public key into the existing `NativeBiometricsHSMKeyInfo` shape expected by `RegisterAuthenticationKey`.
- Maps native library failures through the existing HSM error decoder.
- Native key creation does not currently accept an abort signal. Stopping the XState actor still prevents backend registration after the ceremony finishes.

| Credential known to backend | `true` | Outcome directly |

A fresh registration always requires explicit approval regardless of the persisted value. The acceptance flag affects only the returning-user branch, where no new credential is being created.

The returning-user branches temporarily end at the outcome because authorization is not part of this slice. The upcoming authorization slice will place automatic authorization between this decision and the final outcome.

Because the registration-state snapshot is captured asynchronously, the Provider stores the initiating account ID and reads `ONYXKEYS.SESSION` again immediately before sending `INIT`. If the account changed while initialization was running, the stale flow is rejected instead of starting with another account's device state.

**Tests**

- Native operation tests cover:
    - account-scoped HSM key creation;
    - the exact `NativeBiometricsHSMKeyInfo` result;
    - native library error mapping.
- Web operation tests cover:
    - WebAuthn option construction and credential extraction;
    - local passkey persistence;
    - reconciliation with server-known credentials;
    - WebAuthn error mapping;
    - unexpected credential response types;
    - failed Onyx persistence;
    - abort-signal forwarding;
    - cancellation after a browser ceremony resolves.
- Actor tests cover:
    - short-circuiting before backend registration after a platform refusal;
    - forwarding the exact `keyInfo` into `processRegistration()`;
    - returning backend failures without rollback;
    - cancellation before the backend request starts.
- Explicit transition tests cover:
    - entering `creatingCredential` when a challenge is pending;
    - the returning-user path without a challenge;
    - successful, failed, and rejected actor completion.
- Graph traversal and rendered-UI paths now cover credential-creation success and failure, re-registration, and both soft-prompt acceptance variants.

**Out of scope**

The remaining slices will add:

- authorization on web and native, together with removing the remaining legacy state layer;
- complete cancel and back-press handling;
- custom outcome screens;
- recovery;
- offline handling;
- Sentry logs;
- the final integration merge into `main`.

This PR contains only the cancellation safeguards necessary to prevent an abandoned credential ceremony from starting backend registration. It does not introduce retry or recovery behavior.

### Fixed Issues

<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing.
2. Please postfix `PROPOSAL:` with a URL to the approved proposal.
--->

$ https://github.com/Expensify/App/issues/81197
PROPOSAL: N/A (internal engineering migration, part of the MFA XState refactor)

### Tests

Run the app in dev on this branch using an account whose current device credential is not known to the backend. A fresh dev account works.

**Fresh registration**

1. Trigger an MFA scenario, for example through Troubleshoot > Biometrics test.
2. Verify that the validate-code screen appears and a security-code email arrives.
3. Submit the valid security code from the email.
4. Verify that the soft prompt appears.
5. Press Confirm.
6. Verify that:
    - the Confirm button enters a loading state and cannot be pressed again;
    - web opens the browser passkey dialog;
    - native opens the biometric/device-credential ceremony.
7. Complete the ceremony.
8. Verify that the flow reaches the success outcome.
9. Close the modal and trigger the scenario again.
10. Verify that the registered device skips the validate-code screen. If soft-prompt acceptance is already persisted, it also skips the soft prompt in this temporary pre-authorization flow.

**Re-registration**

1. Complete the fresh-registration test.
2. Revoke the credential using the Troubleshoot settings.
3. Trigger the MFA scenario again.
4. Verify that:
    - the validate-code screen appears;
    - a new security-code email arrives;
    - after submitting the valid code, the soft prompt appears even though it was accepted previously.
5. Confirm the prompt and complete the new credential ceremony.
6. Verify that the flow reaches the success outcome.

**Platform refusal**

1. Start a fresh registration and reach the soft prompt.
2. Press Confirm.
3. Cancel or reject the browser passkey/native biometric ceremony.
4. Verify that the flow reaches the failure outcome and does not continue to backend registration.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Reach the validate-code or soft-prompt screen.
2. Go offline.
3. Verify that the existing full-page offline blocking view covers the screen and credential creation cannot be started.
4. Go online and verify that the screen becomes interactive again.

Registration retry and recovery after connectivity changes are intentionally deferred to the dedicated offline and recovery slices.

### QA Steps

[No QA] - internal stacked PR on the MFA XState integration branch. The flow is intentionally partial between slices and does not reach staging until the final integration merge.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos

<details>

<summary>iOS: Native</summary>

</details>
  

<details>

<summary>MacOS: Chrome / Safari</summary>

</details>
