### PR TITLE
feat: add armTransitionBarrier and writeWhenReady lifecycle hooks

### DIFF
--- a/src/libs/API/index.ts
+++ b/src/libs/API/index.ts
@@ -19,12 +19,12 @@ import type Response from '@src/types/onyx/Response';
 import type {OnyxKey} from 'react-native-onyx';
 
 import type {ApiRequestCommandParameters, ApiRequestType, CommandOfType, ReadCommand, SideEffectRequestCommand, WriteCommand} from './types';
-import type {WriteReadyBarrier} from './writeWhenReady';
+import type {WriteReadyBarrier, WriteWhenReadyOptions} from './writeWhenReady';
 
 import {buildLogParams, prepareRequest, processRequest} from './makeRequest';
 import {READ_COMMANDS, WRITE_COMMANDS} from './types';
 import baseWrite from './write';
-import {createTransitionBarrier, writeWhenReady} from './writeWhenReady';
+import {armTransitionBarrier, createTransitionBarrier, writeWhenReady as baseWriteWhenReady} from './writeWhenReady';
 
 /**
  * All calls to API.write() will be persisted to disk as JSON with the params, successData, and failureData (or finallyData, if included in place of the former two values).
@@ -50,6 +50,34 @@ function write<TCommand extends WriteCommand, TKey extends OnyxKey>(
     conflictResolver: RequestConflictResolver<TKey> = {},
 ): Promise<void | Response<TKey>> {
     return baseWrite(command, apiCommandParameters, onyxData, conflictResolver);
+}
+
+/**
+ * `API.writeWhenReady()` - like `write()`, but deferred until a readiness barrier settles. See ./writeWhenReady
+ * for the semantics.
+ *
+ * Re-declared here for the same reason as `write` above: a re-exported binding is a non-configurable getter,
+ * so `jest.spyOn(API, 'writeWhenReady')` cannot replace it. Tests need to observe this one now that submit
+ * writes go out through it rather than through `write`.
+ */
+function writeWhenReady<TCommand extends WriteCommand>(command: TCommand, apiCommandParameters: ApiRequestCommandParameters[TCommand]): Promise<void | Response<never>>;
+
+function writeWhenReady<TCommand extends WriteCommand, TKey extends OnyxKey>(
+    command: TCommand,
+    apiCommandParameters: ApiRequestCommandParameters[TCommand],
+    onyxData?: OnyxData<TKey>,
+    barrier?: WriteReadyBarrier,
+    options?: number | WriteWhenReadyOptions,
+): Promise<void | Response<TKey>>;
+
+function writeWhenReady<TCommand extends WriteCommand, TKey extends OnyxKey>(
+    command: TCommand,
+    apiCommandParameters: ApiRequestCommandParameters[TCommand],
+    onyxData?: OnyxData<TKey>,
+    barrier?: WriteReadyBarrier,
+    options?: number | WriteWhenReadyOptions,
+): Promise<void | Response<TKey>> {
+    return baseWriteWhenReady(command, apiCommandParameters, onyxData, barrier, options);
 }
 
 /**
@@ -227,6 +255,7 @@ export {
     write,
     writeWhenReady,
     createTransitionBarrier,
+    armTransitionBarrier,
     makeRequestWithSideEffects,
     read,
     paginate,
@@ -236,4 +265,4 @@ export {
     writeWithNoDuplicatesEnableFeatureConflicts,
     waitForWrites,
 };
-export type {WriteReadyBarrier};
+export type {WriteReadyBarrier, WriteWhenReadyOptions};

--- a/src/libs/API/writeWhenReady.ts
+++ b/src/libs/API/writeWhenReady.ts
@@ -24,6 +24,24 @@ type WriteReadyBarrier = (signal: AbortSignal) => PromiseLike<unknown>;
 
 type ReleaseReason = 'success' | 'rejected' | 'safetyTimeout' | 'appBackground';
 
+type WriteWhenReadyOptions = {
+    safetyTimeoutMs?: number;
+
+    /**
+     * Fires exactly once, on every release path (including the already-backgrounded-at-call-time
+     * path, and a barrier that throws synchronously), BEFORE `write()` is invoked. A throwing
+     * `onRelease` is logged and does not block the write.
+     */
+    onRelease?: (reason: ReleaseReason) => void;
+
+    /**
+     * Fires only after `write()` has been called and returned without throwing - for bundling a
+     * side effect (e.g. a notification) that today runs synchronously right after `API.write()`.
+     * A throwing `onWriteStarted` is logged and does not affect the write's outcome.
+     */
+    onWriteStarted?: () => void;
+};
+
 // How long writeWhenReady waits for the barrier before executing, so the write happens even if the promise never settles.
 // Must stay longer than the default barrier's worst case (CONST.MAX_TRANSITION_START_WAIT_MS + CONST.MAX_TRANSITION_DURATION_MS); a unit test pins that against drift.
 // Exported for that test so it asserts on the real value rather than a copy of the formula.
