### PR TITLE
Amend the ButtonComposed instant spinner

### DIFF
--- a/src/components/ButtonComposed/Button.tsx
+++ b/src/components/ButtonComposed/Button.tsx
@@ -70,16 +70,8 @@ function Button({
     // Passed to onPress so a handler can enter the loading state itself, after its own validation/branching.
     const loadingController: PressLoadingController = {run: startWithLoading};
 
-    const handlePress = (event?: GestureResponderEvent | KeyboardEvent) => {
-        if (event?.type === 'click') {
-            const currentTarget = event?.currentTarget as HTMLElement;
-            currentTarget?.blur();
-        }
-
-        if (enableHapticFeedback) {
-            HapticFeedback.press();
-        }
-
+    // Shared by a pointer press and the Enter shortcut, so both take the same route into onPress.
+    const runPress = (event?: GestureResponderEvent | KeyboardEvent) => {
         if (isDisabled || isLoading) {
             return;
         }
@@ -90,18 +82,23 @@ function Button({
         return onPress(event, loadingController);
     };
 
-    // Route the Enter shortcut (fired by ButtonKeyboardShortcut via the actions context) through the same paths as a pointer
-    // press, minus the mouse-only blur/haptic handling — so the immediate spinner works on Enter too. Living in the actions
-    // context (functions only) keeps it clear of rulesdir/context-provider-split-values.
-    const handleEnterPress = () => {
-        if (isDisabled || isLoading) {
-            return;
+    const handlePress = (event?: GestureResponderEvent | KeyboardEvent) => {
+        if (event?.type === 'click') {
+            const currentTarget = event?.currentTarget as HTMLElement;
+            currentTarget?.blur();
         }
-        if (shouldShowLoadingImmediatelyOnPress) {
-            return startWithLoading(() => onPress(undefined, loadingController));
+
+        if (enableHapticFeedback) {
+            HapticFeedback.press();
         }
-        return onPress(undefined, loadingController);
+
+        return runPress(event);
     };
+
+    // The Enter shortcut is fired by ButtonKeyboardShortcut through the actions context. It shares runPress with a pointer press so the
+    // immediate spinner works on Enter too, and skips the mouse-only blur/haptic handling. Living in the actions context (functions only)
+    // keeps it clear of rulesdir/context-provider-split-values.
+    const handleEnterPress = () => runPress();
 
     const buttonVariantStyles = useMemo(() => {
         const shouldUseDisabledStyles = isDisabled && !stayNormalOnDisable;

--- a/src/components/ButtonComposed/Button.tsx
+++ b/src/components/ButtonComposed/Button.tsx
@@ -28,7 +28,7 @@ function Button({
     contentContainerStyle = [],
     size = CONST.BUTTON_SIZE.MEDIUM,
     isLoading: isOnyxLoading,
-    showInstantLoadingOnPress = false,
+    shouldShowLoadingImmediatelyOnPress = false,
     isDisabled = false,
     onLayout = () => {},
     onPress = () => {},
@@ -64,24 +64,21 @@ function Button({
         context: 'Button',
     };
 
-    // isLoading is the pressed flag combined with isOnyxLoading, and drives rendering, the press guard and the disabled state.
-    // isOnyxLoading is forwarded undefined when the consumer supplies none, so the hook knows there is no hand-over coming.
-    // resetOnFocus is scoped to the opt-in, so buttons that never engage the mechanism don't subscribe a navigation listener.
-    const {isLoading, startWithLoading} = usePressLoading({isLoading: isOnyxLoading, resetOnFocus: showInstantLoadingOnPress});
+    // Merges the consumer's isLoading with the pressed state into the single flag that drives the spinner.
+    const {isLoading, startWithLoading} = usePressLoading({isLoading: isOnyxLoading, resetOnFocus: shouldShowLoadingImmediatelyOnPress});
 
     // Shared by a pointer press and the Enter shortcut, so both take the same route into onPress.
     const runPress = (event?: GestureResponderEvent | KeyboardEvent) => {
         if (isDisabled || isLoading) {
             return;
         }
-        // The opt-in wraps the whole handler. A handler that needs the spinner on only some branches calls usePressLoading
-        // itself and drives the isLoading prop with it, so onPress keeps the signature every other press handler already has.
-        if (showInstantLoadingOnPress) {
+        if (shouldShowLoadingImmediatelyOnPress) {
             return startWithLoading(() => onPress(event));
         }
         return onPress(event);
     };
 
+    // Entry point for a pointer press: drops focus from the pressed element and fires haptic feedback before the shared press logic.
     const handlePress = (event?: GestureResponderEvent | KeyboardEvent) => {
         if (event?.type === 'click') {
             const currentTarget = event?.currentTarget as HTMLElement;
@@ -95,9 +92,7 @@ function Button({
         return runPress(event);
     };
 
-    // The Enter shortcut is fired by ButtonKeyboardShortcut through the actions context. It shares runPress with a pointer press so the
-    // immediate spinner works on Enter too, and skips the mouse-only blur/haptic handling. Living in the actions context (functions only)
-    // keeps it clear of rulesdir/context-provider-split-values.
+    // Entry point for the Enter shortcut: same press logic as a pointer press, without the mouse-only blur and haptic feedback.
     const handleEnterPress = () => runPress();
 
     const buttonVariantStyles = useMemo(() => {

--- a/src/components/ButtonComposed/Button.tsx
+++ b/src/components/ButtonComposed/Button.tsx
@@ -19,7 +19,7 @@ import type {ValueOf} from 'type-fest';
 import React, {useMemo, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 
-import type {ButtonProps, PressLoadingController} from './types';
+import type {ButtonProps} from './types';
 
 import {ButtonActionsContext, ButtonStateContext} from './context';
 
@@ -67,19 +67,17 @@ function Button({
     // isLoading is the pressed flag combined with isOnyxLoading, and drives rendering, the press guard and the disabled state.
     const {isLoading, startWithLoading} = usePressLoading({isLoading: isOnyxLoading});
 
-    // Passed to onPress so a handler can enter the loading state itself, after its own validation/branching.
-    const loadingController: PressLoadingController = {run: startWithLoading};
-
     // Shared by a pointer press and the Enter shortcut, so both take the same route into onPress.
     const runPress = (event?: GestureResponderEvent | KeyboardEvent) => {
         if (isDisabled || isLoading) {
             return;
         }
-        // Simple tier: wrap the whole handler. Otherwise hand the controller to onPress so it can opt in per branch.
+        // The opt-in wraps the whole handler. A handler that needs the spinner on only some branches calls usePressLoading
+        // itself and drives the isLoading prop with it, so onPress keeps the signature every other press handler already has.
         if (showInstantLoadingOnPress) {
-            return startWithLoading(() => onPress(event, loadingController));
+            return startWithLoading(() => onPress(event));
         }
-        return onPress(event, loadingController);
+        return onPress(event);
     };
 
     const handlePress = (event?: GestureResponderEvent | KeyboardEvent) => {

--- a/src/components/ButtonComposed/Button.tsx
+++ b/src/components/ButtonComposed/Button.tsx
@@ -28,7 +28,7 @@ function Button({
     contentContainerStyle = [],
     size = CONST.BUTTON_SIZE.MEDIUM,
     isLoading: isOnyxLoading = false,
-    shouldShowLoadingImmediatelyOnPress = false,
+    showInstantLoadingOnPress = false,
     isDisabled = false,
     onLayout = () => {},
     onPress = () => {},
@@ -76,7 +76,7 @@ function Button({
             return;
         }
         // Simple tier: wrap the whole handler. Otherwise hand the controller to onPress so it can opt in per branch.
-        if (shouldShowLoadingImmediatelyOnPress) {
+        if (showInstantLoadingOnPress) {
             return startWithLoading(() => onPress(event, loadingController));
         }
         return onPress(event, loadingController);

--- a/src/components/ButtonComposed/Button.tsx
+++ b/src/components/ButtonComposed/Button.tsx
@@ -27,7 +27,7 @@ function Button({
     children,
     contentContainerStyle = [],
     size = CONST.BUTTON_SIZE.MEDIUM,
-    isLoading: isOnyxLoading = false,
+    isLoading: isOnyxLoading,
     showInstantLoadingOnPress = false,
     isDisabled = false,
     onLayout = () => {},
@@ -65,7 +65,9 @@ function Button({
     };
 
     // isLoading is the pressed flag combined with isOnyxLoading, and drives rendering, the press guard and the disabled state.
-    const {isLoading, startWithLoading} = usePressLoading({isLoading: isOnyxLoading});
+    // isOnyxLoading is forwarded undefined when the consumer supplies none, so the hook knows there is no hand-over coming.
+    // resetOnFocus is scoped to the opt-in, so buttons that never engage the mechanism don't subscribe a navigation listener.
+    const {isLoading, startWithLoading} = usePressLoading({isLoading: isOnyxLoading, resetOnFocus: showInstantLoadingOnPress});
 
     // Shared by a pointer press and the Enter shortcut, so both take the same route into onPress.
     const runPress = (event?: GestureResponderEvent | KeyboardEvent) => {

--- a/src/components/ButtonComposed/Button.tsx
+++ b/src/components/ButtonComposed/Button.tsx
@@ -3,6 +3,7 @@ import {getButtonRole} from '@components/Button/utils';
 import type {PressableRef} from '@components/Pressable/GenericPressable/types';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 
+import usePressLoading from '@hooks/usePressLoading';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -15,8 +16,7 @@ import CONST from '@src/CONST';
 import type {GestureResponderEvent, StyleProp, ViewStyle} from 'react-native';
 import type {ValueOf} from 'type-fest';
 
-import {NavigationContext} from '@react-navigation/core';
-import React, {useContext, useEffect, useMemo, useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 
 import type {ButtonProps, PressLoadingController} from './types';
@@ -64,41 +64,8 @@ function Button({
         context: 'Button',
     };
 
-    // Local flag set the instant the button is pressed, used only when the immediate-loading mechanism is engaged.
-    const [isPressed, setIsPressed] = useState(false);
-    const navigationContext = useContext(NavigationContext);
-
-    // Hand the loading state over from the local press flag to the external isOnyxLoading once it turns true, so the spinner doesn't flip off and back on.
-    if (isPressed && isOnyxLoading) {
-        setIsPressed(false);
-    }
-
-    // Combined loading used for rendering, the press guard and the disabled state.
-    const isLoading = isPressed || isOnyxLoading;
-
-    // Reset the pressed state when the screen regains focus, covering flows that navigate away and return without an external
-    // isOnyxLoading to hand off to. Subscribed lazily: only while a press is pending, so buttons that never use the mechanism add no listener.
-    // Note: this Button is not wrapped in withNavigationFallback, so outside a navigator navigationContext is undefined and reset is simply skipped.
-    useEffect(() => {
-        if (!isPressed || !navigationContext) {
-            return;
-        }
-        return navigationContext.addListener('focus', () => setIsPressed(false));
-    }, [isPressed, navigationContext]);
-
-    // Show the spinner immediately, let React paint it, then run the real work one macrotask later so a JS-blocking onPress doesn't delay the feedback.
-    const startWithLoading = async (runAfterPaint: () => void | Promise<void>) => {
-        setIsPressed(true);
-        await new Promise((resolve) => {
-            setTimeout(resolve, 0);
-        });
-        try {
-            await runAfterPaint();
-        } catch (error) {
-            setIsPressed(false);
-            throw error;
-        }
-    };
+    // isLoading is the pressed flag combined with isOnyxLoading, and drives rendering, the press guard and the disabled state.
+    const {isLoading, startWithLoading} = usePressLoading({isLoading: isOnyxLoading});
 
     // Passed to onPress so a handler can enter the loading state itself, after its own validation/branching.
     const loadingController: PressLoadingController = {run: startWithLoading};

--- a/src/components/ButtonComposed/context/types.ts
+++ b/src/components/ButtonComposed/context/types.ts
@@ -5,10 +5,7 @@ import type CONST from '@src/CONST';
 import type {GestureResponderEvent} from 'react-native';
 import type {ValueOf} from 'type-fest';
 
-/**
- * State (data) published by the parent `Button` for its child primitives (Text/Icon/KeyboardShortcut/...) to consume via `useButtonState`.
- * Kept separate from actions so a single provider never mixes data and functions (rulesdir/context-provider-split-values).
- */
+/** State (data) published by the parent `Button` for its child primitives (Text/Icon/KeyboardShortcut/...) to consume via `useButtonState`. */
 type ButtonStateContextValue = {
     /** Button size — primitives use it to pick matching paddings/icon dimensions/font sizes. */
     size: ValueOf<typeof CONST.BUTTON_SIZE>;
@@ -26,9 +23,9 @@ type ButtonStateContextValue = {
     isLoading: boolean;
 };
 
-/** Actions (functions) published by the parent `Button`, consumed via `useButtonActions`. Kept apart from state per rulesdir/context-provider-split-values. */
+/** Actions (functions) published by the parent `Button`, consumed via `useButtonActions` */
 type ButtonActionsContextValue = {
-    /** The Button's press handler — `ButtonKeyboardShortcut` fires it when Enter is pressed. Routed through the immediate-loading mechanism, like a pointer press. */
+    /** The Button's press handler — `ButtonKeyboardShortcut` fires it when Enter is pressed. */
     onPress: (event?: GestureResponderEvent | KeyboardEvent) => void | Promise<void>;
 };
 

--- a/src/components/ButtonComposed/index.tsx
+++ b/src/components/ButtonComposed/index.tsx
@@ -36,4 +36,4 @@ const Button = Object.assign(ButtonBase, {
 });
 
 export default Button;
-export type {ButtonProps, PressLoadingController} from './types';
+export type {ButtonProps} from './types';

--- a/src/components/ButtonComposed/types.ts
+++ b/src/components/ButtonComposed/types.ts
@@ -8,25 +8,9 @@ import type React from 'react';
 import type {AccessibilityState, GestureResponderEvent, LayoutChangeEvent, NativeSyntheticEvent, StyleProp, TargetedEvent, View, ViewStyle} from 'react-native';
 import type {ValueOf} from 'type-fest';
 
-/**
- * Imperative loading controller passed to `onPress` as its second argument.
- *
- * Call `run(work)` once the handler decides the button should enter its loading state (e.g. after validation passes).
- * The button paints the spinner immediately, then runs `work` one macrotask later, so a JS-blocking `work` doesn't delay
- * the feedback. Branches that bail out (e.g. on a validation error) simply return without calling `run`, so no spinner shows.
- */
-type PressLoadingController = {
-    run: (work: () => void | Promise<void>) => Promise<void>;
-};
-
 type ButtonEventsProps = {
-    /**
-     * A function that is called when the button is clicked on.
-     *
-     * Receives a `loading` controller as its second argument. Call `loading.run(work)` to show the spinner immediately and
-     * defer the heavy work until after paint — useful when the handler validates first and only some branches should load.
-     */
-    onPress?: (event?: GestureResponderEvent | KeyboardEvent, loading?: PressLoadingController) => void | Promise<void>;
+    /** A function that is called when the button is clicked on. */
+    onPress?: (event?: GestureResponderEvent | KeyboardEvent) => void | Promise<void>;
 
     /** A function that is called when the button is long pressed */
     onLongPress?: (event?: GestureResponderEvent) => void;
@@ -59,8 +43,8 @@ type ButtonBehaviorProps = {
      *
      * The button owns the pressed state and paints the spinner before running `onPress`, so a JS-blocking handler still
      * gives instant feedback. When an external `isLoading` turns true the button hands the spinner over to it; otherwise
-     * the pressed state resets when the screen regains focus. Leave it off for handlers that only navigate, toggle local
-     * state, or bail out on validation — those should use the `loading` controller passed to `onPress` instead.
+     * the pressed state clears once `onPress` settles. It wraps the whole handler, so a handler that needs the spinner on
+     * only some of its branches should call `usePressLoading` itself and drive the `isLoading` prop with it.
      */
     showInstantLoadingOnPress?: boolean;
 
@@ -153,4 +137,4 @@ type ButtonProps = BaseButtonProps & {
     children: React.ReactNode;
 };
 
-export type {ButtonEventsProps, ButtonBehaviorProps, ButtonStyleProps, BaseButtonProps, ButtonProps, ButtonKeyboardShortcutProps, PressLoadingController};
+export type {ButtonEventsProps, ButtonBehaviorProps, ButtonStyleProps, BaseButtonProps, ButtonProps, ButtonKeyboardShortcutProps};

--- a/src/components/ButtonComposed/types.ts
+++ b/src/components/ButtonComposed/types.ts
@@ -62,7 +62,7 @@ type ButtonBehaviorProps = {
      * the pressed state resets when the screen regains focus. Leave it off for handlers that only navigate, toggle local
      * state, or bail out on validation — those should use the `loading` controller passed to `onPress` instead.
      */
-    shouldShowLoadingImmediatelyOnPress?: boolean;
+    showInstantLoadingOnPress?: boolean;
 
     /** Indicates whether the button should be disabled */
     isDisabled?: boolean;

--- a/src/components/ButtonComposed/types.ts
+++ b/src/components/ButtonComposed/types.ts
@@ -39,14 +39,15 @@ type ButtonBehaviorProps = {
     isLoading?: boolean;
 
     /**
-     * Opt-in: show the loading spinner the moment the button is pressed, ahead of `onPress`. Defaults to false.
+     * Shows the loading spinner the moment the button is pressed, ahead of `onPress`. Defaults to false.
      *
-     * The button owns the pressed state and paints the spinner before running `onPress`, so a JS-blocking handler still
-     * gives instant feedback. When an external `isLoading` turns true the button hands the spinner over to it; otherwise
-     * the pressed state clears once `onPress` settles. It wraps the whole handler, so a handler that needs the spinner on
-     * only some of its branches should call `usePressLoading` itself and drive the `isLoading` prop with it.
+     * The spinner is painted before `onPress` runs, so a JS-blocking handler still gives instant feedback. What clears it
+     * depends on `isLoading` being defined: without one it clears as `onPress` settles, with one the button hands it over,
+     * so pass a stable boolean that does turn true, or none at all.
+     *
+     * It wraps the whole handler; for a spinner on only some branches, drive `isLoading` from your own `usePressLoading`.
      */
-    showInstantLoadingOnPress?: boolean;
+    shouldShowLoadingImmediatelyOnPress?: boolean;
 
     /** Indicates whether the button should be disabled */
     isDisabled?: boolean;

--- a/src/components/MoneyReportHeaderPrimaryAction/MarkAsCashPrimaryAction.tsx
+++ b/src/components/MoneyReportHeaderPrimaryAction/MarkAsCashPrimaryAction.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/ButtonComposed';
 
 import useLocalize from '@hooks/useLocalize';
+import usePressLoading from '@hooks/usePressLoading';
 import useTransactionViolations from '@hooks/useTransactionViolations';
 
 import {markAsCash as markAsCashAction} from '@userActions/Transaction';
@@ -17,15 +18,19 @@ function MarkAsCashPrimaryAction({reportID, chatReportID}: SimpleActionProps) {
     const {translate} = useLocalize();
     const {requestParentReportAction, iouTransactionID, transactionThreadReport} = useTransactionThreadData(reportID, chatReportID);
     const transactionViolations = useTransactionViolations(iouTransactionID);
+    const {isLoading, startWithLoading} = usePressLoading();
 
     return (
         <Button
             variant={CONST.BUTTON_VARIANT.SUCCESS}
+            isLoading={isLoading}
             onPress={() => {
                 if (!requestParentReportAction || !iouTransactionID || !transactionThreadReport?.reportID) {
                     return;
                 }
-                markAsCashAction(iouTransactionID, transactionThreadReport.reportID, transactionViolations);
+                startWithLoading(() => {
+                    markAsCashAction(iouTransactionID, transactionThreadReport.reportID, transactionViolations);
+                });
             }}
         >
             <Button.Text>{translate('iou.markAsCash')}</Button.Text>

--- a/src/hooks/usePressLoading.ts
+++ b/src/hooks/usePressLoading.ts
@@ -23,9 +23,6 @@ type UsePressLoadingReturn = {
  * This hook shows the loading and lets React paint it first, then runs the real work, so the user gets immediate
  * feedback instead of an unresponsive button. When a loading state already exists, pass it in as isLoading so the
  * spinner is guaranteed to render before the heavy work starts.
- *
- * The pressed state is never cleared on success: it ends when isLoading turns true, when the screen regains focus, when the work throws, or
- * on unmount. A handler that neither navigates nor drives an external isLoading therefore keeps the spinner up for good.
  */
 function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadingOptions = {}): UsePressLoadingReturn {
     const [isPressed, setIsPressed] = useState(false);
@@ -35,18 +32,22 @@ function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadi
         setIsPressed(false);
     }
     // Defer the work by one macrotask so React can commit isPressed and paint the spinner before the consumer code that may block the JS thread runs.
-    // The work is awaited so a rejecting async handler also clears the pressed state.
+    // The work is awaited so the pressed state clears once it settles, whether it resolves or rejects. A rejection still propagates to the caller.
     const startWithLoading = async (runAfterPaint: () => void | Promise<void>) => {
         setIsPressed(true);
         await new Promise((resolve) => {
             setTimeout(resolve, 0);
         });
+        // Written as catch-and-rethrow rather than finally because the React Compiler cannot lower a try without a catch clause.
         try {
             await runAfterPaint();
         } catch (error) {
             setIsPressed(false);
             throw error;
         }
+        // Clearing on success too, because the button is disabled while the flag is set: a handler that returns without navigating and
+        // without driving an external isLoading (a validation bail-out) would otherwise leave it spinning and unpressable for good.
+        setIsPressed(false);
     };
 
     // Reset on focus regain covers flows that navigate away and come back with no external isLoading to hand off to.

--- a/src/hooks/usePressLoading.ts
+++ b/src/hooks/usePressLoading.ts
@@ -21,57 +21,42 @@ type UsePressLoadingReturn = {
 /**
  * Shows a spinner the moment a button is pressed, so the interaction feels responsive and the INP metric improves.
  *
- * On many submit buttons nothing visible happens for a while after the press, because the handler runs a
- * Onyx update that forces many components on the page to re-render before the new state appears.
- * This hook shows the loading and lets React paint it first, then runs the real work, so the user gets immediate
- * feedback instead of an unresponsive button. When a loading state already exists, pass it in as isLoading so the
- * spinner is guaranteed to render before the heavy work starts.
+ * Submit handlers often run an Onyx update that re-renders the whole page before anything appears, leaving the button
+ * dead in the meantime. This paints the spinner first, then runs the real work. Pass any loading state that already
+ * exists as isLoading, so the spinner is guaranteed to render before the heavy work starts.
  */
 function usePressLoading({isLoading, resetOnFocus = true}: UsePressLoadingOptions = {}): UsePressLoadingReturn {
     const [isPressed, setIsPressed] = useState(false);
 
-    // Whether someone else can take the loading state over once the work settles. Drives the clear below.
     const hasExternalLoading = isLoading !== undefined;
 
-    // Resetting here hands the loading state over from the local press flag to the external isLoading once it turns true.
     if (isPressed && isLoading) {
         setIsPressed(false);
     }
     // Defer the work by one macrotask so React can commit isPressed and paint the spinner before the consumer code that may block the JS thread runs.
-    // The work is awaited so the pressed state clears once it settles, whether it resolves or rejects. A rejection still propagates to the caller.
     const startWithLoading = async (runAfterPaint: () => void | Promise<void>) => {
         setIsPressed(true);
         await new Promise((resolve) => {
             setTimeout(resolve, 0);
         });
-        // Written as catch-and-rethrow rather than finally because the React Compiler cannot lower a try without a catch clause.
         try {
             await runAfterPaint();
         } catch (error) {
             setIsPressed(false);
             throw error;
         }
-        // Clearing on success only when there is no external isLoading to hand over to. The consumer is disabled while the flag is set, so a
-        // handler that returns without navigating (a validation bail-out) would otherwise leave it spinning and unpressable for good. Clearing
-        // unconditionally would be worse: the work is usually synchronous, so this resolves a microtask later, long before an Onyx-driven flag
-        // arrives — the spinner would blink off during exactly the wait it exists to cover, and the press guard would reopen with it.
         if (!hasExternalLoading) {
             setIsPressed(false);
         }
     };
 
-    // Reset on focus regain covers flows that navigate away and come back with no external isLoading to hand off to.
-    // NavigationContext is read directly because useNavigation (and so useFocusEffect) throws with no NavigationContainer above it, and this
-    // hook is also used by components that render outside one — there the reset is skipped, as there is nothing to focus.
     const navigationContext = useContext(NavigationContext);
 
-    // Subscribed for the hook's lifetime rather than only while a press is pending, so a press doesn't re-subscribe mid-flight.
-    // The functional updater keeps that cheap: returning the same value skips the re-render for consumers that are never pressed.
     useEffect(() => {
         if (!resetOnFocus || !navigationContext) {
             return;
         }
-        return navigationContext.addListener('focus', () => setIsPressed((wasPressed) => (wasPressed ? false : wasPressed)));
+        return navigationContext.addListener('focus', () => setIsPressed(false));
     }, [resetOnFocus, navigationContext]);
 
     return {isLoading: isPressed || !!isLoading, startWithLoading};

--- a/src/hooks/usePressLoading.ts
+++ b/src/hooks/usePressLoading.ts
@@ -1,5 +1,5 @@
-import {useFocusEffect} from '@react-navigation/native';
-import {useCallback, useState} from 'react';
+import {NavigationContext} from '@react-navigation/core';
+import {useContext, useEffect, useState} from 'react';
 
 type UsePressLoadingOptions = {
     /** External loading flag (e.g. driven by Onyx) */
@@ -12,7 +12,7 @@ type UsePressLoadingReturn = {
     /** True while the button press is pending or the external loading flag is set, so the spinner stays visible. */
     isLoading: boolean;
     /** Call instead of a bare press handler to show the spinner immediately on press. */
-    startWithLoading: (runAfterPaint: () => void) => Promise<void>;
+    startWithLoading: (runAfterPaint: () => void | Promise<void>) => Promise<void>;
 };
 
 /**
@@ -23,6 +23,9 @@ type UsePressLoadingReturn = {
  * This hook shows the loading and lets React paint it first, then runs the real work, so the user gets immediate
  * feedback instead of an unresponsive button. When a loading state already exists, pass it in as isLoading so the
  * spinner is guaranteed to render before the heavy work starts.
+ *
+ * The pressed state is never cleared on success: it ends when isLoading turns true, when the screen regains focus, when the work throws, or
+ * on unmount. A handler that neither navigates nor drives an external isLoading therefore keeps the spinner up for good.
  */
 function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadingOptions = {}): UsePressLoadingReturn {
     const [isPressed, setIsPressed] = useState(false);
@@ -32,27 +35,33 @@ function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadi
         setIsPressed(false);
     }
     // Defer the work by one macrotask so React can commit isPressed and paint the spinner before the consumer code that may block the JS thread runs.
-    const startWithLoading = async (runAfterPaint: () => void) => {
+    // The work is awaited so a rejecting async handler also clears the pressed state.
+    const startWithLoading = async (runAfterPaint: () => void | Promise<void>) => {
         setIsPressed(true);
         await new Promise((resolve) => {
             setTimeout(resolve, 0);
         });
         try {
-            runAfterPaint();
+            await runAfterPaint();
         } catch (error) {
             setIsPressed(false);
             throw error;
         }
     };
 
-    useFocusEffect(
-        useCallback(() => {
-            if (!resetOnFocus) {
-                return;
-            }
-            setIsPressed(false);
-        }, [resetOnFocus]),
-    );
+    // Reset on focus regain covers flows that navigate away and come back with no external isLoading to hand off to.
+    // NavigationContext is read directly because useNavigation (and so useFocusEffect) throws with no NavigationContainer above it, and this
+    // hook is also used by components that render outside one — there the reset is skipped, as there is nothing to focus.
+    const navigationContext = useContext(NavigationContext);
+
+    // Subscribed for the whole lifetime rather than only while a press is pending, so the listener is in place before deferred work can
+    // navigate away. The updater keeps that free for consumers that are never pressed: returning the same value skips the re-render.
+    useEffect(() => {
+        if (!resetOnFocus || !navigationContext) {
+            return;
+        }
+        return navigationContext.addListener('focus', () => setIsPressed((wasPressed) => (wasPressed ? false : wasPressed)));
+    }, [resetOnFocus, navigationContext]);
 
     return {isLoading: isPressed || isLoading, startWithLoading};
 }

--- a/src/hooks/usePressLoading.ts
+++ b/src/hooks/usePressLoading.ts
@@ -65,8 +65,8 @@ function usePressLoading({isLoading, resetOnFocus = true}: UsePressLoadingOption
     // hook is also used by components that render outside one — there the reset is skipped, as there is nothing to focus.
     const navigationContext = useContext(NavigationContext);
 
-    // Subscribed for the whole lifetime rather than only while a press is pending, so the listener is in place before deferred work can
-    // navigate away. The updater keeps that free for consumers that are never pressed: returning the same value skips the re-render.
+    // Subscribed for the hook's lifetime rather than only while a press is pending, so a press doesn't re-subscribe mid-flight.
+    // The functional updater keeps that cheap: returning the same value skips the re-render for consumers that are never pressed.
     useEffect(() => {
         if (!resetOnFocus || !navigationContext) {
             return;

--- a/src/hooks/usePressLoading.ts
+++ b/src/hooks/usePressLoading.ts
@@ -2,7 +2,10 @@ import {NavigationContext} from '@react-navigation/core';
 import {useContext, useEffect, useState} from 'react';
 
 type UsePressLoadingOptions = {
-    /** External loading flag (e.g. driven by Onyx) */
+    /**
+     * External loading flag (e.g. driven by Onyx). Leave it undefined when there is none: the hook then clears the pressed
+     * state once the work settles, instead of waiting for a hand-over that is never coming.
+     */
     isLoading?: boolean;
     /** Reset the pressed state when the screen regains navigation focus. Defaults to true. */
     resetOnFocus?: boolean;
@@ -24,8 +27,11 @@ type UsePressLoadingReturn = {
  * feedback instead of an unresponsive button. When a loading state already exists, pass it in as isLoading so the
  * spinner is guaranteed to render before the heavy work starts.
  */
-function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadingOptions = {}): UsePressLoadingReturn {
+function usePressLoading({isLoading, resetOnFocus = true}: UsePressLoadingOptions = {}): UsePressLoadingReturn {
     const [isPressed, setIsPressed] = useState(false);
+
+    // Whether someone else can take the loading state over once the work settles. Drives the clear below.
+    const hasExternalLoading = isLoading !== undefined;
 
     // Resetting here hands the loading state over from the local press flag to the external isLoading once it turns true.
     if (isPressed && isLoading) {
@@ -45,9 +51,13 @@ function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadi
             setIsPressed(false);
             throw error;
         }
-        // Clearing on success too, because the button is disabled while the flag is set: a handler that returns without navigating and
-        // without driving an external isLoading (a validation bail-out) would otherwise leave it spinning and unpressable for good.
-        setIsPressed(false);
+        // Clearing on success only when there is no external isLoading to hand over to. The consumer is disabled while the flag is set, so a
+        // handler that returns without navigating (a validation bail-out) would otherwise leave it spinning and unpressable for good. Clearing
+        // unconditionally would be worse: the work is usually synchronous, so this resolves a microtask later, long before an Onyx-driven flag
+        // arrives — the spinner would blink off during exactly the wait it exists to cover, and the press guard would reopen with it.
+        if (!hasExternalLoading) {
+            setIsPressed(false);
+        }
     };
 
     // Reset on focus regain covers flows that navigate away and come back with no external isLoading to hand off to.
@@ -64,7 +74,7 @@ function usePressLoading({isLoading = false, resetOnFocus = true}: UsePressLoadi
         return navigationContext.addListener('focus', () => setIsPressed((wasPressed) => (wasPressed ? false : wasPressed)));
     }, [resetOnFocus, navigationContext]);
 
-    return {isLoading: isPressed || isLoading, startWithLoading};
+    return {isLoading: isPressed || !!isLoading, startWithLoading};
 }
 
 export default usePressLoading;

--- a/src/pages/iou/request/MoneyRequestAttendeeSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestAttendeeSelector.tsx
@@ -155,7 +155,7 @@ function MoneyRequestAttendeeSelector({attendees = [], onFinish, onAttendeesAdde
                 )}
                 <Button
                     variant={CONST.BUTTON_VARIANT.SUCCESS}
-                    onPress={() => confirmSelection()}
+                    onPress={confirmSelection}
                     size={CONST.BUTTON_SIZE.LARGE}
                     isDisabled={shouldShowErrorMessage}
                     sentryLabel={CONST.SENTRY_LABEL.MONEY_REQUEST.ATTENDEES_SAVE_BUTTON}

--- a/src/pages/settings/Wallet/ReportCardLostPage.tsx
+++ b/src/pages/settings/Wallet/ReportCardLostPage.tsx
@@ -71,7 +71,7 @@ function ReportCardLostPage({
     const [isReasonConfirmed, setIsReasonConfirmed] = useState(false);
     const [shouldShowAddressError, setShouldShowAddressError] = useState(false);
     const [shouldShowReasonError, setShouldShowReasonError] = useState(false);
-    const {isLoading, startWithLoading} = usePressLoading({isLoading: formData?.isLoading});
+    const {isLoading, startWithLoading} = usePressLoading({isLoading: formData?.isLoading ?? false});
 
     const physicalCard = cardList?.[cardID];
 

--- a/tests/unit/hooks/usePressLoading.test.ts
+++ b/tests/unit/hooks/usePressLoading.test.ts
@@ -2,6 +2,12 @@ import {act, renderHook} from '@testing-library/react-native';
 
 import usePressLoading from '@hooks/usePressLoading';
 
+import type {NavigationProp, ParamListBase} from '@react-navigation/native';
+import type {ReactNode} from 'react';
+
+import {NavigationContext} from '@react-navigation/core';
+import {createElement} from 'react';
+
 /** Lets the deferred macrotask and the awaited work settle. */
 const flush = async () => {
     await act(async () => {
@@ -9,6 +15,35 @@ const flush = async () => {
         await Promise.resolve();
     });
 };
+
+/** Stands in for a screen's navigation object, so a test can fire the 'focus' event the hook subscribes to. */
+const createNavigationStub = () => {
+    const focusListeners = new Set<() => void>();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const navigation = {
+        addListener: (event: string, callback: () => void) => {
+            if (event !== 'focus') {
+                return () => {};
+            }
+            focusListeners.add(callback);
+            return () => {
+                focusListeners.delete(callback);
+            };
+        },
+    } as unknown as NavigationProp<ParamListBase>;
+
+    return {
+        wrapper: ({children}: {children: ReactNode}) => createElement(NavigationContext.Provider, {value: navigation}, children),
+        emitFocus: () => {
+            for (const listener of focusListeners) {
+                listener();
+            }
+        },
+    };
+};
+
+/** A handler that navigates away and so never settles, leaving the pressed state for the focus reset to clear. */
+const navigateAway = () => new Promise<void>(() => {});
 
 describe('usePressLoading', () => {
     beforeEach(() => {
@@ -75,6 +110,25 @@ describe('usePressLoading', () => {
         expect(result.current.isLoading).toBe(false);
     });
 
+    it('clears on settle when isLoading is undefined at press time, even if it turns true later', async () => {
+        // Given a consumer that passes an isLoading which has not resolved to a boolean yet, as `someOnyxValue?.isLoading`
+        // does before Onyx writes anything
+        const {result, rerender} = renderHook((props: {isLoading?: boolean} = {}) => usePressLoading(props));
+
+        // When a synchronous handler runs to completion
+        act(() => {
+            result.current.startWithLoading(() => {});
+        });
+        await flush();
+
+        // Then undefined counted as "nobody will take this over", so the pressed state cleared instead of waiting
+        expect(result.current.isLoading).toBe(false);
+
+        // And a flag arriving afterwards drives the state on its own, rather than resuming a hand-over that never started
+        rerender({isLoading: true});
+        expect(result.current.isLoading).toBe(true);
+    });
+
     it('clears the loading state and rethrows when the work fails', async () => {
         // Given a handler that rejects
         const {result} = renderHook(() => usePressLoading({isLoading: false}));
@@ -94,5 +148,81 @@ describe('usePressLoading', () => {
         // Then the error reaches the caller and the consumer is usable again
         expect(caught).toBe(error);
         expect(result.current.isLoading).toBe(false);
+    });
+
+    it('clears the loading state and rethrows when the work fails with no external isLoading', async () => {
+        // Given a handler that rejects on the branch most consumers are on, with no flag to hand over to
+        const {result} = renderHook(() => usePressLoading());
+        const error = new Error('boom');
+        let caught: unknown;
+
+        // When it is pressed
+        await act(async () => {
+            result.current
+                .startWithLoading(() => Promise.reject(error))
+                .catch((caughtError: unknown) => {
+                    caught = caughtError;
+                });
+            jest.advanceTimersByTime(1);
+        });
+
+        // Then the catch clears the pressed state before rethrowing, so the button does not stay stuck
+        expect(caught).toBe(error);
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('clears a pending pressed state when the screen regains focus', async () => {
+        // Given a press whose handler navigates away, so nothing settles to clear the pressed state
+        const {wrapper, emitFocus} = createNavigationStub();
+        const {result} = renderHook(() => usePressLoading(), {wrapper});
+        act(() => {
+            result.current.startWithLoading(navigateAway);
+        });
+        await flush();
+        expect(result.current.isLoading).toBe(true);
+
+        // When the user comes back and the screen regains focus
+        act(() => {
+            emitFocus();
+        });
+
+        // Then the button is pressable again, instead of spinning for the rest of the session
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('leaves the pressed state alone on focus when resetOnFocus is off', async () => {
+        // Given a consumer that opted out of the focus reset, as Button does when shouldShowLoadingImmediatelyOnPress is false
+        const {wrapper, emitFocus} = createNavigationStub();
+        const {result} = renderHook(() => usePressLoading({resetOnFocus: false}), {wrapper});
+        act(() => {
+            result.current.startWithLoading(navigateAway);
+        });
+        await flush();
+
+        // When the screen regains focus
+        act(() => {
+            emitFocus();
+        });
+
+        // Then nothing was subscribed, so the pressed state survives
+        expect(result.current.isLoading).toBe(true);
+    });
+
+    it('skips the focus reset instead of throwing when there is no navigation context', async () => {
+        // Given a component rendered outside a NavigationContainer, where useFocusEffect would throw.
+        // This is the reason the hook reads NavigationContext directly rather than using useNavigation.
+        let renderHookResult: ReturnType<typeof renderHook<ReturnType<typeof usePressLoading>, unknown>> | undefined;
+        expect(() => {
+            renderHookResult = renderHook(() => usePressLoading());
+        }).not.toThrow();
+
+        // Then presses still work, just without a focus reset to fall back on
+        act(() => {
+            renderHookResult?.result.current.startWithLoading(() => {});
+        });
+        expect(renderHookResult?.result.current.isLoading).toBe(true);
+
+        await flush();
+        expect(renderHookResult?.result.current.isLoading).toBe(false);
     });
 });

--- a/tests/unit/hooks/usePressLoading.test.ts
+++ b/tests/unit/hooks/usePressLoading.test.ts
@@ -1,0 +1,98 @@
+import {act, renderHook} from '@testing-library/react-native';
+
+import usePressLoading from '@hooks/usePressLoading';
+
+/** Lets the deferred macrotask and the awaited work settle. */
+const flush = async () => {
+    await act(async () => {
+        jest.advanceTimersByTime(1);
+        await Promise.resolve();
+    });
+};
+
+describe('usePressLoading', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('shows the loading state immediately on press, before the work runs', async () => {
+        // Given a hook with no external loading flag
+        const {result} = renderHook(() => usePressLoading());
+        const work = jest.fn();
+
+        // When a press starts
+        act(() => {
+            result.current.startWithLoading(work);
+        });
+
+        // Then the loading state is already set and the work has not run yet
+        expect(result.current.isLoading).toBe(true);
+        expect(work).not.toHaveBeenCalled();
+
+        await flush();
+        expect(work).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the loading state once the work settles when there is no external isLoading', async () => {
+        // Given a handler that returns without navigating and without driving an external flag,
+        // as a validation bail-out does
+        const {result} = renderHook(() => usePressLoading());
+
+        // When it is pressed and the work settles
+        act(() => {
+            result.current.startWithLoading(() => {});
+        });
+        await flush();
+
+        // Then the consumer becomes usable again instead of staying disabled forever
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('holds the loading state until an external isLoading takes over, without a gap', async () => {
+        // Given a consumer whose loading flag is driven externally (e.g. by Onyx)
+        const {result, rerender} = renderHook((props: {isLoading?: boolean} = {}) => usePressLoading(props), {initialProps: {isLoading: false}});
+
+        // When a synchronous handler runs to completion
+        act(() => {
+            result.current.startWithLoading(() => {});
+        });
+        await flush();
+
+        // Then the flag stays set while the external one is still on its way. Clearing here would blink
+        // the spinner off during exactly the wait it exists to cover, and reopen the press guard with it.
+        expect(result.current.isLoading).toBe(true);
+
+        // And once the external flag arrives, it owns the state
+        rerender({isLoading: true});
+        expect(result.current.isLoading).toBe(true);
+
+        // And when the external flag clears, so does the loading state
+        rerender({isLoading: false});
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('clears the loading state and rethrows when the work fails', async () => {
+        // Given a handler that rejects
+        const {result} = renderHook(() => usePressLoading({isLoading: false}));
+        const error = new Error('boom');
+        let caught: unknown;
+
+        // When it is pressed
+        await act(async () => {
+            result.current
+                .startWithLoading(() => Promise.reject(error))
+                .catch((caughtError: unknown) => {
+                    caught = caughtError;
+                });
+            jest.advanceTimersByTime(1);
+        });
+
+        // Then the error reaches the caller and the consumer is usable again
+        expect(caught).toBe(error);
+        expect(result.current.isLoading).toBe(false);
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Reuses the existing `usePressLoading` hook in `ButtonComposed/Button` instead of the inline copy, extracts the shared press handler, and renames the opt-in to `showInstantLoadingOnPress`.

Drops the loading controller from `onPress`. `onPress` isn't a new API — handlers across the app already match its shape, so a second positional argument lands in a slot some of them already use. That happened in `MoneyRequestAttendeeSelector`, where `option` is checked only for truthiness. Handlers needing per-branch control call `usePressLoading` themselves, as `DateFilterBase` and `TermsStep` already do.

The pressed state now also clears when the work settles, but only when the consumer supplied no external `isLoading`. `showInstantLoadingOnPress` wraps the whole handler, so a validation bail-out previously left the spinner up and the button disabled until the screen refocused. Clearing unconditionally would be worse: call sites pass synchronous functions, so `await` resolves a microtask later, while an Onyx-driven `isLoading` needs several ticks — the clear would win that race, blinking the spinner off during exactly the wait it exists to cover and reopening the press guard with it. Gating on `isLoading !== undefined` keeps the hand-over intact for the ~25 existing consumers, which all supply one. `Button` therefore forwards `undefined` rather than defaulting to `false`. Known gap: a button with both the opt-in and an external `isLoading` that bails out early still holds until refocus.

`resetOnFocus` is scoped to the opt-in, so buttons that never engage the mechanism no longer subscribe a navigation focus listener.

Adds `tests/unit/hooks/usePressLoading.test.ts`. The hand-over test fails against an unconditional clear.

Generally these changes are connected to suggestions from [this review](https://github.com/Expensify/App/pull/97956#pullrequestreview-4915428871).
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
