### PR TITLE
Add NumericInput with Symbol and Container

### DIFF
--- a/src/components/NumericEditingController/hooks/useNumericEditingController.ts
+++ b/src/components/NumericEditingController/hooks/useNumericEditingController.ts
@@ -63,7 +63,6 @@ function useNumericEditingController({
     // Keep the latest committed value available across batched state updates.
     const committedValueRef = useRef(externalValue);
 
-    const isNegative = currentValue.startsWith('-');
     const formattedNumber = replaceAllDigits(toDisplayText(currentValue), toLocaleDigit);
 
     const {selection, collapse, reset, syncToEnd, syncAfterEdit, handleKeyPress, rejectEdit, handleNativeSelectionChange} = useNumericSelection({displayText: formattedNumber});
@@ -135,7 +134,6 @@ function useNumericEditingController({
     return {
         value: currentValue,
         formattedNumber,
-        isNegative,
         selection,
         setNumber,
         setCanonicalValue,

--- a/src/components/NumericEditingController/hooks/useNumericEditingController.ts
+++ b/src/components/NumericEditingController/hooks/useNumericEditingController.ts
@@ -1,4 +1,4 @@
-import {normalizeNumericInput} from '@components/NumericEditingController/utils';
+import {normalizeNumericInput, toCanonicalValueDefault, toDisplayTextDefault} from '@components/NumericEditingController/utils';
 
 import useLocalize from '@hooks/useLocalize';
 
@@ -20,6 +20,12 @@ type UseNumericEditingControllerParams = {
 
     /** Maximum number of integer digits accepted by the controller. */
     maxLength?: number;
+
+    /** Maps canonical values to displayed text. Defaults to identity. */
+    toDisplayText?: (canonicalValue: string) => string;
+
+    /** Maps validated text to a canonical value. Defaults to identity. */
+    toCanonicalValue?: (displayText: string, previousCanonicalValue: string) => string;
 };
 
 /** Runs on mount and whenever `decimals` changes, sanitizing values that exceed the new precision. */
@@ -38,7 +44,15 @@ function useDecimalsChangeEffect(decimals: number, sanitizeForDecimals: (decimal
 }
 
 /** Owns numeric value, formatting, validation, and commits while delegating caret state to `useNumericSelection`. */
-function useNumericEditingController({value: externalValueProp, onInputChange, allowNegative = false, decimals = 0, maxLength}: UseNumericEditingControllerParams) {
+function useNumericEditingController({
+    value: externalValueProp,
+    onInputChange,
+    allowNegative = false,
+    decimals = 0,
+    maxLength,
+    toDisplayText = toDisplayTextDefault,
+    toCanonicalValue = toCanonicalValueDefault,
+}: UseNumericEditingControllerParams) {
     const {fromLocaleDigit, toLocaleDigit} = useLocalize();
 
     const externalValue = externalValueProp ?? '';
@@ -49,7 +63,8 @@ function useNumericEditingController({value: externalValueProp, onInputChange, a
     // Keep the latest committed value available across batched state updates.
     const committedValueRef = useRef(externalValue);
 
-    const formattedNumber = replaceAllDigits(currentValue, toLocaleDigit);
+    const isNegative = currentValue.startsWith('-');
+    const formattedNumber = replaceAllDigits(toDisplayText(currentValue), toLocaleDigit);
 
     const {selection, collapse, reset, syncToEnd, syncAfterEdit, handleKeyPress, rejectEdit, handleNativeSelectionChange} = useNumericSelection({displayText: formattedNumber});
 
@@ -84,15 +99,21 @@ function useNumericEditingController({value: externalValueProp, onInputChange, a
             return;
         }
 
-        const previousValue = applyValue(numberWithLeadingZero);
+        const nextValue = toCanonicalValue(numberWithLeadingZero, committedValueRef.current);
+        const previousValue = applyValue(nextValue);
 
-        syncAfterEdit({previousText: previousValue, nextText: numberWithLeadingZero});
+        syncAfterEdit({previousText: toDisplayText(previousValue), nextText: toDisplayText(nextValue)});
     };
 
     // Replaces the canonical value without validation or notification and moves the caret to the end.
     const updateNumber = (newNumber: string) => {
         applyValue(newNumber, {notify: false});
-        syncToEnd(newNumber);
+        syncToEnd(toDisplayText(newNumber));
+    };
+
+    // Commits a canonical value without validation and without moving the caret, notifying the parent by default.
+    const setCanonicalValue = (nextValue: string, {notify = true}: {notify?: boolean} = {}) => {
+        applyValue(nextValue, {notify});
     };
 
     const getNumber = () => committedValueRef.current;
@@ -108,14 +129,16 @@ function useNumericEditingController({value: externalValueProp, onInputChange, a
             return;
         }
 
-        setNumber(stripDecimalsFromAmount(currentValue));
+        setNumber(toDisplayText(stripDecimalsFromAmount(currentValue)));
     });
 
     return {
         value: currentValue,
         formattedNumber,
+        isNegative,
         selection,
         setNumber,
+        setCanonicalValue,
         updateNumber,
         getNumber,
         clearSelection: collapse,

--- a/src/components/NumericEditingController/hooks/useNumericEditingController.ts
+++ b/src/components/NumericEditingController/hooks/useNumericEditingController.ts
@@ -124,7 +124,7 @@ function useNumericEditingController({
 
     useDecimalsChangeEffect(decimals, (newDecimals) => {
         // Empty values and values already valid at the new precision need no update.
-        if (externalValue === '' || validateAmount(currentValue, newDecimals, maxLength, allowNegative)) {
+        if (currentValue === '' || validateAmount(currentValue, newDecimals, maxLength, allowNegative)) {
             return;
         }
 

--- a/src/components/NumericEditingController/utils.ts
+++ b/src/components/NumericEditingController/utils.ts
@@ -65,4 +65,12 @@ function clampSelection(selection: NumericEditingSelection, maxLength: number): 
     };
 }
 
-export {clampSelection, collapseSelection, getSelectionAfterEdit, getSelectionAtOffset, isForwardDeleteKeyPress, normalizeNumericInput};
+function toDisplayTextDefault(canonicalValue: string): string {
+    return canonicalValue;
+}
+
+function toCanonicalValueDefault(displayText: string): string {
+    return displayText;
+}
+
+export {clampSelection, collapseSelection, getSelectionAfterEdit, getSelectionAtOffset, isForwardDeleteKeyPress, normalizeNumericInput, toCanonicalValueDefault, toDisplayTextDefault};

--- a/src/components/NumericField/primitives/NumericTextInput.tsx
+++ b/src/components/NumericField/primitives/NumericTextInput.tsx
@@ -27,7 +27,7 @@ function NumericTextInput({
     shouldApplyPaddingToContainer,
     shouldUseDefaultLineHeightForPrefix,
     onSubmitEditing,
-    submitBehavior,
+    submitBehavior = 'submit',
     testID,
     touchableInputWrapperStyle,
     style,

--- a/src/components/NumericInput/NumericInput.tsx
+++ b/src/components/NumericInput/NumericInput.tsx
@@ -1,0 +1,77 @@
+import {useNumericEditingController} from '@components/NumericEditingController';
+import type {NumericEditingRef} from '@components/NumericEditingController';
+import isTextInputFocused from '@components/TextInput/BaseTextInput/isTextInputFocused';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
+import type {ForwardedRef, ReactNode} from 'react';
+
+import {useImperativeHandle, useRef} from 'react';
+
+import type {NumericInputActionsContextValue, NumericInputStateContextValue} from './context/types';
+
+import {NumericInputActionsContext, NumericInputStateContext} from './context';
+
+type NumericInputProps = {
+    /** The canonical value shared by composed primitives. Only a reset to an empty string re-initializes the editing state. */
+    value?: string;
+
+    /** Called with the canonical value when a composed primitive changes it. */
+    onInputChange?: (value: string) => void;
+
+    /** Number of decimal places accepted by the composer. */
+    decimals?: number;
+
+    /** Maximum number of integer digits accepted by the composer. */
+    maxLength?: number;
+
+    /** Reference exposing the number editing imperative API. */
+    numericInputRef?: ForwardedRef<NumericEditingRef>;
+
+    children: ReactNode;
+};
+
+function NumericInput({value = '', onInputChange, decimals = 0, maxLength, numericInputRef, children}: NumericInputProps) {
+    const inputRef = useRef<BaseTextInputRef | null>(null);
+    const controller = useNumericEditingController({
+        value,
+        onInputChange,
+        decimals,
+        maxLength,
+    });
+
+    useImperativeHandle(numericInputRef, () => ({
+        clearSelection: controller.clearSelection,
+        getNumber: controller.getNumber,
+        updateNumber: controller.updateNumber,
+    }));
+
+    const focusInput = () => {
+        if (isTextInputFocused(inputRef)) {
+            return;
+        }
+
+        inputRef.current?.focus();
+    };
+
+    const stateContextValue: NumericInputStateContextValue = {
+        formattedNumber: controller.formattedNumber,
+        selection: controller.selection,
+        inputRef,
+    };
+
+    const actionsContextValue: NumericInputActionsContextValue = {
+        setNumber: controller.setNumber,
+        clearSelection: controller.clearSelection,
+        handleSelectionChange: controller.handleSelectionChange,
+        handleKeyPress: controller.handleKeyPress,
+        focusInput,
+    };
+
+    return (
+        <NumericInputStateContext.Provider value={stateContextValue}>
+            <NumericInputActionsContext.Provider value={actionsContextValue}>{children}</NumericInputActionsContext.Provider>
+        </NumericInputStateContext.Provider>
+    );
+}
+
+export default NumericInput;

--- a/src/components/NumericInput/NumericInput.tsx
+++ b/src/components/NumericInput/NumericInput.tsx
@@ -12,7 +12,7 @@ import type {NumericInputActionsContextValue, NumericInputStateContextValue} fro
 import {NumericInputActionsContext, NumericInputStateContext} from './context';
 
 type NumericInputProps = {
-    /** The canonical value shared by composed primitives. Only a reset to an empty string re-initializes the editing state. */
+    /** Canonical value shared by composed primitives. Only an empty value resets editing state. */
     value?: string;
 
     /** Called with the canonical value when a composed primitive changes it. */
@@ -24,9 +24,10 @@ type NumericInputProps = {
     /** Maximum number of integer digits accepted by the composer. */
     maxLength?: number;
 
-    /** Reference exposing the number editing imperative API. */
+    /** Ref exposing the number editing imperative API. */
     numericInputRef?: ForwardedRef<NumericEditingRef>;
 
+    /** Composed primitives that consume NumericInput state and actions through context. */
     children: ReactNode;
 };
 

--- a/src/components/NumericInput/NumericInput.tsx
+++ b/src/components/NumericInput/NumericInput.tsx
@@ -40,13 +40,13 @@ type NumericInputProps = {
     errorText?: string;
 
     /** Ref exposing the number editing imperative API. */
-    numericInputRef?: ForwardedRef<NumericEditingRef>;
+    ref?: ForwardedRef<NumericEditingRef>;
 
     /** Composed primitives that consume NumericInput state and actions through context. */
     children: ReactNode;
 };
 
-function NumericInput({value = '', onInputChange, allowNegative = false, decimals = 0, maxLength, errorText, numericInputRef, children}: NumericInputProps) {
+function NumericInput({value = '', onInputChange, allowNegative = false, decimals = 0, maxLength, errorText, ref, children}: NumericInputProps) {
     const inputRef = useRef<BaseTextInputRef | null>(null);
     const controller = useNumericEditingController({
         value,
@@ -58,7 +58,7 @@ function NumericInput({value = '', onInputChange, allowNegative = false, decimal
         toCanonicalValue: (displayText, previousCanonicalValue) => getSignedValue(displayText, previousCanonicalValue, allowNegative),
     });
 
-    useImperativeHandle(numericInputRef, () => ({
+    useImperativeHandle(ref, () => ({
         clearSelection: controller.clearSelection,
         getNumber: controller.getNumber,
         updateNumber: controller.updateNumber,

--- a/src/components/NumericInput/NumericInput.tsx
+++ b/src/components/NumericInput/NumericInput.tsx
@@ -11,18 +11,33 @@ import type {NumericInputActionsContextValue, NumericInputStateContextValue} fro
 
 import {NumericInputActionsContext, NumericInputStateContext} from './context';
 
+/** The composed input displays the magnitude because the sign is rendered separately. */
+const getMagnitude = (canonicalValue: string) => (canonicalValue.startsWith('-') ? canonicalValue.slice(1) : canonicalValue);
+
+/** Preserves the sign that is rendered outside the text input while the magnitude is edited. Clearing the display text also clears the sign. */
+const getSignedValue = (displayText: string, previousCanonicalValue: string, allowNegative: boolean) => {
+    const shouldPreserveNegativeSign = allowNegative && displayText && !displayText.startsWith('-') && previousCanonicalValue.startsWith('-');
+    return shouldPreserveNegativeSign ? `-${displayText}` : displayText;
+};
+
 type NumericInputProps = {
     /** Canonical value shared by composed primitives. Only an empty value resets editing state. */
     value?: string;
 
-    /** Called with the canonical value when a composed primitive changes it. */
+    /** Called with the canonical signed value when a composed primitive changes it. */
     onInputChange?: (value: string) => void;
+
+    /** Whether negative values are allowed. The canonical value always stores its sign. */
+    allowNegative?: boolean;
 
     /** Number of decimal places accepted by the composer. */
     decimals?: number;
 
     /** Maximum number of integer digits accepted by the composer. */
     maxLength?: number;
+
+    /** Error supplied by FormProvider and rendered by `NumericInput.Error`. */
+    errorText?: string;
 
     /** Ref exposing the number editing imperative API. */
     numericInputRef?: ForwardedRef<NumericEditingRef>;
@@ -31,13 +46,16 @@ type NumericInputProps = {
     children: ReactNode;
 };
 
-function NumericInput({value = '', onInputChange, decimals = 0, maxLength, numericInputRef, children}: NumericInputProps) {
+function NumericInput({value = '', onInputChange, allowNegative = false, decimals = 0, maxLength, errorText, numericInputRef, children}: NumericInputProps) {
     const inputRef = useRef<BaseTextInputRef | null>(null);
     const controller = useNumericEditingController({
         value,
         onInputChange,
+        allowNegative,
         decimals,
         maxLength,
+        toDisplayText: getMagnitude,
+        toCanonicalValue: (displayText, previousCanonicalValue) => getSignedValue(displayText, previousCanonicalValue, allowNegative),
     });
 
     useImperativeHandle(numericInputRef, () => ({
@@ -45,6 +63,25 @@ function NumericInput({value = '', onInputChange, decimals = 0, maxLength, numer
         getNumber: controller.getNumber,
         updateNumber: controller.updateNumber,
     }));
+
+    // The displayed magnitude does not change when the sign toggles, so the selection remains valid.
+    const toggleSign = () => {
+        if (!allowNegative) {
+            return;
+        }
+
+        const currentValue = controller.getNumber();
+        controller.setCanonicalValue(currentValue.startsWith('-') ? currentValue.slice(1) : `-${currentValue}`);
+    };
+
+    const clearSign = () => {
+        const currentValue = controller.getNumber();
+        if (!currentValue.startsWith('-')) {
+            return;
+        }
+
+        controller.setCanonicalValue(currentValue.slice(1));
+    };
 
     const focusInput = () => {
         if (isTextInputFocused(inputRef)) {
@@ -55,14 +92,20 @@ function NumericInput({value = '', onInputChange, decimals = 0, maxLength, numer
     };
 
     const stateContextValue: NumericInputStateContextValue = {
+        value: controller.value,
         formattedNumber: controller.formattedNumber,
+        isNegative: allowNegative && controller.value.startsWith('-'),
         selection: controller.selection,
+        allowNegative,
+        errorText,
         inputRef,
     };
 
     const actionsContextValue: NumericInputActionsContextValue = {
         setNumber: controller.setNumber,
         clearSelection: controller.clearSelection,
+        toggleSign,
+        clearSign,
         handleSelectionChange: controller.handleSelectionChange,
         handleKeyPress: controller.handleKeyPress,
         focusInput,

--- a/src/components/NumericInput/NumericInput.tsx
+++ b/src/components/NumericInput/NumericInput.tsx
@@ -12,7 +12,7 @@ import type {NumericInputActionsContextValue, NumericInputStateContextValue} fro
 import {NumericInputActionsContext, NumericInputStateContext} from './context';
 
 /** The composed input displays the magnitude because the sign is rendered separately. */
-const getMagnitude = (canonicalValue: string) => (canonicalValue.startsWith('-') ? canonicalValue.slice(1) : canonicalValue);
+const getMagnitude = (canonicalValue: string, allowNegative: boolean) => (allowNegative && canonicalValue.startsWith('-') ? canonicalValue.slice(1) : canonicalValue);
 
 /** Preserves the sign that is rendered outside the text input while the magnitude is edited. Clearing the display text also clears the sign. */
 const getSignedValue = (displayText: string, previousCanonicalValue: string, allowNegative: boolean) => {
@@ -54,7 +54,7 @@ function NumericInput({value = '', onInputChange, allowNegative = false, decimal
         allowNegative,
         decimals,
         maxLength,
-        toDisplayText: getMagnitude,
+        toDisplayText: (canonicalValue) => getMagnitude(canonicalValue, allowNegative),
         toCanonicalValue: (displayText, previousCanonicalValue) => getSignedValue(displayText, previousCanonicalValue, allowNegative),
     });
 

--- a/src/components/NumericInput/context/NumericInputContext.ts
+++ b/src/components/NumericInput/context/NumericInputContext.ts
@@ -1,0 +1,18 @@
+import createContextNamespace from '@hooks/createContextNamespace';
+
+import type {NumericInputActionsContextValue, NumericInputStateContextValue} from './types';
+
+const createNumericInputContext = createContextNamespace('NumericInput');
+
+const [NumericInputStateContext, useNumericInputStateContext] = createNumericInputContext<NumericInputStateContextValue>('State');
+const [NumericInputActionsContext, useNumericInputActionsContext] = createNumericInputContext<NumericInputActionsContextValue>('Actions');
+
+function useNumericInputState() {
+    return useNumericInputStateContext('useNumericInputState');
+}
+
+function useNumericInputActions() {
+    return useNumericInputActionsContext('useNumericInputActions');
+}
+
+export {NumericInputActionsContext, NumericInputStateContext, useNumericInputActions, useNumericInputState};

--- a/src/components/NumericInput/context/index.ts
+++ b/src/components/NumericInput/context/index.ts
@@ -1,0 +1,1 @@
+export {NumericInputActionsContext, NumericInputStateContext, useNumericInputActions, useNumericInputState} from './NumericInputContext';

--- a/src/components/NumericInput/context/types.ts
+++ b/src/components/NumericInput/context/types.ts
@@ -1,0 +1,34 @@
+import type {NumericEditingKeyPressEvent, NumericEditingSelection} from '@components/NumericEditingController/types';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
+import type {RefObject} from 'react';
+
+type NumericInputStateContextValue = {
+    /** The text the composed input displays, rendered with locale digits. */
+    formattedNumber: string;
+
+    /** The selection to render, clamped to the displayed magnitude. */
+    selection: NumericEditingSelection;
+
+    /** The underlying text input, owned by the root. The text input primitive fills it in; the web caret sync reads the element from it. */
+    inputRef: RefObject<BaseTextInputRef | null>;
+};
+
+type NumericInputActionsContextValue = {
+    /** Normalizes, validates, and commits the value displayed by the composed input. */
+    setNumber: (text: string) => void;
+
+    /** Collapses the current selection to its end. */
+    clearSelection: () => void;
+
+    /** Applies a native selection change, dropping the stale event emitted alongside a manual update. */
+    handleSelectionChange: (selectionStart: number, selectionEnd: number) => void;
+
+    /** Tracks forward-delete key presses. */
+    handleKeyPress: (event: NumericEditingKeyPressEvent) => void;
+
+    /** Focuses the underlying text input when a layout container is clicked. */
+    focusInput: () => void;
+};
+
+export type {NumericInputActionsContextValue, NumericInputStateContextValue};

--- a/src/components/NumericInput/context/types.ts
+++ b/src/components/NumericInput/context/types.ts
@@ -4,11 +4,23 @@ import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import type {RefObject} from 'react';
 
 type NumericInputStateContextValue = {
+    /** The canonical signed value owned by the root. */
+    value: string;
+
     /** Canonical value rendered with locale digits. */
     formattedNumber: string;
 
     /** Selection clamped to the displayed text. */
     selection: NumericEditingSelection;
+
+    /** Whether the canonical value is negative. */
+    isNegative: boolean;
+
+    /** Whether negative values are allowed. */
+    allowNegative: boolean;
+
+    /** Error supplied by FormProvider. Rendered by the `NumericInput.Error` primitive wherever the composition places it. */
+    errorText?: string;
 
     /** Underlying text input, filled in by the text input primitive and read by focus handling and the web caret sync. */
     inputRef: RefObject<BaseTextInputRef | null>;
@@ -20,6 +32,12 @@ type NumericInputActionsContextValue = {
 
     /** Places the caret at the selection end, clearing any highlighted range. */
     clearSelection: () => void;
+
+    /** Toggles the sign of the canonical value and notifies the parent. */
+    toggleSign: () => void;
+
+    /** Removes the negative sign from the canonical value and notifies the parent. */
+    clearSign: () => void;
 
     /** Applies a native selection change, dropping stale events from manual updates. */
     handleSelectionChange: (selectionStart: number, selectionEnd: number) => void;

--- a/src/components/NumericInput/context/types.ts
+++ b/src/components/NumericInput/context/types.ts
@@ -4,30 +4,30 @@ import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import type {RefObject} from 'react';
 
 type NumericInputStateContextValue = {
-    /** The text the composed input displays, rendered with locale digits. */
+    /** Canonical value rendered with locale digits. */
     formattedNumber: string;
 
-    /** The selection to render, clamped to the displayed magnitude. */
+    /** Selection clamped to the displayed text. */
     selection: NumericEditingSelection;
 
-    /** The underlying text input, owned by the root. The text input primitive fills it in; the web caret sync reads the element from it. */
+    /** Underlying text input, filled in by the text input primitive and read by focus handling and the web caret sync. */
     inputRef: RefObject<BaseTextInputRef | null>;
 };
 
 type NumericInputActionsContextValue = {
-    /** Normalizes, validates, and commits the value displayed by the composed input. */
+    /** Normalizes, validates, and commits displayed text. */
     setNumber: (text: string) => void;
 
-    /** Collapses the current selection to its end. */
+    /** Places the caret at the selection end, clearing any highlighted range. */
     clearSelection: () => void;
 
-    /** Applies a native selection change, dropping the stale event emitted alongside a manual update. */
+    /** Applies a native selection change, dropping stale events from manual updates. */
     handleSelectionChange: (selectionStart: number, selectionEnd: number) => void;
 
-    /** Tracks forward-delete key presses. */
+    /** Tracks forward-delete key presses for caret positioning. */
     handleKeyPress: (event: NumericEditingKeyPressEvent) => void;
 
-    /** Focuses the underlying text input when a layout container is clicked. */
+    /** Focuses the underlying text input. */
     focusInput: () => void;
 };
 

--- a/src/components/NumericInput/hooks/useNumericDynamicFontSize.ts
+++ b/src/components/NumericInput/hooks/useNumericDynamicFontSize.ts
@@ -1,0 +1,15 @@
+import {useNumericInputState} from '@components/NumericInput/context';
+
+import useStyleUtils from '@hooks/useStyleUtils';
+
+import type {TextStyle} from 'react-native';
+
+/** Returns one font-size style for all pieces of a composed numeric input. */
+function useNumericDynamicFontSize(symbol = ''): TextStyle {
+    const StyleUtils = useStyleUtils();
+    const {formattedNumber, isNegative} = useNumericInputState();
+
+    return StyleUtils.getAmountInputFontSize(formattedNumber.length + symbol.length + (isNegative ? 1 : 0));
+}
+
+export default useNumericDynamicFontSize;

--- a/src/components/NumericInput/hooks/useNumericPressSelection/index.tsx
+++ b/src/components/NumericInput/hooks/useNumericPressSelection/index.tsx
@@ -1,0 +1,11 @@
+import type {BaseTextInputProps} from '@components/TextInput/BaseTextInput/types';
+
+/**
+ * Native emits a selection change whenever the caret moves, including on press, so the root selection stays in sync
+ * without any extra handling. The web implementation reads the caret from the DOM element instead.
+ */
+function useNumericPressSelection(onPress?: BaseTextInputProps['onPress']): BaseTextInputProps['onPress'] {
+    return onPress;
+}
+
+export default useNumericPressSelection;

--- a/src/components/NumericInput/hooks/useNumericPressSelection/index.tsx
+++ b/src/components/NumericInput/hooks/useNumericPressSelection/index.tsx
@@ -1,9 +1,6 @@
 import type {BaseTextInputProps} from '@components/TextInput/BaseTextInput/types';
 
-/**
- * Native emits a selection change whenever the caret moves, including on press, so the root selection stays in sync
- * without any extra handling. The web implementation reads the caret from the DOM element instead.
- */
+/** Native emits a selection change whenever the caret moves, including on press, so no extra handling is needed. */
 function useNumericPressSelection(onPress?: BaseTextInputProps['onPress']): BaseTextInputProps['onPress'] {
     return onPress;
 }

--- a/src/components/NumericInput/hooks/useNumericPressSelection/index.web.tsx
+++ b/src/components/NumericInput/hooks/useNumericPressSelection/index.web.tsx
@@ -1,0 +1,26 @@
+import {useNumericInputActions, useNumericInputState} from '@components/NumericInput/context';
+import type {BaseTextInputProps, BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
+/** Only the rendered form element exposes the caret offsets. */
+function getSelectableElement(input: BaseTextInputRef | null): HTMLInputElement | null {
+    return input instanceof HTMLInputElement ? input : null;
+}
+
+/**
+ * The browser moves the caret on click without emitting a selection change, so the controlled selection would snap the
+ * caret back to where it was. Reading the caret from the root's input element on press keeps the root selection in sync.
+ */
+function useNumericPressSelection(onPress?: BaseTextInputProps['onPress']): BaseTextInputProps['onPress'] {
+    const {handleSelectionChange} = useNumericInputActions();
+    const {inputRef} = useNumericInputState();
+
+    return (event) => {
+        const inputElement = getSelectableElement(inputRef.current);
+        if (inputElement) {
+            handleSelectionChange(inputElement.selectionStart ?? 0, inputElement.selectionEnd ?? 0);
+        }
+        onPress?.(event);
+    };
+}
+
+export default useNumericPressSelection;

--- a/src/components/NumericInput/hooks/useNumericPressSelection/index.web.tsx
+++ b/src/components/NumericInput/hooks/useNumericPressSelection/index.web.tsx
@@ -7,8 +7,8 @@ function getSelectableElement(input: BaseTextInputRef | null): HTMLInputElement 
 }
 
 /**
- * The browser moves the caret on click without emitting a selection change, so the controlled selection would snap the
- * caret back to where it was. Reading the caret from the root's input element on press keeps the root selection in sync.
+ * The browser moves the caret on click without emitting a selection change, so the controlled selection would snap it
+ * back. Reading the caret from the input element on press keeps the root selection in sync.
  */
 function useNumericPressSelection(onPress?: BaseTextInputProps['onPress']): BaseTextInputProps['onPress'] {
     const {handleSelectionChange} = useNumericInputActions();

--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * NumericInput – a composable numeric editing experience for symbol and
+ * number-pad interactions.
+ *
+ * The root owns the canonical value, the selection, and validation through the
+ * same root-instantiated edit controller as NumericField. The symbol is a
+ * primitive the composition places itself, in the order it wants and inside the
+ * row it lays out.
+ *
+ * @example
+ * ```tsx
+ * import NumericInput from '@components/NumericInput';
+ *
+ * <NumericInput
+ *   value={amount}
+ *   onInputChange={setAmount}
+ *   decimals={2}
+ * >
+ *   <View style={[styles.flexRow, styles.alignItemsCenter]}>
+ *     <NumericInput.Symbol>$</NumericInput.Symbol>
+ *     <NumericInput.TextInput />
+ *   </View>
+ * </NumericInput>
+ * ```
+ *
+ * A suffix symbol is the same composition with the symbol placed after the input. The `Container` primitive provides the
+ * centered full-size amount layout when a composition needs the
+ * legacy empty-area refocus behavior. The number pad, controls, and footer primitives arrive in a later PR.
+ */
+import NumericInputComponent from './NumericInput';
+import NumericInputContainer from './primitives/NumericInputContainer';
+import NumericSymbol from './primitives/NumericSymbol';
+import NumericTextInput from './primitives/NumericTextInput';
+
+const NumericInput = Object.assign(NumericInputComponent, {
+    /** Renders the number itself, displaying and editing the magnitude of the canonical value. */
+    TextInput: NumericTextInput,
+
+    /** Renders its children as the symbol (currency or unit) displayed beside the number. */
+    Symbol: NumericSymbol,
+
+    /** Renders the centered, full-size amount layout with legacy empty-area refocus behavior. */
+    Container: NumericInputContainer,
+});
+
+export default NumericInput;

--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -30,6 +30,7 @@
 import NumericInputComponent from './NumericInput';
 import NumericInputContainer from './primitives/NumericInputContainer';
 import NumericSymbol from './primitives/NumericSymbol';
+import NumericSymbolButton from './primitives/NumericSymbolButton';
 import NumericTextInput from './primitives/NumericTextInput';
 
 const NumericInput = Object.assign(NumericInputComponent, {
@@ -38,6 +39,9 @@ const NumericInput = Object.assign(NumericInputComponent, {
 
     /** Renders its children as the symbol (currency or unit) displayed beside the number. */
     Symbol: NumericSymbol,
+
+    /** Renders a pressable symbol (currency or unit) selector. */
+    SymbolButton: NumericSymbolButton,
 
     /** Renders the centered, full-size amount layout with legacy empty-area refocus behavior. */
     Container: NumericInputContainer,

--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -1,8 +1,9 @@
 /**
  * NumericInput – a composable numeric editing experience for symbol and number-pad interactions.
  *
- * The root owns the canonical value, the selection, and validation through the same root-instantiated
- * edit controller as NumericField. Primitives are placed by the composition, in the order and layout it wants.
+ * The root owns the canonical signed value, the selection, and validation through the same root-instantiated
+ * edit controller as NumericField. The composed input displays only the magnitude; the sign and symbol are
+ * primitives placed by the composition, in the order and layout it wants.
  *
  * @example
  * ```tsx
@@ -12,17 +13,25 @@
  *   value={amount}
  *   onInputChange={setAmount}
  *   decimals={2}
+ *   allowNegative
  * >
  *   <NumericInput.Container>
+ *     <NumericInput.MinusSign />
  *     <NumericInput.Symbol>$</NumericInput.Symbol>
  *     <NumericInput.TextInput />
  *   </NumericInput.Container>
+ *   <NumericInput.Error />
  * </NumericInput>
  * ```
  *
+ * A suffix symbol is the same composition with the symbol placed after the input. The error is rendered by its own
+ * primitive because number-pad layouts position it differently. A composition that needs shared dynamic sizing can
+ * read `useNumericDynamicFontSize` once and pass the resulting style to its rendered primitives.
  */
 import NumericInputComponent from './NumericInput';
+import NumericError from './primitives/NumericError';
 import NumericInputContainer from './primitives/NumericInputContainer';
+import NumericMinusSign from './primitives/NumericMinusSign';
 import NumericSymbol from './primitives/NumericSymbol';
 import NumericSymbolButton from './primitives/NumericSymbolButton';
 import NumericTextInput from './primitives/NumericTextInput';
@@ -37,8 +46,16 @@ const NumericInput = Object.assign(NumericInputComponent, {
     /** Renders a pressable symbol (currency or unit) selector. */
     SymbolButton: NumericSymbolButton,
 
+    /** Renders the minus sign of a negative value, which the input itself does not display. */
+    MinusSign: NumericMinusSign,
+
+    /** Renders the root error, positioned by the composition. */
+    Error: NumericError,
+
     /** Renders the centered, full-size amount layout with legacy empty-area refocus behavior. */
     Container: NumericInputContainer,
 });
 
 export default NumericInput;
+export {useNumericInputActions} from './context';
+export {default as useNumericDynamicFontSize} from './hooks/useNumericDynamicFontSize';

--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -1,11 +1,8 @@
 /**
- * NumericInput – a composable numeric editing experience for symbol and
- * number-pad interactions.
+ * NumericInput – a composable numeric editing experience for symbol and number-pad interactions.
  *
- * The root owns the canonical value, the selection, and validation through the
- * same root-instantiated edit controller as NumericField. The symbol is a
- * primitive the composition places itself, in the order it wants and inside the
- * row it lays out.
+ * The root owns the canonical value, the selection, and validation through the same root-instantiated
+ * edit controller as NumericField. Primitives are placed by the composition, in the order and layout it wants.
  *
  * @example
  * ```tsx
@@ -16,16 +13,13 @@
  *   onInputChange={setAmount}
  *   decimals={2}
  * >
- *   <View style={[styles.flexRow, styles.alignItemsCenter]}>
+ *   <NumericInput.Container>
  *     <NumericInput.Symbol>$</NumericInput.Symbol>
  *     <NumericInput.TextInput />
- *   </View>
+ *   </NumericInput.Container>
  * </NumericInput>
  * ```
  *
- * A suffix symbol is the same composition with the symbol placed after the input. The `Container` primitive provides the
- * centered full-size amount layout when a composition needs the
- * legacy empty-area refocus behavior. The number pad, controls, and footer primitives arrive in a later PR.
  */
 import NumericInputComponent from './NumericInput';
 import NumericInputContainer from './primitives/NumericInputContainer';

--- a/src/components/NumericInput/primitives/NumericError.tsx
+++ b/src/components/NumericInput/primitives/NumericError.tsx
@@ -1,0 +1,25 @@
+import FormHelpMessage from '@components/FormHelpMessage';
+import {useNumericInputState} from '@components/NumericInput/context';
+import type {NumericErrorProps} from '@components/NumericInput/types';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+/** Renders the root error wherever the composition places this primitive. */
+function NumericError({style}: NumericErrorProps) {
+    const styles = useThemeStyles();
+    const {errorText} = useNumericInputState();
+
+    if (!errorText) {
+        return null;
+    }
+
+    return (
+        <FormHelpMessage
+            style={[styles.ph5, styles.w100, style]}
+            isError
+            message={errorText}
+        />
+    );
+}
+
+export default NumericError;

--- a/src/components/NumericInput/primitives/NumericInputContainer.tsx
+++ b/src/components/NumericInput/primitives/NumericInputContainer.tsx
@@ -1,0 +1,47 @@
+import {useNumericInputActions} from '@components/NumericInput/context';
+import type {NumericInputContainerProps} from '@components/NumericInput/types';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import isHTMLElement from '@libs/isHTMLElement';
+
+import type {MouseEvent} from 'react';
+
+import {useId} from 'react';
+import {View} from 'react-native';
+
+/**
+ * Renders the centered, full-size amount layout used by the legacy number form.
+ * Clicking its empty web area keeps the numeric input focused instead of letting the browser blur it.
+ */
+function NumericInputContainer({children, style, testID}: NumericInputContainerProps) {
+    const styles = useThemeStyles();
+    const {clearSelection, focusInput} = useNumericInputActions();
+    const numberViewId = useId();
+
+    const handleMouseDown = (event: MouseEvent<Element>) => {
+        const targetId = isHTMLElement(event.nativeEvent?.target) ? event.nativeEvent.target.id : undefined;
+        if (targetId !== numberViewId) {
+            return;
+        }
+
+        event.preventDefault();
+        clearSelection();
+        focusInput();
+    };
+
+    return (
+        <View style={[styles.flex1, styles.justifyContentCenter, styles.alignItemsCenter, style]}>
+            <View
+                id={numberViewId}
+                onMouseDown={handleMouseDown}
+                style={[styles.flex1, styles.w100, styles.alignItemsCenter, styles.justifyContentCenter]}
+                testID={testID}
+            >
+                <View style={[styles.flexRow, styles.moneyRequestAmountContainer, styles.alignItemsCenter, styles.justifyContentCenter]}>{children}</View>
+            </View>
+        </View>
+    );
+}
+
+export default NumericInputContainer;

--- a/src/components/NumericInput/primitives/NumericInputContainer.tsx
+++ b/src/components/NumericInput/primitives/NumericInputContainer.tsx
@@ -20,6 +20,7 @@ function NumericInputContainer({children, style, testID}: NumericInputContainerP
     const numberViewId = useId();
 
     const handleMouseDown = (event: MouseEvent<Element>) => {
+        // Only the container's own empty area refocuses the input. Presses bubbling up from children keep their caret.
         const targetId = isHTMLElement(event.nativeEvent?.target) ? event.nativeEvent.target.id : undefined;
         if (targetId !== numberViewId) {
             return;

--- a/src/components/NumericInput/primitives/NumericMinusSign.tsx
+++ b/src/components/NumericInput/primitives/NumericMinusSign.tsx
@@ -1,0 +1,19 @@
+import {useNumericInputState} from '@components/NumericInput/context';
+import type {NumericMinusSignProps} from '@components/NumericInput/types';
+import Text from '@components/Text';
+
+import useThemeStyles from '@hooks/useThemeStyles';
+
+/** Renders the sign separately from the editable numeric magnitude. */
+function NumericMinusSign({style}: NumericMinusSignProps) {
+    const styles = useThemeStyles();
+    const {isNegative} = useNumericInputState();
+
+    if (!isNegative) {
+        return null;
+    }
+
+    return <Text style={[styles.iouAmountText, style]}>-</Text>;
+}
+
+export default NumericMinusSign;

--- a/src/components/NumericInput/primitives/NumericSymbol.tsx
+++ b/src/components/NumericInput/primitives/NumericSymbol.tsx
@@ -1,0 +1,53 @@
+import Icon from '@components/Icon';
+import type {NumericSymbolProps} from '@components/NumericInput/types';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import Text from '@components/Text';
+import Tooltip from '@components/Tooltip';
+
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
+
+import {View} from 'react-native';
+
+/**
+ * Renders the symbol (currency or unit) displayed beside the number. The composition decides what the symbol is, where
+ * it sits, and whether it renders at all, so the primitive renders its children alone and leaves prefix/suffix
+ * placement to its parent.
+ */
+function NumericSymbol({children, isSymbolPressable = false, onSymbolButtonPress, textStyle}: NumericSymbolProps) {
+    const icons = useMemoizedLazyExpensifyIcons(['DownArrow']);
+    const {translate} = useLocalize();
+    const styles = useThemeStyles();
+    const theme = useTheme();
+
+    const symbolText = <Text style={[styles.iouAmountText, styles.lineHeightUndefined, textStyle]}>{children}</Text>;
+
+    if (!isSymbolPressable) {
+        return <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}>{symbolText}</View>;
+    }
+
+    return (
+        <Tooltip text={translate('common.selectSymbolOrCurrency')}>
+            <PressableWithoutFeedback
+                onPress={onSymbolButtonPress}
+                accessibilityLabel={translate('common.selectSymbolOrCurrency')}
+                role={CONST.ROLE.BUTTON}
+                sentryLabel="NumericInput-Symbol"
+                style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}
+            >
+                <Icon
+                    size={CONST.ICON_SIZE.SMALL}
+                    src={icons.DownArrow}
+                    fill={theme.icon}
+                />
+                {symbolText}
+            </PressableWithoutFeedback>
+        </Tooltip>
+    );
+}
+
+export default NumericSymbol;

--- a/src/components/NumericInput/primitives/NumericSymbol.tsx
+++ b/src/components/NumericInput/primitives/NumericSymbol.tsx
@@ -1,53 +1,17 @@
-import Icon from '@components/Icon';
 import type {NumericSymbolProps} from '@components/NumericInput/types';
-import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import Text from '@components/Text';
-import Tooltip from '@components/Tooltip';
 
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
-import useLocalize from '@hooks/useLocalize';
-import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-
-import CONST from '@src/CONST';
-
-import {View} from 'react-native';
 
 /**
  * Renders the symbol (currency or unit) displayed beside the number. The composition decides what the symbol is, where
- * it sits, and whether it renders at all, so the primitive renders its children alone and leaves prefix/suffix
- * placement to its parent.
+ * it sits, and whether it renders at all, so the primitive only renders the styled symbol and leaves layout to its
+ * parent.
  */
-function NumericSymbol({children, isSymbolPressable = false, onSymbolButtonPress, textStyle}: NumericSymbolProps) {
-    const icons = useMemoizedLazyExpensifyIcons(['DownArrow']);
-    const {translate} = useLocalize();
+function NumericSymbol({children, textStyle}: NumericSymbolProps) {
     const styles = useThemeStyles();
-    const theme = useTheme();
 
-    const symbolText = <Text style={[styles.iouAmountText, styles.lineHeightUndefined, textStyle]}>{children}</Text>;
-
-    if (!isSymbolPressable) {
-        return <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}>{symbolText}</View>;
-    }
-
-    return (
-        <Tooltip text={translate('common.selectSymbolOrCurrency')}>
-            <PressableWithoutFeedback
-                onPress={onSymbolButtonPress}
-                accessibilityLabel={translate('common.selectSymbolOrCurrency')}
-                role={CONST.ROLE.BUTTON}
-                sentryLabel="NumericInput-Symbol"
-                style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}
-            >
-                <Icon
-                    size={CONST.ICON_SIZE.SMALL}
-                    src={icons.DownArrow}
-                    fill={theme.icon}
-                />
-                {symbolText}
-            </PressableWithoutFeedback>
-        </Tooltip>
-    );
+    return <Text style={[styles.iouAmountText, styles.lineHeightUndefined, textStyle]}>{children}</Text>;
 }
 
 export default NumericSymbol;

--- a/src/components/NumericInput/primitives/NumericSymbol.tsx
+++ b/src/components/NumericInput/primitives/NumericSymbol.tsx
@@ -3,11 +3,7 @@ import Text from '@components/Text';
 
 import useThemeStyles from '@hooks/useThemeStyles';
 
-/**
- * Renders the symbol (currency or unit) displayed beside the number. The composition decides what the symbol is, where
- * it sits, and whether it renders at all, so the primitive only renders the styled symbol and leaves layout to its
- * parent.
- */
+/** Renders the symbol (currency or unit) displayed beside the number, leaving placement to the parent composition. */
 function NumericSymbol({children, textStyle}: NumericSymbolProps) {
     const styles = useThemeStyles();
 

--- a/src/components/NumericInput/primitives/NumericSymbolButton.tsx
+++ b/src/components/NumericInput/primitives/NumericSymbolButton.tsx
@@ -1,0 +1,42 @@
+import Icon from '@components/Icon';
+import type {NumericSymbolButtonProps} from '@components/NumericInput/types';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import Tooltip from '@components/Tooltip';
+
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import CONST from '@src/CONST';
+
+import NumericSymbol from './NumericSymbol';
+
+/** Renders a pressable symbol control with the shared NumericInput symbol styling. */
+function NumericSymbolButton({children, onPress, textStyle}: NumericSymbolButtonProps) {
+    const icons = useMemoizedLazyExpensifyIcons(['DownArrow']);
+    const {translate} = useLocalize();
+    const styles = useThemeStyles();
+    const theme = useTheme();
+
+    return (
+        <Tooltip text={translate('common.selectSymbolOrCurrency')}>
+            <PressableWithoutFeedback
+                onPress={onPress}
+                accessibilityLabel={translate('common.selectSymbolOrCurrency')}
+                role={CONST.ROLE.BUTTON}
+                sentryLabel="NumericInput-Symbol"
+                style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}
+            >
+                <Icon
+                    size={CONST.ICON_SIZE.SMALL}
+                    src={icons.DownArrow}
+                    fill={theme.icon}
+                />
+                <NumericSymbol textStyle={textStyle}>{children}</NumericSymbol>
+            </PressableWithoutFeedback>
+        </Tooltip>
+    );
+}
+
+export default NumericSymbolButton;

--- a/src/components/NumericInput/primitives/NumericTextInput.tsx
+++ b/src/components/NumericInput/primitives/NumericTextInput.tsx
@@ -1,0 +1,126 @@
+import type {NumericEditingKeyPressEvent} from '@components/NumericEditingController';
+import {useNumericInputActions, useNumericInputState} from '@components/NumericInput/context';
+import useNumericPressSelection from '@components/NumericInput/hooks/useNumericPressSelection';
+import type {NumericTextInputProps} from '@components/NumericInput/types';
+import TextInput from '@components/TextInput';
+
+import useLocalize from '@hooks/useLocalize';
+import {useMouseActions} from '@hooks/useMouseContext';
+import useThemeStyles from '@hooks/useThemeStyles';
+
+import mergeRefs from '@libs/mergeRefs';
+
+import CONST from '@src/CONST';
+
+import type {MouseEvent} from 'react';
+import type {TextInputKeyPressEvent, TextInputSelectionChangeEvent} from 'react-native';
+
+import {useNavigation} from '@react-navigation/native';
+/**
+ * Renders the number itself. The root owns the canonical value, and the symbol primitive can be placed beside it by the
+ * composition.
+ */
+function NumericTextInput({
+    style,
+    ref,
+    onKeyPress,
+    onBlur,
+    accessibilityLabel,
+    autoFocus,
+    autoGrow = true,
+    autoGrowExtraSpace,
+    autoGrowMarginSide,
+    contentWidth,
+    containerStyle,
+    disabled,
+    disableKeyboard = true,
+    hideFocusedState = true,
+    keyboardType,
+    onFocus,
+    onPress,
+    prefixCharacter,
+    prefixStyle,
+    prefixContainerStyle,
+    shouldApplyPaddingToContainer = false,
+    shouldUseDefaultLineHeightForPrefix,
+    testID,
+    touchableInputWrapperStyle,
+}: NumericTextInputProps) {
+    const {numberFormat, translate} = useLocalize();
+    const {setMouseDown, setMouseUp} = useMouseActions();
+    const styles = useThemeStyles();
+    const navigation = useNavigation();
+    const {formattedNumber, inputRef, selection} = useNumericInputState();
+    const {handleKeyPress, handleSelectionChange, setNumber} = useNumericInputActions();
+
+    // The browser needs the caret read from the element on press; native syncs it through the selection change event.
+    const handlePress = useNumericPressSelection(onPress);
+
+    const handleInputKeyPress = (event: NumericEditingKeyPressEvent) => {
+        handleKeyPress(event);
+        onKeyPress?.(event);
+    };
+
+    const handleMouseDown = (event: MouseEvent<Element>) => {
+        event.stopPropagation();
+        setMouseDown();
+    };
+
+    const handleMouseUp = (event: MouseEvent<Element>) => {
+        event.stopPropagation();
+        setMouseUp();
+    };
+
+    return (
+        <TextInput
+            accessibilityLabel={accessibilityLabel ?? translate('iou.amount')}
+            // On android autoCapitalize="words" is necessary when keyboardType="decimal-pad" or inputMode="decimal" to prevent input lag.
+            // See https://github.com/Expensify/App/issues/51868 for more information
+            autoCapitalize="words"
+            // On iPad, even if the soft keyboard is hidden, the keyboard suggestion is still shown.
+            // Setting both autoCorrect and spellCheck to false will hide the suggestion.
+            autoCorrect={false}
+            autoFocus={autoFocus}
+            autoGrow={autoGrow}
+            autoGrowExtraSpace={autoGrowExtraSpace}
+            autoGrowMarginSide={autoGrowMarginSide}
+            contentWidth={contentWidth}
+            disabled={disabled}
+            disableKeyboard={disableKeyboard}
+            disableKeyboardShortcuts
+            hideFocusedState={hideFocusedState}
+            inputMode={!keyboardType ? CONST.INPUT_MODE.DECIMAL : undefined}
+            inputStyle={[styles.pr1, style]}
+            keyboardType={keyboardType}
+            // The navigation prop keeps disableKeyboard working when the app returns from the background.
+            navigation={navigation}
+            onBlur={onBlur}
+            onChangeText={setNumber}
+            onFocus={onFocus}
+            onKeyPress={handleInputKeyPress as (event: TextInputKeyPressEvent) => void}
+            onMouseDown={handleMouseDown}
+            onMouseUp={handleMouseUp}
+            onPress={handlePress}
+            onSelectionChange={(event: TextInputSelectionChangeEvent) => handleSelectionChange(event.nativeEvent.selection.start, event.nativeEvent.selection.end)}
+            placeholder={numberFormat(0)}
+            prefixCharacter={prefixCharacter}
+            prefixContainerStyle={prefixContainerStyle}
+            prefixStyle={prefixStyle}
+            ref={mergeRefs(inputRef, ref)}
+            selection={selection}
+            shouldAllowFocusInLandscapeMode
+            shouldApplyPaddingToContainer={shouldApplyPaddingToContainer}
+            shouldInterceptSwipe
+            shouldUseDefaultLineHeightForPrefix={shouldUseDefaultLineHeightForPrefix}
+            shouldUseFullInputHeight
+            spellCheck={false}
+            submitBehavior="submit"
+            testID={testID}
+            textInputContainerStyles={containerStyle}
+            touchableInputWrapperStyle={touchableInputWrapperStyle}
+            value={formattedNumber}
+        />
+    );
+}
+
+export default NumericTextInput;

--- a/src/components/NumericInput/primitives/NumericTextInput.tsx
+++ b/src/components/NumericInput/primitives/NumericTextInput.tsx
@@ -16,10 +16,7 @@ import type {MouseEvent} from 'react';
 import type {TextInputKeyPressEvent, TextInputSelectionChangeEvent} from 'react-native';
 
 import {useNavigation} from '@react-navigation/native';
-/**
- * Renders the number itself. The root owns the canonical value, and the symbol primitive can be placed beside it by the
- * composition.
- */
+/** Renders the number itself, displaying and editing the canonical value owned by the root. */
 function NumericTextInput({
     style,
     ref,
@@ -52,7 +49,6 @@ function NumericTextInput({
     const {formattedNumber, inputRef, selection} = useNumericInputState();
     const {handleKeyPress, handleSelectionChange, setNumber} = useNumericInputActions();
 
-    // The browser needs the caret read from the element on press; native syncs it through the selection change event.
     const handlePress = useNumericPressSelection(onPress);
 
     const handleInputKeyPress = (event: NumericEditingKeyPressEvent) => {
@@ -104,6 +100,7 @@ function NumericTextInput({
             prefixCharacter={prefixCharacter}
             prefixContainerStyle={prefixContainerStyle}
             prefixStyle={prefixStyle}
+            // The root's ref drives focus and the web caret sync, so the caller's ref is merged into it.
             ref={mergeRefs(inputRef, ref)}
             selection={selection}
             shouldAllowFocusInLandscapeMode

--- a/src/components/NumericInput/primitives/NumericTextInput.tsx
+++ b/src/components/NumericInput/primitives/NumericTextInput.tsx
@@ -30,7 +30,6 @@ function NumericTextInput({
     autoGrow = true,
     autoGrowExtraSpace,
     autoGrowMarginSide,
-    contentWidth,
     containerStyle,
     disabled,
     disableKeyboard = true,
@@ -84,7 +83,6 @@ function NumericTextInput({
             autoGrow={autoGrow}
             autoGrowExtraSpace={autoGrowExtraSpace}
             autoGrowMarginSide={autoGrowMarginSide}
-            contentWidth={contentWidth}
             disabled={disabled}
             disableKeyboard={disableKeyboard}
             disableKeyboardShortcuts

--- a/src/components/NumericInput/primitives/NumericTextInput.tsx
+++ b/src/components/NumericInput/primitives/NumericTextInput.tsx
@@ -13,7 +13,7 @@ import mergeRefs from '@libs/mergeRefs';
 import CONST from '@src/CONST';
 
 import type {MouseEvent} from 'react';
-import type {TextInputKeyPressEvent, TextInputSelectionChangeEvent} from 'react-native';
+import type {TextInputSelectionChangeEvent} from 'react-native';
 
 import {useNavigation} from '@react-navigation/native';
 /** Renders the number itself, displaying and editing the canonical value owned by the root. */
@@ -100,7 +100,7 @@ function NumericTextInput({
             onBlur={onBlur}
             onChangeText={setNumber}
             onFocus={onFocus}
-            onKeyPress={handleInputKeyPress as (event: TextInputKeyPressEvent) => void}
+            onKeyPress={handleInputKeyPress}
             onMouseDown={handleMouseDown}
             onMouseUp={handleMouseUp}
             onPress={handlePress}

--- a/src/components/NumericInput/primitives/NumericTextInput.tsx
+++ b/src/components/NumericInput/primitives/NumericTextInput.tsx
@@ -34,9 +34,11 @@ function NumericTextInput({
     keyboardType,
     onFocus,
     onPress,
+    onSubmitEditing,
     prefixCharacter,
     prefixStyle,
     prefixContainerStyle,
+    shouldAllowFocusInLandscapeMode = true,
     shouldApplyPaddingToContainer = false,
     shouldUseDefaultLineHeightForPrefix,
     testID,
@@ -46,12 +48,19 @@ function NumericTextInput({
     const {setMouseDown, setMouseUp} = useMouseActions();
     const styles = useThemeStyles();
     const navigation = useNavigation();
-    const {formattedNumber, inputRef, selection} = useNumericInputState();
-    const {handleKeyPress, handleSelectionChange, setNumber} = useNumericInputActions();
+    const {formattedNumber, inputRef, isNegative, selection} = useNumericInputState();
+    const {clearSign, handleKeyPress, handleSelectionChange, setNumber} = useNumericInputActions();
 
     const handlePress = useNumericPressSelection(onPress);
 
     const handleInputKeyPress = (event: NumericEditingKeyPressEvent) => {
+        const key = event.nativeEvent.key.toLowerCase();
+
+        // The minus sign is rendered outside the input, so backspacing an empty input clears it.
+        if (!formattedNumber && key === 'backspace' && isNegative) {
+            clearSign();
+        }
+
         handleKeyPress(event);
         onKeyPress?.(event);
     };
@@ -96,6 +105,7 @@ function NumericTextInput({
             onMouseUp={handleMouseUp}
             onPress={handlePress}
             onSelectionChange={(event: TextInputSelectionChangeEvent) => handleSelectionChange(event.nativeEvent.selection.start, event.nativeEvent.selection.end)}
+            onSubmitEditing={onSubmitEditing}
             placeholder={numberFormat(0)}
             prefixCharacter={prefixCharacter}
             prefixContainerStyle={prefixContainerStyle}
@@ -103,7 +113,7 @@ function NumericTextInput({
             // The root's ref drives focus and the web caret sync, so the caller's ref is merged into it.
             ref={mergeRefs(inputRef, ref)}
             selection={selection}
-            shouldAllowFocusInLandscapeMode
+            shouldAllowFocusInLandscapeMode={shouldAllowFocusInLandscapeMode}
             shouldApplyPaddingToContainer={shouldApplyPaddingToContainer}
             shouldInterceptSwipe
             shouldUseDefaultLineHeightForPrefix={shouldUseDefaultLineHeightForPrefix}

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -1,0 +1,73 @@
+import type {NumericEditingKeyPressEvent} from '@components/NumericEditingController/types';
+import type {BaseTextInputProps, BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
+import type {ForwardedRef, ReactNode} from 'react';
+import type {StyleProp, TextStyle, ViewStyle} from 'react-native';
+
+type NumericInputContainerProps = {
+    /** Composed numeric primitives rendered inside the centered amount layout. */
+    children: ReactNode;
+
+    /** Additional styles applied to the outer container. */
+    style?: StyleProp<ViewStyle>;
+
+    /** Test identifier applied to the interactive number view. */
+    testID?: string;
+};
+
+type NumericTextInputProps = {
+    /** Style applied to the number input. */
+    style?: StyleProp<TextStyle>;
+
+    /** Reference to the underlying text input. */
+    ref?: ForwardedRef<BaseTextInputRef>;
+
+    /** Callback for keyboard events received by the numeric input. */
+    onKeyPress?: (event: NumericEditingKeyPressEvent) => void;
+
+    /** Whether the input grows with its content. */
+    autoGrow?: boolean;
+
+    /** Hide the focused appearance of the input. */
+    hideFocusedState?: boolean;
+
+    /** Style applied to the input container. */
+    containerStyle?: StyleProp<ViewStyle>;
+} & Pick<
+    BaseTextInputProps,
+    | 'accessibilityLabel'
+    | 'autoFocus'
+    | 'autoGrowExtraSpace'
+    | 'autoGrowMarginSide'
+    | 'contentWidth'
+    | 'disabled'
+    | 'disableKeyboard'
+    | 'keyboardType'
+    | 'onBlur'
+    | 'onFocus'
+    | 'onPress'
+    | 'prefixCharacter'
+    | 'prefixContainerStyle'
+    | 'prefixStyle'
+    | 'shouldApplyPaddingToContainer'
+    | 'shouldUseDefaultLineHeightForPrefix'
+    | 'submitBehavior'
+    | 'testID'
+    | 'touchableInputWrapperStyle'
+>;
+
+type NumericSymbolProps = {
+    /** Symbol (currency or unit) rendered beside the number. The composition decides whether to render it at all. */
+    children: ReactNode;
+
+    /** Whether the symbol can be pressed. Prefer a dedicated currency control for new compositions. */
+    isSymbolPressable?: boolean;
+
+    /** Called when the symbol is pressed. Prefer a dedicated currency control for new compositions. */
+    onSymbolButtonPress?: () => void;
+
+    /** Style applied to the symbol text, appended to the primitive's defaults. */
+    textStyle?: StyleProp<TextStyle>;
+};
+
+export type {NumericInputContainerProps, NumericSymbolProps, NumericTextInputProps};

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -51,7 +51,7 @@ type NumericTextInputProps = {
 >;
 
 type NumericSymbolProps = {
-    /** Symbol (currency or unit) rendered beside the number. The composition decides where it sits and whether it renders at all. */
+    /** Symbol (currency or unit) rendered beside the number. */
     children: ReactNode;
 
     /** Style applied to the symbol text, appended to the primitive's defaults. */

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -39,7 +39,6 @@ type NumericTextInputProps = {
     | 'autoFocus'
     | 'autoGrowExtraSpace'
     | 'autoGrowMarginSide'
-    | 'contentWidth'
     | 'disabled'
     | 'disableKeyboard'
     | 'keyboardType'

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -65,7 +65,7 @@ type NumericSymbolButtonProps = {
     children: ReactNode;
 
     /** Called when the symbol button is pressed. */
-    onPress?: () => void;
+    onPress: () => void;
 
     /** Style applied to the symbol text, appended to the primitive's defaults. */
     textStyle?: StyleProp<TextStyle>;

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -56,17 +56,22 @@ type NumericTextInputProps = {
 >;
 
 type NumericSymbolProps = {
-    /** Symbol (currency or unit) rendered beside the number. The composition decides whether to render it at all. */
+    /** Symbol (currency or unit) rendered beside the number. The composition decides where it sits and whether it renders at all. */
     children: ReactNode;
-
-    /** Whether the symbol can be pressed. Prefer a dedicated currency control for new compositions. */
-    isSymbolPressable?: boolean;
-
-    /** Called when the symbol is pressed. Prefer a dedicated currency control for new compositions. */
-    onSymbolButtonPress?: () => void;
 
     /** Style applied to the symbol text, appended to the primitive's defaults. */
     textStyle?: StyleProp<TextStyle>;
 };
 
-export type {NumericInputContainerProps, NumericSymbolProps, NumericTextInputProps};
+type NumericSymbolButtonProps = {
+    /** Symbol (currency or unit) rendered inside the button. */
+    children: ReactNode;
+
+    /** Called when the symbol button is pressed. */
+    onPress?: () => void;
+
+    /** Style applied to the symbol text, appended to the primitive's defaults. */
+    textStyle?: StyleProp<TextStyle>;
+};
+
+export type {NumericInputContainerProps, NumericSymbolButtonProps, NumericSymbolProps, NumericTextInputProps};

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -25,22 +25,18 @@ type NumericTextInputProps = {
     /** Callback for keyboard events received by the numeric input. */
     onKeyPress?: (event: NumericEditingKeyPressEvent) => void;
 
-    /** Whether the input grows with its content. */
-    autoGrow?: boolean;
-
-    /** Hide the focused appearance of the input. */
-    hideFocusedState?: boolean;
-
     /** Style applied to the input container. */
     containerStyle?: StyleProp<ViewStyle>;
 } & Pick<
     BaseTextInputProps,
     | 'accessibilityLabel'
     | 'autoFocus'
+    | 'autoGrow'
     | 'autoGrowExtraSpace'
     | 'autoGrowMarginSide'
     | 'disabled'
     | 'disableKeyboard'
+    | 'hideFocusedState'
     | 'keyboardType'
     | 'onBlur'
     | 'onFocus'
@@ -50,7 +46,6 @@ type NumericTextInputProps = {
     | 'prefixStyle'
     | 'shouldApplyPaddingToContainer'
     | 'shouldUseDefaultLineHeightForPrefix'
-    | 'submitBehavior'
     | 'testID'
     | 'touchableInputWrapperStyle'
 >;

--- a/src/components/NumericInput/types.ts
+++ b/src/components/NumericInput/types.ts
@@ -41,9 +41,11 @@ type NumericTextInputProps = {
     | 'onBlur'
     | 'onFocus'
     | 'onPress'
+    | 'onSubmitEditing'
     | 'prefixCharacter'
     | 'prefixContainerStyle'
     | 'prefixStyle'
+    | 'shouldAllowFocusInLandscapeMode'
     | 'shouldApplyPaddingToContainer'
     | 'shouldUseDefaultLineHeightForPrefix'
     | 'testID'
@@ -69,4 +71,14 @@ type NumericSymbolButtonProps = {
     textStyle?: StyleProp<TextStyle>;
 };
 
-export type {NumericInputContainerProps, NumericSymbolButtonProps, NumericSymbolProps, NumericTextInputProps};
+type NumericMinusSignProps = {
+    /** Style applied to the minus sign, appended to the primitive's defaults. */
+    style?: StyleProp<TextStyle>;
+};
+
+type NumericErrorProps = {
+    /** Style applied to the message container, appended to the primitive's defaults. */
+    style?: StyleProp<ViewStyle>;
+};
+
+export type {NumericErrorProps, NumericInputContainerProps, NumericMinusSignProps, NumericSymbolButtonProps, NumericSymbolProps, NumericTextInputProps};

--- a/src/components/TextInput/BaseTextInput/isTextInputFocused.ts
+++ b/src/components/TextInput/BaseTextInput/isTextInputFocused.ts
@@ -1,8 +1,19 @@
-import type {AnimatedTextInputRef} from '@components/RNTextInput';
-
 import type {BaseTextInputRef} from './types';
 
+type FocusableTextInputRef = BaseTextInputRef & {
+    isFocused: () => boolean;
+};
+
+function isFocusableTextInputRef(textInput: BaseTextInputRef): textInput is FocusableTextInputRef {
+    return 'isFocused' in textInput && typeof textInput.isFocused === 'function';
+}
+
 /** Checks that text input has the isFocused method and is focused. */
-export default function isTextInputFocused(textInput: React.MutableRefObject<BaseTextInputRef | null>): boolean | null {
-    return textInput.current && 'isFocused' in textInput.current && (textInput.current as AnimatedTextInputRef).isFocused();
+export default function isTextInputFocused(textInput: React.RefObject<BaseTextInputRef | null>): boolean | null {
+    const currentTextInput = textInput.current;
+    if (!currentTextInput || !isFocusableTextInputRef(currentTextInput)) {
+        return null;
+    }
+
+    return currentTextInput.isFocused();
 }

--- a/src/pages/workspace/taxes/WorkspaceCreateTaxValuePage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceCreateTaxValuePage.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/ButtonComposed';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import NumberWithSymbolForm from '@components/NumberWithSymbolForm';
+import NumericInput from '@components/NumericInput';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
@@ -10,6 +11,7 @@ import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {setDraftValues} from '@libs/actions/FormActions';
+import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
@@ -39,6 +41,7 @@ function WorkspaceCreateTaxValuePage({
 
     const [formDraft] = useOnyx(ONYXKEYS.FORMS.WORKSPACE_NEW_TAX_FORM_DRAFT);
     const [currentValue, setCurrentValue] = useState(formDraft?.[INPUT_IDS.VALUE]);
+    const shouldUseLegacyInput = canUseTouchScreen();
 
     const goBack = () => Navigation.goBack(ROUTES.WORKSPACE_TAX_CREATE.getRoute(policyID));
 
@@ -72,21 +75,42 @@ function WorkspaceCreateTaxValuePage({
                 addBottomSafeAreaPadding
             >
                 <View style={styles.flex1}>
-                    <NumberWithSymbolForm
-                        value={currentValue}
-                        onInputChange={setCurrentValue}
-                        ref={inputRef}
-                        decimals={CONST.MAX_TAX_RATE_DECIMAL_PLACES}
-                        maxLength={CONST.MAX_TAX_RATE_INTEGER_PLACES}
-                        isSymbolPressable={false}
-                        symbol="%"
-                        symbolPosition={CONST.TEXT_INPUT_SYMBOL_POSITION.SUFFIX}
-                        autoGrowExtraSpace={variables.w80}
-                        autoGrowMarginSide="left"
-                        style={[styles.iouAmountTextInput, styles.textAlignRight]}
-                        containerStyle={styles.iouAmountTextInputContainer}
-                        touchableInputWrapperStyle={styles.heightUndefined}
-                    />
+                    {shouldUseLegacyInput ? (
+                        <NumberWithSymbolForm
+                            value={currentValue}
+                            onInputChange={setCurrentValue}
+                            ref={inputRef}
+                            decimals={CONST.MAX_TAX_RATE_DECIMAL_PLACES}
+                            maxLength={CONST.MAX_TAX_RATE_INTEGER_PLACES}
+                            isSymbolPressable={false}
+                            symbol="%"
+                            symbolPosition={CONST.TEXT_INPUT_SYMBOL_POSITION.SUFFIX}
+                            autoGrowExtraSpace={variables.w80}
+                            autoGrowMarginSide="left"
+                            style={[styles.iouAmountTextInput, styles.textAlignRight]}
+                            containerStyle={styles.iouAmountTextInputContainer}
+                            touchableInputWrapperStyle={styles.heightUndefined}
+                        />
+                    ) : (
+                        <NumericInput
+                            value={currentValue}
+                            onInputChange={setCurrentValue}
+                            decimals={CONST.MAX_TAX_RATE_DECIMAL_PLACES}
+                            maxLength={CONST.MAX_TAX_RATE_INTEGER_PLACES}
+                        >
+                            <NumericInput.Container>
+                                <NumericInput.TextInput
+                                    autoGrowExtraSpace={variables.w80}
+                                    autoGrowMarginSide="left"
+                                    style={[styles.iouAmountTextInput, styles.textAlignRight]}
+                                    containerStyle={styles.iouAmountTextInputContainer}
+                                    touchableInputWrapperStyle={styles.heightUndefined}
+                                    ref={inputRef}
+                                />
+                                <NumericInput.Symbol>%</NumericInput.Symbol>
+                            </NumericInput.Container>
+                        </NumericInput>
+                    )}
                     <Button
                         variant={CONST.BUTTON_VARIANT.SUCCESS}
                         size={CONST.BUTTON_SIZE.LARGE}

--- a/src/pages/workspace/taxes/WorkspaceCreateTaxValuePage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceCreateTaxValuePage.tsx
@@ -11,7 +11,7 @@ import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 
 import {setDraftValues} from '@libs/actions/FormActions';
-import {canUseTouchScreen} from '@libs/DeviceCapabilities';
+import {canUseTouchScreen as canUseTouchScreenUtil} from '@libs/DeviceCapabilities';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import TransitionTracker from '@libs/Navigation/TransitionTracker';
@@ -31,6 +31,8 @@ import {View} from 'react-native';
 
 type WorkspaceCreateTaxValuePageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.TAX_CREATE_VALUE>;
 
+const shouldUseLegacyInput = canUseTouchScreenUtil();
+
 function WorkspaceCreateTaxValuePage({
     route: {
         params: {policyID},
@@ -41,7 +43,6 @@ function WorkspaceCreateTaxValuePage({
 
     const [formDraft] = useOnyx(ONYXKEYS.FORMS.WORKSPACE_NEW_TAX_FORM_DRAFT);
     const [currentValue, setCurrentValue] = useState(formDraft?.[INPUT_IDS.VALUE]);
-    const shouldUseLegacyInput = canUseTouchScreen();
 
     const goBack = () => Navigation.goBack(ROUTES.WORKSPACE_TAX_CREATE.getRoute(policyID));
 

--- a/tests/ui/NumericFieldInputTest.tsx
+++ b/tests/ui/NumericFieldInputTest.tsx
@@ -394,6 +394,23 @@ describe('NumericField.TextInput', () => {
         expect(inputOnKeyPress).toHaveBeenCalledTimes(1);
     });
 
+    it('uses submit behavior by default and preserves an explicit override', async () => {
+        // Given a NumericField.TextInput without an explicit submit behavior
+        const {unmount} = renderTextInput({testID: INPUT_TEST_ID}, {value: '10'});
+        await waitForBatchedUpdatesWithAct();
+
+        // Then Enter submits without blurring by default
+        expect(screen.getByTestId(INPUT_TEST_ID).props.submitBehavior).toBe('submit');
+
+        // When an explicit blur behavior is provided
+        unmount();
+        renderTextInput({testID: INPUT_TEST_ID, submitBehavior: 'blurAndSubmit'}, {value: '10'});
+        await waitForBatchedUpdatesWithAct();
+
+        // Then the caller's override is preserved
+        expect(screen.getByTestId(INPUT_TEST_ID).props.submitBehavior).toBe('blurAndSubmit');
+    });
+
     it('collapses the selection onto its end when clearSelection is called', async () => {
         const ref = React.createRef<NumericFieldRef>();
 

--- a/tests/ui/NumericFieldInputTest.tsx
+++ b/tests/ui/NumericFieldInputTest.tsx
@@ -394,20 +394,21 @@ describe('NumericField.TextInput', () => {
         expect(inputOnKeyPress).toHaveBeenCalledTimes(1);
     });
 
-    it('uses submit behavior by default and preserves an explicit override', async () => {
-        // Given a NumericField.TextInput without an explicit submit behavior
-        const {unmount} = renderTextInput({testID: INPUT_TEST_ID}, {value: '10'});
+    it('submits without blurring when no submit behavior is given', async () => {
+        // Given a TextInput without an explicit submit behavior
+        renderTextInput({testID: INPUT_TEST_ID}, {value: '10'});
         await waitForBatchedUpdatesWithAct();
 
-        // Then Enter submits without blurring by default
+        // Then Enter submits without blurring
         expect(screen.getByTestId(INPUT_TEST_ID).props.submitBehavior).toBe('submit');
+    });
 
-        // When an explicit blur behavior is provided
-        unmount();
+    it("preserves the caller's submit behavior override", async () => {
+        // Given a TextInput with an explicit blur-and-submit behavior
         renderTextInput({testID: INPUT_TEST_ID, submitBehavior: 'blurAndSubmit'}, {value: '10'});
         await waitForBatchedUpdatesWithAct();
 
-        // Then the caller's override is preserved
+        // Then the override reaches the underlying input
         expect(screen.getByTestId(INPUT_TEST_ID).props.submitBehavior).toBe('blurAndSubmit');
     });
 

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -1,9 +1,13 @@
-import {fireEvent, render, screen} from '@testing-library/react-native';
+import {act, fireEvent, render, screen} from '@testing-library/react-native';
 
 import ComposeProviders from '@components/ComposeProviders';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import type {NumericEditingRef} from '@components/NumericEditingController';
 import NumericInput from '@components/NumericInput';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
+import CONST from '@src/CONST';
 
 import type * as NativeNavigation from '@react-navigation/native';
 
@@ -21,8 +25,28 @@ jest.mock('@react-navigation/native', () => ({
 type NumericInputProps = React.ComponentProps<typeof NumericInput>;
 
 const INPUT_TEST_ID = 'numeric-text-input';
+const CONTAINER_TEST_ID = 'numeric-input-container';
+const SYMBOL_ACCESSIBILITY_LABEL = 'Select a symbol or currency';
+
 function renderWithProviders(children: React.ReactNode) {
     return render(<ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>{children}</ComposeProviders>);
+}
+
+/** Builds the mouse event the web container handler expects, with `target.id` set to the pressed view's id. */
+function getMouseDownEvent(targetId: string) {
+    const target = document.createElement('div');
+    target.id = targetId;
+
+    return {nativeEvent: {target}, preventDefault: jest.fn()};
+}
+
+function getContainerViewId(testID: string) {
+    const container = screen.getByTestId(testID);
+    if (typeof container.props.id !== 'string') {
+        throw new Error(`Numeric input container id was not assigned for ${testID}`);
+    }
+
+    return container.props.id;
 }
 
 describe('NumericInput', () => {
@@ -49,19 +73,20 @@ describe('NumericInput', () => {
     });
 
     describe('symbol primitive', () => {
-        it('renders the symbol the composition places beside the input', () => {
-            renderNumericInput({value: '12'});
-
-            expect(screen.getByText('$')).toBeOnTheScreen();
-        });
-
-        it('renders on its own, without an input', () => {
+        it('renders its children as the symbol beside the input', () => {
             renderNumericInput({value: '12'}, <NumericInput.Symbol>km</NumericInput.Symbol>);
 
             expect(screen.getByText('km')).toBeOnTheScreen();
         });
 
-        it('calls back when the pressable symbol is pressed', () => {
+        it('renders no button when the symbol is not pressable', () => {
+            renderNumericInput({value: '12'}, <NumericInput.Symbol>$</NumericInput.Symbol>);
+
+            expect(screen.getByText('$')).toBeOnTheScreen();
+            expect(screen.queryAllByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL})).toHaveLength(0);
+        });
+
+        it('calls onSymbolButtonPress when the pressable symbol is pressed', () => {
             const onSymbolButtonPress = jest.fn();
             renderNumericInput(
                 {value: '12'},
@@ -73,20 +98,210 @@ describe('NumericInput', () => {
                 </NumericInput.Symbol>,
             );
 
-            fireEvent.press(screen.getByText('$'));
+            fireEvent.press(screen.getByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL}));
 
             expect(onSymbolButtonPress).toHaveBeenCalledTimes(1);
         });
     });
 
+    describe('container primitive', () => {
+        const renderContainerComposition = (inputRef?: React.Ref<BaseTextInputRef>) =>
+            renderNumericInput(
+                {value: '12'},
+                <NumericInput.Container testID={CONTAINER_TEST_ID}>
+                    <NumericInput.TextInput
+                        testID={INPUT_TEST_ID}
+                        ref={inputRef}
+                    />
+                    <NumericInput.Symbol>%</NumericInput.Symbol>
+                </NumericInput.Container>,
+            );
+
+        it('focuses the input and collapses the selection when its own empty area is pressed', () => {
+            // Given a container composition with a range selection on the input
+            const inputRef = React.createRef<BaseTextInputRef>();
+            renderContainerComposition(inputRef);
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'selectionChange', {
+                nativeEvent: {selection: {start: 0, end: 2}},
+            });
+            expect(input.props.selection).toEqual({start: 0, end: 2});
+
+            const inputElement = inputRef.current;
+            if (!inputElement) {
+                throw new Error('Numeric input ref was not assigned');
+            }
+            const focus = jest.spyOn(inputElement, 'focus');
+
+            // When the container's own empty area is pressed
+            const event = getMouseDownEvent(getContainerViewId(CONTAINER_TEST_ID));
+            fireEvent(screen.getByTestId(CONTAINER_TEST_ID), 'mouseDown', event);
+
+            // Then the browser blur is prevented, the input is focused, and the selection collapses onto its end
+            expect(event.preventDefault).toHaveBeenCalledTimes(1);
+            expect(focus).toHaveBeenCalledTimes(1);
+            expect(input.props.selection).toEqual({start: 2, end: 2});
+            focus.mockRestore();
+        });
+
+        it('ignores a press that originates from a nested view instead of its own empty area', () => {
+            // Given a container composition with a range selection on the input
+            const inputRef = React.createRef<BaseTextInputRef>();
+            renderContainerComposition(inputRef);
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'selectionChange', {
+                nativeEvent: {selection: {start: 0, end: 2}},
+            });
+
+            const inputElement = inputRef.current;
+            if (!inputElement) {
+                throw new Error('Numeric input ref was not assigned');
+            }
+            const focus = jest.spyOn(inputElement, 'focus');
+
+            // When the press bubbles up from a nested view, which owns the caret placement itself
+            const event = getMouseDownEvent('some-nested-view-id');
+            fireEvent(screen.getByTestId(CONTAINER_TEST_ID), 'mouseDown', event);
+
+            // Then the container leaves the press and the selection alone
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(focus).not.toHaveBeenCalled();
+            expect(input.props.selection).toEqual({start: 0, end: 2});
+            focus.mockRestore();
+        });
+
+        it('assigns a distinct target id to each mounted container', () => {
+            renderWithProviders(
+                <>
+                    <NumericInput
+                        onInputChange={onInputChange}
+                        value="12"
+                    >
+                        <NumericInput.Container testID={`${CONTAINER_TEST_ID}-one`}>
+                            <NumericInput.TextInput />
+                        </NumericInput.Container>
+                    </NumericInput>
+                    <NumericInput
+                        onInputChange={onInputChange}
+                        value="34"
+                    >
+                        <NumericInput.Container testID={`${CONTAINER_TEST_ID}-two`}>
+                            <NumericInput.TextInput />
+                        </NumericInput.Container>
+                    </NumericInput>
+                </>,
+            );
+
+            expect(getContainerViewId(`${CONTAINER_TEST_ID}-one`)).not.toBe(getContainerViewId(`${CONTAINER_TEST_ID}-two`));
+        });
+    });
+
     describe('text input primitive', () => {
+        it('commits a valid edit through the root and displays it', () => {
+            // Given a composition with two accepted decimal places and value "12"
+            renderNumericInput({value: '12'});
+
+            // When the user appends a decimal fraction
+            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '12.5');
+
+            // Then the root is notified and the input displays the committed value
+            expect(onInputChange).toHaveBeenLastCalledWith('12.5');
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12.5');
+        });
+
+        it('moves the caret to the end of the value after an edit', () => {
+            // Given a composition with value "12" and the caret at the end
+            renderNumericInput({value: '12'});
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'selectionChange', {
+                nativeEvent: {selection: {start: 2, end: 2}},
+            });
+
+            // When a digit is appended
+            fireEvent.changeText(input, '123');
+
+            // Then the caret follows the appended digit
+            expect(input.props.selection).toEqual({start: 3, end: 3});
+        });
+
+        it('normalizes spaces and comma separators before committing', () => {
+            // Given an empty composition with two accepted decimal places
+            renderNumericInput({value: ''});
+
+            // When a value with spaces and a comma separator is pasted
+            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '1 2,5');
+
+            // Then the canonical value is committed
+            expect(onInputChange).toHaveBeenLastCalledWith('12.5');
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12.5');
+        });
+
         it('rejects an edit that exceeds the accepted number of decimals', () => {
+            // Given a composition with two accepted decimal places and value "1.23"
             renderNumericInput({value: '1.23'});
 
+            // When the user types a third decimal place
             fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '1.234');
 
+            // Then the edit is rejected and the displayed value is unchanged
             expect(onInputChange).not.toHaveBeenCalled();
             expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('1.23');
+        });
+
+        it('rejects an edit with more integer digits than the root maxLength allows', () => {
+            // Given a composition limited to two integer digits and value "12"
+            renderNumericInput({value: '12', maxLength: 2});
+
+            // When the user types a third integer digit
+            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '123');
+
+            // Then the edit is rejected and the displayed value is unchanged
+            expect(onInputChange).not.toHaveBeenCalled();
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12');
+        });
+    });
+
+    describe('root imperative API', () => {
+        it('reads and replaces the value without notifying onInputChange', () => {
+            // Given a composition holding value "12" and a root ref
+            const numericInputRef = React.createRef<NumericEditingRef>();
+            renderNumericInput({value: '12', numericInputRef});
+
+            expect(numericInputRef.current?.getNumber()).toBe('12');
+
+            // When the value is replaced imperatively
+            act(() => {
+                numericInputRef.current?.updateNumber('7.5');
+            });
+
+            // Then the new value is displayed with the caret at its end, and the root is not notified
+            expect(numericInputRef.current?.getNumber()).toBe('7.5');
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('7.5');
+            expect(screen.getByTestId(INPUT_TEST_ID).props.selection).toEqual({start: 3, end: 3});
+            expect(onInputChange).not.toHaveBeenCalled();
+        });
+
+        it('collapses the selection onto its end when clearSelection is called', () => {
+            // Given a composition with a range selection on the input
+            const numericInputRef = React.createRef<NumericEditingRef>();
+            renderNumericInput({value: '1234', numericInputRef});
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'selectionChange', {
+                nativeEvent: {selection: {start: 1, end: 3}},
+            });
+            expect(input.props.selection).toEqual({start: 1, end: 3});
+
+            // When the selection is cleared imperatively
+            act(() => {
+                numericInputRef.current?.clearSelection();
+            });
+
+            // Then the selection collapses onto its end
+            expect(input.props.selection).toEqual({start: 3, end: 3});
         });
     });
 });

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -1,0 +1,92 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import NumericInput from '@components/NumericInput';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+
+import type * as NativeNavigation from '@react-navigation/native';
+
+import React from 'react';
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual<typeof NativeNavigation>('@react-navigation/native'),
+    useIsFocused: jest.fn(() => true),
+    useNavigation: jest.fn(() => ({
+        navigate: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+    })),
+}));
+
+type NumericInputProps = React.ComponentProps<typeof NumericInput>;
+
+const INPUT_TEST_ID = 'numeric-text-input';
+function renderWithProviders(children: React.ReactNode) {
+    return render(<ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>{children}</ComposeProviders>);
+}
+
+describe('NumericInput', () => {
+    const onInputChange = jest.fn();
+
+    const renderNumericInput = (props: Partial<NumericInputProps> = {}, children?: React.ReactNode) =>
+        renderWithProviders(
+            <NumericInput
+                onInputChange={onInputChange}
+                decimals={2}
+                {...props}
+            >
+                {children ?? (
+                    <>
+                        <NumericInput.Symbol>$</NumericInput.Symbol>
+                        <NumericInput.TextInput testID={INPUT_TEST_ID} />
+                    </>
+                )}
+            </NumericInput>,
+        );
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('symbol primitive', () => {
+        it('renders the symbol the composition places beside the input', () => {
+            renderNumericInput({value: '12'});
+
+            expect(screen.getByText('$')).toBeOnTheScreen();
+        });
+
+        it('renders on its own, without an input', () => {
+            renderNumericInput({value: '12'}, <NumericInput.Symbol>km</NumericInput.Symbol>);
+
+            expect(screen.getByText('km')).toBeOnTheScreen();
+        });
+
+        it('calls back when the pressable symbol is pressed', () => {
+            const onSymbolButtonPress = jest.fn();
+            renderNumericInput(
+                {value: '12'},
+                <NumericInput.Symbol
+                    isSymbolPressable
+                    onSymbolButtonPress={onSymbolButtonPress}
+                >
+                    $
+                </NumericInput.Symbol>,
+            );
+
+            fireEvent.press(screen.getByText('$'));
+
+            expect(onSymbolButtonPress).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('text input primitive', () => {
+        it('rejects an edit that exceeds the accepted number of decimals', () => {
+            renderNumericInput({value: '1.23'});
+
+            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '1.234');
+
+            expect(onInputChange).not.toHaveBeenCalled();
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('1.23');
+        });
+    });
+});

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -409,18 +409,18 @@ describe('NumericInput', () => {
     describe('root imperative API', () => {
         it('reads and replaces the value without notifying onInputChange', () => {
             // Given a composition holding value "12" and a root ref
-            const numericInputRef = React.createRef<NumericEditingRef>();
-            renderNumericInput({value: '12', numericInputRef});
+            const ref = React.createRef<NumericEditingRef>();
+            renderNumericInput({value: '12', ref});
 
-            expect(numericInputRef.current?.getNumber()).toBe('12');
+            expect(ref.current?.getNumber()).toBe('12');
 
             // When the value is replaced imperatively
             act(() => {
-                numericInputRef.current?.updateNumber('7.5');
+                ref.current?.updateNumber('7.5');
             });
 
             // Then the new value is displayed with the caret at its end, and the root is not notified
-            expect(numericInputRef.current?.getNumber()).toBe('7.5');
+            expect(ref.current?.getNumber()).toBe('7.5');
             expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('7.5');
             expect(screen.getByTestId(INPUT_TEST_ID).props.selection).toEqual({start: 3, end: 3});
             expect(onInputChange).not.toHaveBeenCalled();
@@ -428,8 +428,8 @@ describe('NumericInput', () => {
 
         it('collapses the selection onto its end when clearSelection is called', () => {
             // Given a composition with a range selection on the input
-            const numericInputRef = React.createRef<NumericEditingRef>();
-            renderNumericInput({value: '1234', numericInputRef});
+            const ref = React.createRef<NumericEditingRef>();
+            renderNumericInput({value: '1234', ref});
 
             const input = screen.getByTestId(INPUT_TEST_ID);
             fireEvent(input, 'selectionChange', {
@@ -439,7 +439,7 @@ describe('NumericInput', () => {
 
             // When the selection is cleared imperatively
             act(() => {
-                numericInputRef.current?.clearSelection();
+                ref.current?.clearSelection();
             });
 
             // Then the selection collapses onto its end

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -88,12 +88,7 @@ describe('NumericInput', () => {
 
         it('calls onPress when the symbol button is pressed', () => {
             const onPress = jest.fn();
-            renderNumericInput(
-                {value: '12'},
-                <NumericInput.SymbolButton onPress={onPress}>
-                    $
-                </NumericInput.SymbolButton>,
-            );
+            renderNumericInput({value: '12'}, <NumericInput.SymbolButton onPress={onPress}>$</NumericInput.SymbolButton>);
 
             fireEvent.press(screen.getByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL}));
 

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -3,8 +3,10 @@ import {act, fireEvent, render, screen} from '@testing-library/react-native';
 import ComposeProviders from '@components/ComposeProviders';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import type {NumericEditingRef} from '@components/NumericEditingController';
-import NumericInput from '@components/NumericInput';
+import NumericInput, {useNumericDynamicFontSize, useNumericInputActions} from '@components/NumericInput';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import {PressableWithoutFeedback} from '@components/Pressable';
+import Text from '@components/Text';
 import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 
 import CONST from '@src/CONST';
@@ -27,6 +29,7 @@ type NumericInputProps = React.ComponentProps<typeof NumericInput>;
 const INPUT_TEST_ID = 'numeric-text-input';
 const CONTAINER_TEST_ID = 'numeric-input-container';
 const SYMBOL_ACCESSIBILITY_LABEL = 'Select a symbol or currency';
+const MINUS_SIGN = '-';
 
 function renderWithProviders(children: React.ReactNode) {
     return render(<ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>{children}</ComposeProviders>);
@@ -49,6 +52,18 @@ function getContainerViewId(testID: string) {
     return container.props.id;
 }
 
+function ToggleSignTrigger() {
+    const {toggleSign} = useNumericInputActions();
+
+    return (
+        <PressableWithoutFeedback
+            accessibilityLabel="Toggle sign"
+            testID="toggle-sign"
+            onPress={toggleSign}
+        />
+    );
+}
+
 describe('NumericInput', () => {
     const onInputChange = jest.fn();
 
@@ -61,6 +76,7 @@ describe('NumericInput', () => {
             >
                 {children ?? (
                     <>
+                        <NumericInput.MinusSign />
                         <NumericInput.Symbol>$</NumericInput.Symbol>
                         <NumericInput.TextInput testID={INPUT_TEST_ID} />
                     </>
@@ -191,6 +207,56 @@ describe('NumericInput', () => {
     });
 
     describe('text input primitive', () => {
+        it('renders a negative value as a separate sign and editable magnitude', () => {
+            renderNumericInput({value: '-12', allowNegative: true});
+
+            expect(screen.getByText(MINUS_SIGN)).toBeOnTheScreen();
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12');
+        });
+
+        it('preserves the sign when the magnitude is edited', () => {
+            renderNumericInput({value: '-12', allowNegative: true});
+
+            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '123');
+
+            expect(onInputChange).toHaveBeenCalledWith('-123');
+        });
+
+        it('clears the sign when the magnitude is cleared', () => {
+            renderNumericInput({value: '-12', allowNegative: true});
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent.changeText(input, '');
+
+            expect(screen.queryByText(MINUS_SIGN)).not.toBeOnTheScreen();
+            expect(input).toHaveDisplayValue('');
+            expect(onInputChange).toHaveBeenCalledWith('');
+        });
+
+        it('clears a standalone minus when backspace is pressed on an empty input', () => {
+            renderNumericInput({value: '-', allowNegative: true});
+
+            fireEvent(screen.getByTestId(INPUT_TEST_ID), 'keyPress', {nativeEvent: {key: 'Backspace'}});
+
+            expect(screen.queryByText(MINUS_SIGN)).not.toBeOnTheScreen();
+            expect(onInputChange).toHaveBeenCalledWith('');
+        });
+
+        it('toggles the sign and notifies the parent with the signed value', () => {
+            renderNumericInput(
+                {value: '12', allowNegative: true},
+                <>
+                    <NumericInput.MinusSign />
+                    <ToggleSignTrigger />
+                </>,
+            );
+
+            fireEvent.press(screen.getByTestId('toggle-sign'));
+
+            expect(screen.getByText(MINUS_SIGN)).toBeOnTheScreen();
+            expect(onInputChange).toHaveBeenLastCalledWith('-12');
+        });
+
         it('commits a valid edit through the root and displays it', () => {
             // Given a composition with two accepted decimal places and value "12"
             renderNumericInput({value: '12'});
@@ -276,6 +342,38 @@ describe('NumericInput', () => {
             // Then each callback runs exactly once
             expect(onBlur).toHaveBeenCalledTimes(1);
             expect(onSubmitEditing).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('error primitive', () => {
+        it('renders the root error where the composition places it', () => {
+            renderNumericInput(
+                {errorText: 'Invalid amount'},
+                <>
+                    <NumericInput.TextInput testID={INPUT_TEST_ID} />
+                    <NumericInput.Error />
+                </>,
+            );
+
+            expect(screen.getByText('Invalid amount')).toBeOnTheScreen();
+        });
+    });
+
+    describe('useNumericDynamicFontSize', () => {
+        function FontSizeReadout({symbol}: {symbol?: string}) {
+            const {fontSize} = useNumericDynamicFontSize(symbol);
+
+            return <Text testID="font-size">{String(fontSize)}</Text>;
+        }
+
+        it('scales down as the displayed value grows', () => {
+            renderNumericInput({value: '1'}, <FontSizeReadout />);
+            const shortValueFontSize = Number(screen.getByTestId('font-size').props.children);
+
+            screen.unmount();
+            renderNumericInput({value: '-123456789', allowNegative: true}, <FontSizeReadout symbol="PLN" />);
+
+            expect(Number(screen.getByTestId('font-size').props.children)).toBeLessThan(shortValueFontSize);
         });
     });
 

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -79,28 +79,25 @@ describe('NumericInput', () => {
             expect(screen.getByText('km')).toBeOnTheScreen();
         });
 
-        it('renders no button when the symbol is not pressable', () => {
+        it('renders a passive symbol without a button', () => {
             renderNumericInput({value: '12'}, <NumericInput.Symbol>$</NumericInput.Symbol>);
 
             expect(screen.getByText('$')).toBeOnTheScreen();
             expect(screen.queryAllByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL})).toHaveLength(0);
         });
 
-        it('calls onSymbolButtonPress when the pressable symbol is pressed', () => {
-            const onSymbolButtonPress = jest.fn();
+        it('calls onPress when the symbol button is pressed', () => {
+            const onPress = jest.fn();
             renderNumericInput(
                 {value: '12'},
-                <NumericInput.Symbol
-                    isSymbolPressable
-                    onSymbolButtonPress={onSymbolButtonPress}
-                >
+                <NumericInput.SymbolButton onPress={onPress}>
                     $
-                </NumericInput.Symbol>,
+                </NumericInput.SymbolButton>,
             );
 
             fireEvent.press(screen.getByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL}));
 
-            expect(onSymbolButtonPress).toHaveBeenCalledTimes(1);
+            expect(onPress).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -254,6 +254,29 @@ describe('NumericInput', () => {
             expect(onInputChange).not.toHaveBeenCalled();
             expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12');
         });
+
+        it('forwards blur and submit to the primitive callbacks', () => {
+            // Given a composition where the text input primitive registers blur and submit callbacks
+            const onBlur = jest.fn();
+            const onSubmitEditing = jest.fn();
+            renderNumericInput(
+                {value: '12'},
+                <NumericInput.TextInput
+                    testID={INPUT_TEST_ID}
+                    onBlur={onBlur}
+                    onSubmitEditing={onSubmitEditing}
+                />,
+            );
+
+            // When the input is blurred and submitted
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'blur');
+            fireEvent(input, 'submitEditing');
+
+            // Then each callback runs exactly once
+            expect(onBlur).toHaveBeenCalledTimes(1);
+            expect(onSubmitEditing).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('root imperative API', () => {

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -214,6 +214,13 @@ describe('NumericInput', () => {
             expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12');
         });
 
+        it('keeps a negative value in the input when negative values are not allowed', () => {
+            renderNumericInput({value: '-12'});
+
+            expect(screen.queryByText(MINUS_SIGN)).not.toBeOnTheScreen();
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('-12');
+        });
+
         it('preserves the sign when the magnitude is edited', () => {
             renderNumericInput({value: '-12', allowNegative: true});
 

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -7,7 +7,6 @@ import NumericInput, {useNumericDynamicFontSize, useNumericInputActions} from '@
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {PressableWithoutFeedback} from '@components/Pressable';
 import Text from '@components/Text';
-import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 
 import CONST from '@src/CONST';
 
@@ -27,29 +26,11 @@ jest.mock('@react-navigation/native', () => ({
 type NumericInputProps = React.ComponentProps<typeof NumericInput>;
 
 const INPUT_TEST_ID = 'numeric-text-input';
-const CONTAINER_TEST_ID = 'numeric-input-container';
 const SYMBOL_ACCESSIBILITY_LABEL = 'Select a symbol or currency';
 const MINUS_SIGN = '-';
 
 function renderWithProviders(children: React.ReactNode) {
     return render(<ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>{children}</ComposeProviders>);
-}
-
-/** Builds the mouse event the web container handler expects, with `target.id` set to the pressed view's id. */
-function getMouseDownEvent(targetId: string) {
-    const target = document.createElement('div');
-    target.id = targetId;
-
-    return {nativeEvent: {target}, preventDefault: jest.fn()};
-}
-
-function getContainerViewId(testID: string) {
-    const container = screen.getByTestId(testID);
-    if (typeof container.props.id !== 'string') {
-        throw new Error(`Numeric input container id was not assigned for ${testID}`);
-    }
-
-    return container.props.id;
 }
 
 function ToggleSignTrigger() {
@@ -89,22 +70,18 @@ describe('NumericInput', () => {
     });
 
     describe('symbol primitive', () => {
-        it('renders its children as the symbol beside the input', () => {
+        it('renders its children as a passive symbol, without a button', () => {
             renderNumericInput({value: '12'}, <NumericInput.Symbol>km</NumericInput.Symbol>);
 
             expect(screen.getByText('km')).toBeOnTheScreen();
-        });
-
-        it('renders a passive symbol without a button', () => {
-            renderNumericInput({value: '12'}, <NumericInput.Symbol>$</NumericInput.Symbol>);
-
-            expect(screen.getByText('$')).toBeOnTheScreen();
             expect(screen.queryAllByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL})).toHaveLength(0);
         });
 
-        it('calls onPress when the symbol button is pressed', () => {
+        it('renders its children inside the symbol button and calls onPress when it is pressed', () => {
             const onPress = jest.fn();
-            renderNumericInput({value: '12'}, <NumericInput.SymbolButton onPress={onPress}>$</NumericInput.SymbolButton>);
+            renderNumericInput({value: '12'}, <NumericInput.SymbolButton onPress={onPress}>km</NumericInput.SymbolButton>);
+
+            expect(screen.getByText('km')).toBeOnTheScreen();
 
             fireEvent.press(screen.getByRole(CONST.ROLE.BUTTON, {name: SYMBOL_ACCESSIBILITY_LABEL}));
 
@@ -112,101 +89,7 @@ describe('NumericInput', () => {
         });
     });
 
-    describe('container primitive', () => {
-        const renderContainerComposition = (inputRef?: React.Ref<BaseTextInputRef>) =>
-            renderNumericInput(
-                {value: '12'},
-                <NumericInput.Container testID={CONTAINER_TEST_ID}>
-                    <NumericInput.TextInput
-                        testID={INPUT_TEST_ID}
-                        ref={inputRef}
-                    />
-                    <NumericInput.Symbol>%</NumericInput.Symbol>
-                </NumericInput.Container>,
-            );
-
-        it('focuses the input and collapses the selection when its own empty area is pressed', () => {
-            // Given a container composition with a range selection on the input
-            const inputRef = React.createRef<BaseTextInputRef>();
-            renderContainerComposition(inputRef);
-
-            const input = screen.getByTestId(INPUT_TEST_ID);
-            fireEvent(input, 'selectionChange', {
-                nativeEvent: {selection: {start: 0, end: 2}},
-            });
-            expect(input.props.selection).toEqual({start: 0, end: 2});
-
-            const inputElement = inputRef.current;
-            if (!inputElement) {
-                throw new Error('Numeric input ref was not assigned');
-            }
-            const focus = jest.spyOn(inputElement, 'focus');
-
-            // When the container's own empty area is pressed
-            const event = getMouseDownEvent(getContainerViewId(CONTAINER_TEST_ID));
-            fireEvent(screen.getByTestId(CONTAINER_TEST_ID), 'mouseDown', event);
-
-            // Then the browser blur is prevented, the input is focused, and the selection collapses onto its end
-            expect(event.preventDefault).toHaveBeenCalledTimes(1);
-            expect(focus).toHaveBeenCalledTimes(1);
-            expect(input.props.selection).toEqual({start: 2, end: 2});
-            focus.mockRestore();
-        });
-
-        it('ignores a press that originates from a nested view instead of its own empty area', () => {
-            // Given a container composition with a range selection on the input
-            const inputRef = React.createRef<BaseTextInputRef>();
-            renderContainerComposition(inputRef);
-
-            const input = screen.getByTestId(INPUT_TEST_ID);
-            fireEvent(input, 'selectionChange', {
-                nativeEvent: {selection: {start: 0, end: 2}},
-            });
-
-            const inputElement = inputRef.current;
-            if (!inputElement) {
-                throw new Error('Numeric input ref was not assigned');
-            }
-            const focus = jest.spyOn(inputElement, 'focus');
-
-            // When the press bubbles up from a nested view, which owns the caret placement itself
-            const event = getMouseDownEvent('some-nested-view-id');
-            fireEvent(screen.getByTestId(CONTAINER_TEST_ID), 'mouseDown', event);
-
-            // Then the container leaves the press and the selection alone
-            expect(event.preventDefault).not.toHaveBeenCalled();
-            expect(focus).not.toHaveBeenCalled();
-            expect(input.props.selection).toEqual({start: 0, end: 2});
-            focus.mockRestore();
-        });
-
-        it('assigns a distinct target id to each mounted container', () => {
-            renderWithProviders(
-                <>
-                    <NumericInput
-                        onInputChange={onInputChange}
-                        value="12"
-                    >
-                        <NumericInput.Container testID={`${CONTAINER_TEST_ID}-one`}>
-                            <NumericInput.TextInput />
-                        </NumericInput.Container>
-                    </NumericInput>
-                    <NumericInput
-                        onInputChange={onInputChange}
-                        value="34"
-                    >
-                        <NumericInput.Container testID={`${CONTAINER_TEST_ID}-two`}>
-                            <NumericInput.TextInput />
-                        </NumericInput.Container>
-                    </NumericInput>
-                </>,
-            );
-
-            expect(getContainerViewId(`${CONTAINER_TEST_ID}-one`)).not.toBe(getContainerViewId(`${CONTAINER_TEST_ID}-two`));
-        });
-    });
-
-    describe('text input primitive', () => {
+    describe('sign handling', () => {
         it('renders a negative value as a separate sign and editable magnitude', () => {
             renderNumericInput({value: '-12', allowNegative: true});
 
@@ -264,6 +147,23 @@ describe('NumericInput', () => {
             expect(onInputChange).toHaveBeenLastCalledWith('-12');
         });
 
+        it('ignores a sign toggle when negative values are not allowed', () => {
+            renderNumericInput(
+                {value: '12'},
+                <>
+                    <NumericInput.MinusSign />
+                    <ToggleSignTrigger />
+                </>,
+            );
+
+            fireEvent.press(screen.getByTestId('toggle-sign'));
+
+            expect(screen.queryByText(MINUS_SIGN)).not.toBeOnTheScreen();
+            expect(onInputChange).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('text input primitive', () => {
         it('commits a valid edit through the root and displays it', () => {
             // Given a composition with two accepted decimal places and value "12"
             renderNumericInput({value: '12'});
@@ -292,16 +192,17 @@ describe('NumericInput', () => {
             expect(input.props.selection).toEqual({start: 3, end: 3});
         });
 
-        it('normalizes spaces and comma separators before committing', () => {
-            // Given an empty composition with two accepted decimal places
-            renderNumericInput({value: ''});
+        it('ignores the stale selection event native echoes after an edit', () => {
+            // Given a composition with value "12"
+            renderNumericInput({value: '12'});
 
-            // When a value with spaces and a comma separator is pasted
-            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '1 2,5');
+            // When a digit is appended and native echoes the pre-edit caret position
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent.changeText(input, '123');
+            fireEvent(input, 'selectionChange', {nativeEvent: {selection: {start: 0, end: 0}}});
 
-            // Then the canonical value is committed
-            expect(onInputChange).toHaveBeenLastCalledWith('12.5');
-            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('12.5');
+            // Then the echo is dropped and the caret stays where the edit put it
+            expect(input.props.selection).toEqual({start: 3, end: 3});
         });
 
         it('rejects an edit that exceeds the accepted number of decimals', () => {
@@ -385,6 +286,19 @@ describe('NumericInput', () => {
             );
 
             expect(screen.getByText('Invalid amount')).toBeOnTheScreen();
+            expect(screen.getByRole(CONST.ROLE.ALERT)).toBeOnTheScreen();
+        });
+
+        it('renders nothing when the root has no error', () => {
+            renderNumericInput(
+                {},
+                <>
+                    <NumericInput.TextInput testID={INPUT_TEST_ID} />
+                    <NumericInput.Error />
+                </>,
+            );
+
+            expect(screen.queryByRole(CONST.ROLE.ALERT)).not.toBeOnTheScreen();
         });
     });
 
@@ -395,14 +309,26 @@ describe('NumericInput', () => {
             return <Text testID="font-size">{String(fontSize)}</Text>;
         }
 
-        it('scales down as the displayed value grows', () => {
-            renderNumericInput({value: '1'}, <FontSizeReadout />);
-            const shortValueFontSize = Number(screen.getByTestId('font-size').props.children);
+        it('scales down when the symbol is longer', () => {
+            renderNumericInput({value: '1234567890'}, <FontSizeReadout />);
+            const withoutSymbolFontSize = Number(screen.getByTestId('font-size').props.children);
 
             screen.unmount();
-            renderNumericInput({value: '-123456789', allowNegative: true}, <FontSizeReadout symbol="PLN" />);
+            renderNumericInput({value: '1234567890'}, <FontSizeReadout symbol="PLN" />);
+            const withSymbolFontSize = Number(screen.getByTestId('font-size').props.children);
 
-            expect(Number(screen.getByTestId('font-size').props.children)).toBeLessThan(shortValueFontSize);
+            expect(withSymbolFontSize).toBeLessThan(withoutSymbolFontSize);
+        });
+
+        it('scales down for negative values, because the sign takes room the input does not display', () => {
+            renderNumericInput({value: '1234567890'}, <FontSizeReadout />);
+            const positiveFontSize = Number(screen.getByTestId('font-size').props.children);
+
+            screen.unmount();
+            renderNumericInput({value: '-1234567890', allowNegative: true}, <FontSizeReadout />);
+            const negativeFontSize = Number(screen.getByTestId('font-size').props.children);
+
+            expect(negativeFontSize).toBeLessThan(positiveFontSize);
         });
     });
 

--- a/tests/ui/NumericInputTest.tsx
+++ b/tests/ui/NumericInputTest.tsx
@@ -309,6 +309,28 @@ describe('NumericInput', () => {
             expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('1.23');
         });
 
+        it('strips decimals from an in-progress value when the accepted decimals decrease', () => {
+            // Given an empty composition whose in-progress value has two decimal places
+            const {rerender} = renderNumericInput({value: ''});
+            fireEvent.changeText(screen.getByTestId(INPUT_TEST_ID), '1.23');
+
+            // When the accepted number of decimals drops to zero
+            rerender(
+                <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+                    <NumericInput
+                        onInputChange={onInputChange}
+                        decimals={0}
+                        value=""
+                    >
+                        <NumericInput.TextInput testID={INPUT_TEST_ID} />
+                    </NumericInput>
+                </ComposeProviders>,
+            );
+
+            // Then the in-progress value is sanitized to the new precision
+            expect(screen.getByTestId(INPUT_TEST_ID)).toHaveDisplayValue('1');
+        });
+
         it('rejects an edit with more integer digits than the root maxLength allows', () => {
             // Given a composition limited to two integer digits and value "12"
             renderNumericInput({value: '12', maxLength: 2});

--- a/tests/ui/NumericInputWebTest.tsx
+++ b/tests/ui/NumericInputWebTest.tsx
@@ -1,0 +1,231 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
+
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import NumericInput from '@components/NumericInput';
+import {NumericInputActionsContext, NumericInputStateContext} from '@components/NumericInput/context';
+import useNumericPressSelection from '@components/NumericInput/hooks/useNumericPressSelection/index.web';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import TextInput from '@components/TextInput';
+import type {BaseTextInputProps, BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+
+import type ShouldIgnoreSelectionWhenUpdatedManually from '@libs/shouldIgnoreSelectionWhenUpdatedManually/types';
+
+import type * as NativeNavigation from '@react-navigation/native';
+
+import React from 'react';
+
+jest.mock('@libs/shouldIgnoreSelectionWhenUpdatedManually', () => ({
+    ...jest.requireActual<{default: ShouldIgnoreSelectionWhenUpdatedManually}>('@libs/shouldIgnoreSelectionWhenUpdatedManually'),
+    __esModule: true,
+    default: false,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual<typeof NativeNavigation>('@react-navigation/native'),
+    useIsFocused: jest.fn(() => true),
+    useNavigation: jest.fn(() => ({
+        navigate: jest.fn(),
+        addListener: jest.fn(() => jest.fn()),
+    })),
+}));
+
+const INPUT_TEST_ID = 'numeric-input-web-test-input';
+const PRESSABLE_TEST_ID = 'numeric-input-web-test-pressable';
+const CONTAINER_TEST_ID = 'numeric-input-web-test-container';
+
+function renderWithProviders(children: React.ReactNode) {
+    return render(<ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>{children}</ComposeProviders>);
+}
+
+/** Builds the mouse event the web container handler expects, with `target.id` set to the pressed view's id. */
+function getMouseDownEvent(targetId: string) {
+    const target = document.createElement('div');
+    target.id = targetId;
+
+    return {nativeEvent: {target}, preventDefault: jest.fn()};
+}
+
+function getContainerViewId(testID: string) {
+    const container = screen.getByTestId(testID);
+    if (typeof container.props.id !== 'string') {
+        throw new Error(`Numeric input container id was not assigned for ${testID}`);
+    }
+
+    return container.props.id;
+}
+
+function WebPressSelectionTest({onPress}: {onPress: BaseTextInputProps['onPress']}) {
+    const handlePress = useNumericPressSelection(onPress);
+
+    return (
+        <TextInput
+            accessibilityLabel="Update selection"
+            onPress={handlePress}
+            testID={PRESSABLE_TEST_ID}
+        />
+    );
+}
+
+/** Renders the press-selection hook against a root state whose `inputRef` holds the given element. */
+function renderPressSelection(inputRef: {current: BaseTextInputRef | null}, onPress: jest.Mock, handleSelectionChange: jest.Mock) {
+    renderWithProviders(
+        <NumericInputStateContext.Provider
+            value={{
+                value: '12345',
+                formattedNumber: '12345',
+                selection: {start: 5, end: 5},
+                isNegative: false,
+                allowNegative: false,
+                inputRef,
+            }}
+        >
+            <NumericInputActionsContext.Provider
+                value={{
+                    setNumber: jest.fn(),
+                    clearSelection: jest.fn(),
+                    toggleSign: jest.fn(),
+                    clearSign: jest.fn(),
+                    handleSelectionChange,
+                    handleKeyPress: jest.fn(),
+                    focusInput: jest.fn(),
+                }}
+            >
+                <WebPressSelectionTest onPress={onPress} />
+            </NumericInputActionsContext.Provider>
+        </NumericInputStateContext.Provider>,
+    );
+}
+
+describe('NumericInput web behavior', () => {
+    it('syncs the root selection with the browser caret when pressed', () => {
+        const onPress = jest.fn();
+        const handleSelectionChange = jest.fn();
+        const inputElement = document.createElement('input');
+        inputElement.value = '12345';
+        inputElement.selectionStart = 2;
+        inputElement.selectionEnd = 4;
+
+        renderPressSelection({current: inputElement as unknown as BaseTextInputRef}, onPress, handleSelectionChange);
+
+        fireEvent.press(screen.getByTestId(PRESSABLE_TEST_ID));
+
+        expect(handleSelectionChange).toHaveBeenCalledWith(2, 4);
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the root selection alone when the ref does not hold a form element exposing the caret', () => {
+        const onPress = jest.fn();
+        const handleSelectionChange = jest.fn();
+
+        renderPressSelection({current: null}, onPress, handleSelectionChange);
+
+        fireEvent.press(screen.getByTestId(PRESSABLE_TEST_ID));
+
+        expect(handleSelectionChange).not.toHaveBeenCalled();
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies a selection event after a manual value update, because the browser does not echo a stale one', () => {
+        renderWithProviders(
+            <NumericInput value="12">
+                <NumericInput.TextInput testID={INPUT_TEST_ID} />
+            </NumericInput>,
+        );
+
+        const input = screen.getByTestId(INPUT_TEST_ID);
+        fireEvent.changeText(input, '13');
+        fireEvent(input, 'selectionChange', {nativeEvent: {selection: {start: 0, end: 0}}});
+
+        expect(input.props.selection).toEqual({start: 0, end: 0});
+    });
+
+    describe('container primitive', () => {
+        const renderContainerComposition = (inputRef?: React.Ref<BaseTextInputRef>) =>
+            renderWithProviders(
+                <NumericInput value="12">
+                    <NumericInput.Container testID={CONTAINER_TEST_ID}>
+                        <NumericInput.TextInput
+                            testID={INPUT_TEST_ID}
+                            ref={inputRef}
+                        />
+                        <NumericInput.Symbol>%</NumericInput.Symbol>
+                    </NumericInput.Container>
+                </NumericInput>,
+            );
+
+        it('focuses the input and collapses the selection when its own empty area is pressed', () => {
+            // Given a container composition with a range selection on the input
+            const inputRef = React.createRef<BaseTextInputRef>();
+            renderContainerComposition(inputRef);
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'selectionChange', {
+                nativeEvent: {selection: {start: 0, end: 2}},
+            });
+            expect(input.props.selection).toEqual({start: 0, end: 2});
+
+            const inputElement = inputRef.current;
+            if (!inputElement) {
+                throw new Error('Numeric input ref was not assigned');
+            }
+            const focus = jest.spyOn(inputElement, 'focus');
+
+            // When the container's own empty area is pressed
+            const event = getMouseDownEvent(getContainerViewId(CONTAINER_TEST_ID));
+            fireEvent(screen.getByTestId(CONTAINER_TEST_ID), 'mouseDown', event);
+
+            // Then the browser blur is prevented, the input is focused, and the selection collapses onto its end
+            expect(event.preventDefault).toHaveBeenCalledTimes(1);
+            expect(focus).toHaveBeenCalledTimes(1);
+            expect(input.props.selection).toEqual({start: 2, end: 2});
+            focus.mockRestore();
+        });
+
+        it('ignores a press that originates from a nested view instead of its own empty area', () => {
+            // Given a container composition with a range selection on the input
+            const inputRef = React.createRef<BaseTextInputRef>();
+            renderContainerComposition(inputRef);
+
+            const input = screen.getByTestId(INPUT_TEST_ID);
+            fireEvent(input, 'selectionChange', {
+                nativeEvent: {selection: {start: 0, end: 2}},
+            });
+
+            const inputElement = inputRef.current;
+            if (!inputElement) {
+                throw new Error('Numeric input ref was not assigned');
+            }
+            const focus = jest.spyOn(inputElement, 'focus');
+
+            // When the press bubbles up from a nested view, which owns the caret placement itself
+            const event = getMouseDownEvent('some-nested-view-id');
+            fireEvent(screen.getByTestId(CONTAINER_TEST_ID), 'mouseDown', event);
+
+            // Then the container leaves the press and the selection alone
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(focus).not.toHaveBeenCalled();
+            expect(input.props.selection).toEqual({start: 0, end: 2});
+            focus.mockRestore();
+        });
+
+        it('assigns a distinct target id to each mounted container, so a press only refocuses its own input', () => {
+            renderWithProviders(
+                <>
+                    <NumericInput value="12">
+                        <NumericInput.Container testID={`${CONTAINER_TEST_ID}-one`}>
+                            <NumericInput.TextInput />
+                        </NumericInput.Container>
+                    </NumericInput>
+                    <NumericInput value="34">
+                        <NumericInput.Container testID={`${CONTAINER_TEST_ID}-two`}>
+                            <NumericInput.TextInput />
+                        </NumericInput.Container>
+                    </NumericInput>
+                </>,
+            );
+
+            expect(getContainerViewId(`${CONTAINER_TEST_ID}-one`)).not.toBe(getContainerViewId(`${CONTAINER_TEST_ID}-two`));
+        });
+    });
+});


### PR DESCRIPTION
### Explanation of Change
This is PR 2/2 of the numeric input migration described in [#98169](https://github.com/Expensify/App/issues/98169), following [PR 1/2](https://github.com/Expensify/App/pull/99772).

This PR introduces the composable `NumericInput` root and the primitives required to build different numeric input layouts:

- `Container`
- `TextInput`
- `Symbol`
- `SymbolButton`
- `MinusSign`
- `Error`

`NumericInput` shares numeric editing, validation, formatting, and selection handling through context and the common `NumericEditingController`. It also supports signed values when `allowNegative` is enabled. The minus sign is rendered separately from the editable magnitude, while sign toggling, sign preservation during edits, and clearing the value are handled by the root component.

The non-touch/web path of `WorkspaceCreateTaxValuePage` has been migrated from `NumberWithSymbolForm` to `NumericInput`. The existing native touch path remains unchanged. This PR also adds coverage for numeric validation, caret and selection behavior, composed primitives, symbol interactions, error rendering, and negative values.

As with `NumericField`, the primitive prop set is intentionally limited at this stage and will be expanded as the migration progresses.

### Fixed Issues
$ https://github.com/Expensify/App/issues/98169
PROPOSAL: https://github.com/Expensify/App/issues/97970

### Tests
1. Open **Workspace settings → Taxes**, select a workspace, and open the tax-value form through **Add tax rate** or by editing an existing tax rate.
2. On a non-touch device or web browser, verify that the tax-value form uses the migrated `NumericInput` and that the `%` symbol is displayed as a suffix.
3. Enter valid whole and decimal tax rates, and verify that the value is formatted using the current locale and that the configured integer and decimal limits are enforced.
4. Move the caret within the value, insert and delete digits, use forward delete where available, and verify that the caret remains in the expected position.
5. Enter an invalid value or exceed the configured limits, and verify that the edit is rejected while the last valid value is preserved.
6. Clear the value, navigate away and back to the form, and verify that the field remains empty and can be focused and edited again.
7. On a touch device, repeat the same tax-value flow and verify that the existing native `NumberWithSymbolForm` path remains unchanged.

- [ ] Verify that no errors appear in the JS console

### Offline tests
1. Turn off the network connection and open **Workspace settings → Taxes**.
2. Open the tax-value form and enter, edit, delete, and clear a tax rate on the migrated non-touch/web path.
3. Verify that formatting, validation, `%` suffix rendering, and caret behavior continue to work offline without console errors.
4. Re-enable the network connection and verify that the final valid value can still be saved successfully.

### QA Steps

Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/2926f50a-9dd2-43db-9802-1999a1fa4d2e

</details>