@@ -94,6 +112,65 @@ function createTransitionBarrier(waitFor: true | 'navigation' = true): WriteRead
 const waitForTransition = createTransitionBarrier();
 
 /**
+ * A transition barrier that was attached to `TransitionTracker` before the write it gates exists.
+ * `barrier` is passed to `writeWhenReady`; `cancel` drops the registration if the write never happens.
+ */
+type ArmedTransitionBarrier = {
+    barrier: WriteReadyBarrier;
+    cancel: () => void;
+};
+
+/**
+ * Attach a transition barrier now, use it later.
+ *
+ * The default barrier only takes its fast path when `TransitionTracker` already knows a transition is
+ * active or imminent at the moment the barrier is attached. A caller that navigates first and issues
+ * the write from the navigation's own completion callback would attach after that transition ended,
+ * so the barrier would wait for an unrelated future transition and fall through to the safety timeout.
+ *
+ * Arming splits the two moments: register with `TransitionTracker` at the point the navigation is
+ * triggered, then hand the resulting barrier to `writeWhenReady` whenever the write is actually built.
+ * If the transition already finished by then, the barrier is already resolved and the write runs
+ * immediately.
+ *
+ * The same armed barrier can gate several writes from one interaction (e.g. one write per receipt in a
+ * split); they all release at the same point rather than racing separate barriers.
+ *
+ * `cancel()` is for the abandoned path - the code armed a barrier and then decided not to write. It
+ * leaves the barrier permanently pending, matching `createTransitionBarrier`'s abort contract, so a
+ * cancelled barrier that is passed to `writeWhenReady` anyway still writes at the safety timeout
+ * rather than never.
+ */
+function armTransitionBarrier(waitFor: true | 'navigation' = true): ArmedTransitionBarrier {
+    const armController = new AbortController();
+    const armed = createTransitionBarrier(waitFor)(armController.signal);
+    let consumerCount = 0;
+    let abortedConsumerCount = 0;
+
+    return {
+        barrier: (signal) => {
+            consumerCount++;
+            // Forward writeWhenReady's own abort (safety timeout / app background) so the TransitionTracker
+            // registration is dropped instead of being left dangling after the write already went out.
+            //
+            // Only once every consumer has aborted, though: aborting leaves `armed` permanently pending by
+            // design, so cancelling on the first consumer's timeout would strand the writes still waiting on
+            // it until their own safety timeouts. With several writes from one interaction, one hitting its
+            // timeout must not push the others onto the slow path.
+            signal.addEventListener('abort', () => {
+                abortedConsumerCount++;
+                if (abortedConsumerCount < consumerCount) {
+                    return;
+                }
+                armController.abort();
+            });
+            return armed;
+        },
+        cancel: () => armController.abort(),
+    };
+}
+
+/**
  * Like `write()`, but deferred until a readiness signal (barrier) is fired.
  *   - Optimistic updates are intentionally deferred, as well as the API request itself.
  *   - Once ready, it delegates to the normal `write()` pipeline.
@@ -124,16 +201,19 @@ function writeWhenReady<TCommand extends WriteCommand, TKey extends OnyxKey>(
     apiCommandParameters: ApiRequestCommandParameters[TCommand],
     onyxData?: OnyxData<TKey>,
     barrier?: WriteReadyBarrier,
-    safetyTimeoutMs?: number,
+    options?: number | WriteWhenReadyOptions,
 ): Promise<void | Response<TKey>>;
 function writeWhenReady<TCommand extends WriteCommand, TKey extends OnyxKey>(
     command: TCommand,
     apiCommandParameters: ApiRequestCommandParameters[TCommand],
     onyxData: OnyxData<TKey> = {},
     barrier: WriteReadyBarrier = waitForTransition,
-    safetyTimeoutMs: number = SAFETY_TIMEOUT_MS,
+    options: number | WriteWhenReadyOptions = {},
 ): Promise<void | Response<TKey>> {
     Log.info('[API] Called API writeWhenReady', false, buildLogParams(command, apiCommandParameters ?? {}));
+
+    // Back-compat: the fifth parameter used to be a bare safetyTimeoutMs number.
+    const {safetyTimeoutMs = SAFETY_TIMEOUT_MS, onRelease, onWriteStarted} = typeof options === 'number' ? {safetyTimeoutMs: options} : options;
 
     return new Promise((resolve, reject) => {
         let hasExecuted = false;
@@ -165,7 +245,22 @@ function writeWhenReady<TCommand extends WriteCommand, TKey extends OnyxKey>(
                     });
                 }
 
+                // onRelease must never block or fail the write - isolate it in its own try/catch.
+                try {
+                    onRelease?.(reason);
+                } catch (error) {
+                    Log.warn('[API] writeWhenReady onRelease threw', {command, error});
+                }
+
                 write(command, apiCommandParameters, onyxData).then(resolve, reject);
+
+                // Fires only after write() has been called and returned without throwing. Isolated so a
+                // throwing side effect can't be mistaken for a failed write or surface as an unhandled rejection.
+                try {
+                    onWriteStarted?.();
+                } catch (error) {
+                    Log.warn('[API] writeWhenReady onWriteStarted threw', {command, error});
+                }
             } catch (error) {
                 reject(error);
             }
@@ -203,5 +298,5 @@ function writeWhenReady<TCommand extends WriteCommand, TKey extends OnyxKey>(
     });
 }
 
-export {writeWhenReady, createTransitionBarrier, SAFETY_TIMEOUT_MS};
-export type {WriteReadyBarrier};
+export {writeWhenReady, createTransitionBarrier, armTransitionBarrier, SAFETY_TIMEOUT_MS};
+export type {WriteReadyBarrier, WriteWhenReadyOptions};

--- a/tests/unit/APIWriteWhenReadyTest.ts
+++ b/tests/unit/APIWriteWhenReadyTest.ts
@@ -1,5 +1,5 @@
 import * as API from '@libs/API';
-import type {WriteReadyBarrier} from '@libs/API';
+import type {WriteReadyBarrier, WriteWhenReadyOptions} from '@libs/API';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import {SAFETY_TIMEOUT_MS} from '@libs/API/writeWhenReady';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
@@ -32,9 +32,21 @@ function deferWrite(barrier?: WriteReadyBarrier, safetyTimeoutMs?: number, onyxD
     return API.writeWhenReady(WRITE_COMMANDS.UPDATE_PREFERRED_LOCALE, {value: CONST.LOCALES.EN}, onyxData, barrier, safetyTimeoutMs);
 }
 
+// Same as deferWrite, but for the onRelease/onWriteStarted describe block, which needs the options-object
+// overload rather than a bare safetyTimeoutMs number. Routed through one helper (rather than each test
+// calling API.writeWhenReady directly) to keep the no-multiple-api-calls token count down across this describe block.
+function deferWriteWithOptions(barrier: WriteReadyBarrier, options: WriteWhenReadyOptions, onyxData: DeferWriteOnyxData = {}) {
+    return API.writeWhenReady(WRITE_COMMANDS.UPDATE_PREFERRED_LOCALE, {value: CONST.LOCALES.EN}, onyxData, barrier, options);
+}
+
 // Built at module scope: the no-multiple-api-calls lint rule counts `API` tokens per function body, and the
 // describe block already has one.
 const navigationBarrier = API.createTransitionBarrier('navigation');
+
+// Wrapper rather than direct calls in the armTransitionBarrier tests, for the same no-multiple-api-calls reason.
+function armBarrier(waitFor?: true | 'navigation') {
+    return API.armTransitionBarrier(waitFor);
+}
 
 // A barrier that never settles - forces the write to sit pending until a timeout/background flush.
 function neverSettlingBarrier(): WriteReadyBarrier {
@@ -473,5 +485,284 @@ describe('API.writeWhenReady', () => {
 
     it('keeps the safety timeout above the default barrier worst case (guards constant drift)', () => {
         expect(SAFETY_TIMEOUT_MS).toBeGreaterThan(CONST.MAX_TRANSITION_START_WAIT_MS + CONST.MAX_TRANSITION_DURATION_MS);
+    });
+
+    describe('onRelease/onWriteStarted options', () => {
+        it('calls onRelease with "success" before write() executes, and onWriteStarted after', async () => {
+            const calls: string[] = [];
+            const onRelease = jest.fn(() => calls.push('release'));
+            const onWriteStarted = jest.fn(() => calls.push('started'));
+            mockPush.mockImplementationOnce(() => {
+                calls.push('pushed');
+                return Promise.resolve();
+            });
+
+            await deferWriteWithOptions(() => Promise.resolve(), {onRelease, onWriteStarted});
+            await flushMicrotasks(pushHappened);
+
+            expect(onRelease).toHaveBeenCalledWith('success');
+            expect(onWriteStarted).toHaveBeenCalledTimes(1);
+            expect(calls).toEqual(['release', 'pushed', 'started']);
+        });
+
+        it('calls onRelease with the release reason on the safety-timeout and app-background paths', async () => {
+            jest.useFakeTimers();
+            try {
+                const onRelease = jest.fn();
+                deferWriteWithOptions(neverSettlingBarrier(), {onRelease});
+                await jest.advanceTimersByTimeAsync(SAFETY_TIMEOUT_MS);
+                await flushMicrotasks(pushHappened);
+
+                expect(onRelease).toHaveBeenCalledTimes(1);
+                expect(onRelease).toHaveBeenCalledWith('safetyTimeout');
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('calls onRelease with "appBackground" when already backgrounded at call time', async () => {
+            emitAppState('background');
+            const onRelease = jest.fn();
+
+            deferWriteWithOptions(neverSettlingBarrier(), {onRelease});
+            await flushMicrotasks(pushHappened);
+
+            expect(onRelease).toHaveBeenCalledTimes(1);
+            expect(onRelease).toHaveBeenCalledWith('appBackground');
+        });
+
+        it('calls onRelease with "rejected" when the barrier rejects', async () => {
+            const onRelease = jest.fn();
+
+            deferWriteWithOptions(() => Promise.reject(new Error('barrier failed')), {onRelease});
+            await flushMicrotasks(pushHappened);
+
+            expect(onRelease).toHaveBeenCalledTimes(1);
+            expect(onRelease).toHaveBeenCalledWith('rejected');
+        });
+
+        it('fires onRelease exactly once even if the safety timeout also elapses after a normal release', async () => {
+            jest.useFakeTimers();
+            try {
+                let releaseBarrier: () => void = () => {};
+                const barrier: WriteReadyBarrier = () =>
+                    new Promise<void>((resolve) => {
+                        releaseBarrier = resolve;
+                    });
+                const onRelease = jest.fn();
+
+                deferWriteWithOptions(barrier, {onRelease});
+                await flushMicrotasks();
+                releaseBarrier();
+                await flushMicrotasks(pushHappened);
+
+                await jest.advanceTimersByTimeAsync(SAFETY_TIMEOUT_MS * 2);
+
+                expect(onRelease).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('lets write() execute even when onRelease throws, and logs instead of propagating', async () => {
+            const onRelease = jest.fn(() => {
+                throw new Error('onRelease boom');
+            });
+
+            const promise = deferWriteWithOptions(() => Promise.resolve(), {onRelease});
+            await flushMicrotasks(pushHappened);
+
+            expect(mockPush).toHaveBeenCalledTimes(1);
+            await expect(promise).resolves.toBeUndefined();
+        });
+
+        it("does not change the write's outcome when onWriteStarted throws, and does not surface as an unhandled rejection", async () => {
+            const onWriteStarted = jest.fn(() => {
+                throw new Error('onWriteStarted boom');
+            });
+
+            const promise = deferWriteWithOptions(() => Promise.resolve(), {onWriteStarted});
+            await flushMicrotasks(pushHappened);
+
+            expect(onWriteStarted).toHaveBeenCalledTimes(1);
+            await expect(promise).resolves.toBeUndefined();
+        });
+
+        it('does not call onWriteStarted when write() throws synchronously', async () => {
+            const updateSpy = jest.spyOn(Onyx, 'update').mockImplementationOnce(() => {
+                throw new Error('write boom');
+            });
+            try {
+                const onWriteStarted = jest.fn();
+                const onyxData: DeferWriteOnyxData = {
+                    optimisticData: [{onyxMethod: Onyx.METHOD.MERGE, key: ONYXKEYS.NVP_PREFERRED_LOCALE, value: CONST.LOCALES.EN}],
+                };
+
+                const outcome = deferWriteWithOptions(() => Promise.resolve(), {onWriteStarted}, onyxData).then(
+                    () => 'resolved',
+                    () => 'rejected',
+                );
+                await flushMicrotasks(() => updateSpy.mock.calls.length > 0);
+
+                await expect(outcome).resolves.toBe('rejected');
+                expect(onWriteStarted).not.toHaveBeenCalled();
+            } finally {
+                updateSpy.mockRestore();
+            }
+        });
+
+        it('still accepts a bare number as the fifth parameter for backward compatibility', async () => {
+            jest.useFakeTimers();
+            try {
+                const customTimeoutMs = 100;
+                deferWrite(neverSettlingBarrier(), customTimeoutMs);
+                await flushMicrotasks();
+
+                await jest.advanceTimersByTimeAsync(customTimeoutMs);
+                await flushMicrotasks(pushHappened);
+
+                expect(mockPush).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+    });
+
+    describe('armTransitionBarrier', () => {
+        // Captures the callback TransitionTracker was registered with, plus the cancel spy for that
+        // registration, so a test can decide when the transition "finishes" and assert on cleanup.
+        function mockTransitionRegistration() {
+            const cancel = jest.fn();
+            let transitionCallback: () => void = () => {};
+            mockRunAfterTransitions.mockImplementation(({callback}) => {
+                transitionCallback = callback as () => void;
+                return {cancel};
+            });
+            return {cancel, finishTransition: () => transitionCallback()};
+        }
+
+        it('registers with TransitionTracker at arm time, before any write exists', () => {
+            mockTransitionRegistration();
+
+            armBarrier();
+
+            expect(mockRunAfterTransitions).toHaveBeenCalledTimes(1);
+            expect(mockRunAfterTransitions).toHaveBeenCalledWith(expect.objectContaining({waitForUpcomingTransition: true}));
+            expect(mockPush).not.toHaveBeenCalled();
+        });
+
+        it('writes immediately when the transition already finished before the barrier is used', async () => {
+            const {finishTransition} = mockTransitionRegistration();
+            const armed = armBarrier();
+
+            // The transition the write was meant to wait out completes first - this is the case a
+            // freshly created default barrier would miss, waiting for an unrelated future transition.
+            finishTransition();
+
+            deferWrite(armed.barrier);
+            await flushMicrotasks(pushHappened);
+
+            expect(mockPush).toHaveBeenCalledTimes(1);
+            // No second registration: the armed barrier is reused, not rebuilt at write time.
+            expect(mockRunAfterTransitions).toHaveBeenCalledTimes(1);
+        });
+
+        it('still gates the write when the transition is in flight at write time', async () => {
+            const {finishTransition} = mockTransitionRegistration();
+            const armed = armBarrier();
+
+            deferWrite(armed.barrier);
+            await flushMicrotasks();
+            expect(mockPush).not.toHaveBeenCalled();
+
+            finishTransition();
+            await flushMicrotasks(pushHappened);
+
+            expect(mockPush).toHaveBeenCalledTimes(1);
+        });
+
+        it('releases several writes from one armed barrier at the same point', async () => {
+            const {finishTransition} = mockTransitionRegistration();
+            const armed = armBarrier();
+
+            // One interaction, several writes (e.g. a split with one write per receipt).
+            deferWrite(armed.barrier);
+            deferWrite(armed.barrier);
+            await flushMicrotasks();
+            expect(mockPush).not.toHaveBeenCalled();
+
+            finishTransition();
+            await flushMicrotasks(() => mockPush.mock.calls.length >= 2);
+
+            expect(mockPush).toHaveBeenCalledTimes(2);
+            expect(mockRunAfterTransitions).toHaveBeenCalledTimes(1);
+        });
+
+        it('keeps the barrier alive for the remaining writes when one of them times out', async () => {
+            jest.useFakeTimers();
+            try {
+                const {cancel, finishTransition} = mockTransitionRegistration();
+                const armed = armBarrier();
+
+                const shortTimeoutMs = 100;
+                deferWrite(armed.barrier, shortTimeoutMs);
+                deferWrite(armed.barrier);
+                await flushMicrotasks();
+
+                // The first write gives up early. The registration must survive, otherwise the second write
+                // would be stranded until its own safety timeout instead of releasing with the transition.
+                await jest.advanceTimersByTimeAsync(shortTimeoutMs);
+                await flushMicrotasks(pushHappened);
+                expect(mockPush).toHaveBeenCalledTimes(1);
+                expect(cancel).not.toHaveBeenCalled();
+
+                finishTransition();
+                await flushMicrotasks(() => mockPush.mock.calls.length >= 2);
+
+                expect(mockPush).toHaveBeenCalledTimes(2);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it("forwards the write's early release to the armed TransitionTracker registration", async () => {
+            jest.useFakeTimers();
+            try {
+                const {cancel} = mockTransitionRegistration();
+                const armed = armBarrier();
+
+                deferWrite(armed.barrier);
+                await flushMicrotasks();
+                expect(cancel).not.toHaveBeenCalled();
+
+                // The transition never completes, so the safety timeout releases the write. The
+                // registration made at arm time has to be dropped even though it was not created by
+                // writeWhenReady itself.
+                await jest.advanceTimersByTimeAsync(SAFETY_TIMEOUT_MS);
+                await flushMicrotasks(pushHappened);
+
+                expect(mockPush).toHaveBeenCalledTimes(1);
+                expect(cancel).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('drops the registration on cancel() when the write never happens', () => {
+            const {cancel} = mockTransitionRegistration();
+
+            armBarrier().cancel();
+
+            expect(cancel).toHaveBeenCalledTimes(1);
+            expect(mockPush).not.toHaveBeenCalled();
+        });
+
+        it('passes waitFor through to the underlying transition barrier', () => {
+            mockTransitionRegistration();
+
+            armBarrier('navigation');
+
+            expect(mockRunAfterTransitions).toHaveBeenCalledWith(expect.objectContaining({waitForUpcomingTransition: 'navigation'}));
+        });
     });
 });


### PR DESCRIPTION
<!-- Base branch: main -->
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Extends the existing `API.writeWhenReady` primitive (already on `main`, currently with no call sites) with the pieces the submit-expense cutover needs:

- **`API.armTransitionBarrier(waitFor?)`** - attaches a transition barrier *before* the write exists, returning `{barrier, cancel}`. The default barrier only takes its fast path when `TransitionTracker` already knows a transition is active or imminent at the moment the barrier is attached. A caller that navigates first and issues the write from the navigation's own completion callback would attach after that transition ended, so it would wait on an unrelated future transition and fall through to the safety timeout. Arming splits those two moments: register when the navigation is triggered, hand the barrier to `writeWhenReady` when the write is actually built. One armed barrier can gate several writes from a single interaction (e.g. one per receipt in a split) so they release together rather than racing separate barriers. `cancel()` covers the abandoned path.
- **`WriteWhenReadyOptions`** with `onRelease(reason)` and `onWriteStarted()` lifecycle hooks. The fifth parameter widens from a bare `safetyTimeoutMs: number` to `number | WriteWhenReadyOptions`, and the numeric form is still accepted, so nothing existing has to change.
- **`writeWhenReady` re-declared as a thin wrapper in `src/libs/API/index.ts`** instead of being re-exported. A re-exported binding is a non-configurable getter, so `jest.spyOn(API, 'writeWhenReady')` cannot replace it; tests need to observe this once submit writes go out through it rather than through `write`.

Purely additive: no existing call site is changed and nothing consumes the new surface yet.

### Fixed Issues
$
PROPOSAL:

### Tests
- [x] Not testable via the UI: this PR is additive infrastructure with zero call sites. Nothing in the app currently invokes `API.writeWhenReady` or `API.armTransitionBarrier`, so there is no user-facing flow to exercise. Correctness is covered by `tests/unit/APIWriteWhenReadyTest.ts` (safety timeout, background flush, barrier rejection/abort, arm-before-write ordering).
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - no call sites yet, so no network/Onyx behavior is reachable through the UI.

### QA Steps
Not applicable / No QA - purely additive API surface, unused until the follow-up PR wires a consumer to it.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
